### PR TITLE
increased max size for subs

### DIFF
--- a/lib/screens/settings/sub_settings/settings_player.dart
+++ b/lib/screens/settings/sub_settings/settings_player.dart
@@ -343,7 +343,7 @@ class _SettingsPlayerState extends State<SettingsPlayer> {
                                 CustomSliderTile(
                                   sliderValue: settings.subtitleSize.toDouble(),
                                   min: 12.0,
-                                  max: 30.0,
+                                  max: 90.0,
                                   divisions: 18,
                                   onChanged: (double value) {
                                     settings.subtitleSize = value.toInt();


### PR DESCRIPTION
# 🚀 Pull Request
**Description:**  
Increased max font size for subtitles

**Title:**  
Increased max font size for subtitles

**Description:**  
Increased max font size for subtitles

**Summary of Changes:**  
changed "max" of subtitle size slider from 30 to 90

**Type of Changes:**  
- Enhancement

**Testing Notes:**  
winged it honestly

**Linked Issue(s):**  
None

**Additional Context:**  
I am old and my eyes need bigger fonts

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [x] I have added or updated documentation as needed
- [x] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request
