### PR TITLE
added autoskip with aniskip inegration

### DIFF
--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -183,6 +183,16 @@ class Settings extends GetxController {
   set subtitleOutlineWidth(int value) =>
       _setPlayerSetting((s) => s?.subtitleOutlineWidth = value);
 
+  bool get autoSkipOP => _getPlayerSetting((s) => s.autoSkipOP);
+  set autoSkipOP(bool value) => _setPlayerSetting((s) => s?.autoSkipOP = value);
+
+  bool get autoSkipED => _getPlayerSetting((s) => s.autoSkipED);
+  set autoSkipED(bool value) => _setPlayerSetting((s) => s?.autoSkipED = value);
+
+  bool get autoSkipOnce => _getPlayerSetting((s) => s.autoSkipOnce);
+  set autoSkipOnce(bool value) =>
+      _setPlayerSetting((s) => s?.autoSkipOnce = value);
+
   void updateHomePageCard(String key, bool value) {
     final currentCards = Map<String, bool>.from(uiSettings.value.homePageCards);
     currentCards[key] = value;

--- a/lib/models/player/player_adaptor.dart
+++ b/lib/models/player/player_adaptor.dart
@@ -34,23 +34,30 @@ class PlayerSettings {
   int playerStyle;
   @HiveField(14)
   int subtitleOutlineWidth;
+  @HiveField(15)
+  bool autoSkipOP;
+  @HiveField(16)
+  bool autoSkipED;
+  @HiveField(17)
+  bool autoSkipOnce;
 
-
-  PlayerSettings({
-    this.speed = 1.0,
-    this.resizeMode = "Contain",
-    this.subtitleSize = 16,
-    this.subtitleColor = "White",
-    this.subtitleFont = 'Poppins',
-    this.subtitleBackgroundColor = "Black",
-    this.subtitleOutlineColor = "Black",
-    this.showSubtitle = true,
-    this.skipDuration = 85,
-    this.seekDuration = 10,
-    this.bottomMargin = 5,
-    this.playerStyle = 0,
-    this.transculentControls = false,
-    this.defaultPortraitMode = false,
-    this.subtitleOutlineWidth = 1,
-  });
+  PlayerSettings(
+      {this.speed = 1.0,
+      this.resizeMode = "Contain",
+      this.subtitleSize = 16,
+      this.subtitleColor = "White",
+      this.subtitleFont = 'Poppins',
+      this.subtitleBackgroundColor = "Black",
+      this.subtitleOutlineColor = "Black",
+      this.showSubtitle = true,
+      this.skipDuration = 85,
+      this.seekDuration = 10,
+      this.bottomMargin = 5,
+      this.playerStyle = 0,
+      this.transculentControls = false,
+      this.defaultPortraitMode = false,
+      this.subtitleOutlineWidth = 1,
+      this.autoSkipED = false,
+      this.autoSkipOP = false,
+      this.autoSkipOnce = false});
 }

--- a/lib/screens/settings/sub_settings/settings_player.dart
+++ b/lib/screens/settings/sub_settings/settings_player.dart
@@ -261,6 +261,31 @@ class _SettingsPlayerState extends State<SettingsPlayer> {
                                     _showResizeModeDialog();
                                   },
                                 ),
+                                CustomSwitchTile(
+                                    padding: const EdgeInsets.all(10),
+                                    icon: Icons.fast_forward,
+                                    title: "Auto Skip OP",
+                                    description: "Auto skip the opening song",
+                                    switchValue: settings.autoSkipOP,
+                                    onChanged: (val) =>
+                                        settings.autoSkipOP = val),
+                                CustomSwitchTile(
+                                    padding: const EdgeInsets.all(10),
+                                    icon: Icons.fast_forward_outlined,
+                                    title: "Auto Skip ED",
+                                    description: "Auto skip the ending song",
+                                    switchValue: settings.autoSkipED,
+                                    onChanged: (val) =>
+                                        settings.autoSkipED = val),
+                                CustomSwitchTile(
+                                    padding: const EdgeInsets.all(10),
+                                    icon: Icons.all_inclusive,
+                                    title: "Auto Skip Once Only",
+                                    description:
+                                        "Auto skip only once per watch",
+                                    switchValue: settings.autoSkipOnce,
+                                    onChanged: (val) =>
+                                        settings.autoSkipOnce = val),
                                 CustomSliderTile(
                                   sliderValue: settings.seekDuration.toDouble(),
                                   max: 50,

--- a/lib/utils/aniskip.dart
+++ b/lib/utils/aniskip.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class AniSkipApi {
+  static const String apiUrl = "https://api.aniskip.com";
+  static const String skipTimeEndpoint = "/v1/skip-times/";
+  static const String skipTypesQuery = "?types=op&types=ed";
+
+  SkipIntervals? getFromResults(String type, List<dynamic> result) {
+    for (var element in result) {
+      if (element["skip_type"] == type) {
+        return SkipIntervals(
+            start: element['interval']['start_time'].toInt(),
+            end: element['interval']['end_time'].toInt());
+      }
+    }
+    return null;
+  }
+
+  Future<EpisodeSkipTimes?> getSkipTimes(SkipSearchQuery query) async {
+    if (query.idMAL == null || query.episodeNumber == null) return null;
+    String idMAL = query.idMAL as String;
+    String episodeNumber = query.episodeNumber as String;
+    String uri = "$apiUrl$skipTimeEndpoint$idMAL/$episodeNumber$skipTypesQuery";
+
+    final response = await http
+        .get(Uri.parse(uri), headers: {"Content-Type": "application/json"});
+
+    if (response.statusCode != 200) return null;
+
+    final skipData = jsonDecode(response.body);
+    if (skipData['found'] == true) {
+      final op = getFromResults('op', skipData['results']);
+      final ed = getFromResults('ed', skipData['results']);
+      return EpisodeSkipTimes(op: op, ed: ed);
+    } else {
+      return null;
+    }
+  }
+}
+
+class EpisodeSkipTimes {
+  final SkipIntervals? op;
+  final SkipIntervals? ed;
+
+  EpisodeSkipTimes({this.op, this.ed});
+}
+
+class SkipIntervals {
+  final int start;
+  final int end;
+
+  SkipIntervals({required this.start, required this.end});
+}
+
+class SkipSearchQuery {
+  final String? idMAL;
+  final String? episodeNumber;
+
+  SkipSearchQuery({this.idMAL, this.episodeNumber});
+}


### PR DESCRIPTION
<!--
# Pull Request
**Description:**  
Added Auto Skip functionality by integrating aniskip api

**Title:**  
Added Auto Skip With AniSkip

**Description:**  
Added player settings to enable auto skipping during anime playback when possible by getting skip data from AniSkip API.

**Summary of Changes:**  
- Added new Player Settings options for choosing whether to skip OP and ED separately and also if skip should happen only once per view.
- Added AniSkip API integration to get skip times for currently playing anime.

**Type of Changes:**  
- Feature
- Enhancement

**Testing Notes:**  
Tested on Windows 10

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [x] I have added or updated documentation as needed
- [x] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request
-->