### PR TITLE
fix: keyboard not focused by default, added new keybinds

### DIFF
--- a/lib/screens/anime/watch_page.dart
+++ b/lib/screens/anime/watch_page.dart
@@ -515,7 +515,7 @@ class _WatchPageState extends State<WatchPage> with TickerProviderStateMixin {
     });
   }
 
-  void _megaSkip(invert) {
+  void _megaSkip(bool invert) {
     if (invert) {
       final duration = Duration(
           seconds: currentPosition.value.inSeconds - settings.skipDuration);
@@ -567,6 +567,7 @@ class _WatchPageState extends State<WatchPage> with TickerProviderStateMixin {
     } else {
       windowManager.setFullScreen(false);
     }
+    _keyboardListenerFocusNode.dispose();
     super.dispose();
   }
 
@@ -583,9 +584,11 @@ class _WatchPageState extends State<WatchPage> with TickerProviderStateMixin {
             _skipSegments(true);
           } else if (e.logicalKey == LogicalKeyboardKey.arrowRight) {
             _skipSegments(false);
-          } else if (e.logicalKey == LogicalKeyboardKey.period) {
+          } else if (e.logicalKey == LogicalKeyboardKey.period ||
+              e.character == '>') {
             _megaSkip(false);
-          } else if (e.logicalKey == LogicalKeyboardKey.comma) {
+          } else if (e.logicalKey == LogicalKeyboardKey.comma ||
+              e.character == '<') {
             _megaSkip(true);
           }
         }

--- a/lib/screens/anime/watch_page.dart
+++ b/lib/screens/anime/watch_page.dart
@@ -173,7 +173,7 @@ class _WatchPageState extends State<WatchPage> with TickerProviderStateMixin {
       skipTraversal: settings.isTV.value,
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_keyboardListenerFocusNode.hasFocus) {
+      if (mounted && !_keyboardListenerFocusNode.hasFocus) {
         _keyboardListenerFocusNode.requestFocus();
       }
     });


### PR DESCRIPTION
<!--
# Pull Request
**Description:**  
Fix keyboard listener not focused by default on start of playback. Added new keybindings for mega skip forward and backward.

**Title:**  
Fix Keyboard Shortcuts and New Keybindings

**Description:**  
Fixed keyboard listener not focused by default on start of playback. 
Added new keybindings for mega skip forward( '>' key ) and backward( '<' key).

**Summary of Changes:**  
- added new `_megaSkip()` fucntion to perform mega skip from keybinding.
- made `FocusNode` of `KeyboardListener` a state to be able to request focus on initialization.
- made `KeyboardListener` have autofocus.

**Type of Changes:**  
- Bug Fix
- Feature
- Enhancement

**Testing Notes:**  
Tested on Windows 10

**Additional Context:**  
Not being able to use keyboard shortcuts without pressing tab was annoying me :P

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [x] I have added or updated documentation as needed
- [x] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request
-->