### PR TITLE
Add AirPlay and Chromecast support for iOS in AppDelegate

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -1,0 +1,32 @@
+﻿name: Build iOS IPA
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build IPA
+        run: flutter build ipa --export-method ad-hoc
+
+      - name: Upload IPA Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: IPA
+          path: build/ios/ipa/*.ipa

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,20 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+
+    // AirPlay support using AVRoutePickerView (iOS 11+)
+    if #available(iOS 11.0, *) {
+        let routePickerView = AVRoutePickerView(frame: CGRect(x: 20, y: 50, width: 44, height: 44))
+        routePickerView.activeTintColor = UIColor.systemBlue
+        routePickerView.tintColor = UIColor.gray
+        window?.rootViewController?.view.addSubview(routePickerView)
+    }
+
+    // Chromecast support using Google Cast SDK
+    // (Ensure your project is configured with the Google Cast SDK)
+    let castButton = GCKUICastButton(frame: CGRect(x: (window?.rootViewController?.view.frame.width ?? 0) - 64, y: 50, width: 44, height: 44))
+    castButton.tintColor = UIColor.white
+    window?.rootViewController?.view.addSubview(castButton)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }


### PR DESCRIPTION
This pull request adds native support for AirPlay and Chromecast to the iOS project. The changes insert code into ios/Runner/AppDelegate.swift immediately after the plugin registration call, ensuring that:

AirPlay Support:
An AVRoutePickerView is added to the root view, enabling AirPlay functionality on iOS 11 and above.

Chromecast Support:
A GCKUICastButton is added to the root view, allowing users to connect to Chromecast devices (make sure the project is configured with the Google Cast SDK).

These modifications provide basic UI elements for external media streaming and should be reviewed for further customization to fit the overall app design.