### PR TITLE
Improving manga reading experience

### DIFF
--- a/lib/screens/manga/reading_page.dart
+++ b/lib/screens/manga/reading_page.dart
@@ -52,31 +52,36 @@ class _ReadingPageState extends State<ReadingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.black,
-      body: Obx(() => GestureDetector(
-            onTap: () => controller.toggleControls(),
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                ReaderView(controller: controller),
-                AnimatedPositioned(
-                  duration: const Duration(milliseconds: 300),
-                  curve: Curves.easeInOut,
-                  top: controller.showControls.value ? 0 : -200,
-                  left: 0,
-                  right: 0,
-                  child: ReaderTopControls(controller: controller),
-                ),
-                AnimatedPositioned(
-                  duration: const Duration(milliseconds: 300),
-                  curve: Curves.easeInOut,
-                  bottom: controller.showControls.value ? 0 : -200,
-                  left: 0,
-                  right: 0,
-                  child: ReaderBottomControls(controller: controller),
-                ),
-              ],
+      body: Obx(
+        () => Stack(
+          fit: StackFit.expand,
+          children: [
+            GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: () => controller.toggleControls(),
+              // Force multiple taps to trigger single tap instead
+              onDoubleTap: () {},
+              child: ReaderView(controller: controller),
             ),
-          )),
+            AnimatedPositioned(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+              top: controller.showControls.value ? 0 : -200,
+              left: 0,
+              right: 0,
+              child: ReaderTopControls(controller: controller),
+            ),
+            AnimatedPositioned(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+              bottom: controller.showControls.value ? 0 : -200,
+              left: 0,
+              right: 0,
+              child: ReaderBottomControls(controller: controller),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/manga/widgets/reader/bottom_controls.dart
+++ b/lib/screens/manga/widgets/reader/bottom_controls.dart
@@ -95,6 +95,7 @@ class ReaderBottomControls extends StatelessWidget {
         : Expanded(
             child: CustomSlider(
               value: controller.currentPageIndex.value.toDouble(),
+              label: controller.currentPageIndex.value.toString(),
               min: 1,
               max: controller.pageList.length.toDouble(),
               divisions: controller.pageList.length > 1

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -58,6 +58,7 @@ class ReaderSettings {
                       onPressed: (int index) {
                         final mode = ReadingMode.values[index];
                         controller.changeActiveMode(mode);
+                        controller.savePreferences();
                       },
                       children: const [
                         Tooltip(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   json_annotation: ^4.9.0
   json_path: ^0.7.4
   kenburns_nullsafety: ^1.0.1
-
+  manga_page_view: ^1.0.1
   
   # repo => https://github.com/media-kit/media-kit
   media_kit: ^1.2.0


### PR DESCRIPTION

# Pull Request

**Title:**  
Improving manga reading experience

**Description:**  
For the past few days I have been working on how to make the reading experience better, specifically fixing the issues that I had faced mostly related to the scrolling (pan) & zoom gestures:
- When zooming in, panning in certain directions (e.g., scrolling down and then trying to pan left/right) often fails unless you lift your finger. In some cases, vertical scrolling doesn’t work at all
- Pinch-to-zoom is hard to trigger and I had to do it slowly and carefully just to trigger it. Also when you start pinching you cannot scroll on certain extent.
- No double-tap and double-trap-and-drag to zoom which I frequently used on manga readers.

Possible reason:
- `InteractiveViewer` and `SingleChildScrollView` (on webtoon mode) or `PageView` (on LTR/RTL mode) doesn’t mix well. Both widgets compete to handle gestures, and whichever captures the input first locks out the other. This prevents zooming and panning at the same time on certain level.

Coming from Dantotsu/Mihon, the experiences do not feel as great. Therefore I tried to change and redesign the gesture handling mechanism with a custom one. As the logic itself is quite big, I decided to release it as a separate widget under a newly released Pub package ([manga_page_view](https://pub.dev/packages/manga_page_view)). Internally this widget uses combination of `Listener`s for gesture detection and `Transform.translate` and `Transform.scale` to manipulate the contents directly, simulating Flutter’s own scrollable views but with better pan & zoom support. It will also handle the widget caching in itself. 

Now the experience should be comparable to Dantotsu’s reader more or less. Also this might open an opportunity for new enhancements as more options can be introduced (padding, spaced page, etc).

Changes are now altered based on the recent manga reader revamp. Hoping you can consider my fix. Thanks! 

**Summary of Changes:**  
Enhancement brought by `MangaPageView`
- Panning while zooming now feels more natural and easier to trigger, You can now zoom in and pan around without restrictions.
- Pinch-to-zoom re-added.
- Double-tap-to-zoom now with steps (1x, 2x, 4x; cycling).
- Double-tap-and-drag to zoom in/out (Exists in Dantotsu/Mihon).
- Better mouse wheel support for desktop (scrolling/zooming with mouse wheel by Shift+Wheel & Ctrl+Wheel)
- Better trackpad support for desktop (pinch, two finger swipe), at least for Macbooks
- For LTR & RTL mode, pages can now be loaded in advance (configurable via `precache` options). By comparison, current `PageView` only builds the widget as soon as it becomes visible.
- Overscrolling to previous/next chapter are now easier to trigger, and comes with customizable indicator widget (currently just a basic icon)

Other miscellaneous fixes
- Removed current usages of ScrollablePositionedList, ScrollController etc. on reader view.
- Fixed issue where Reader Setting - Layout selection doesn’t get saved
- Fixed slider page number showing extraneous decimal places (e.g. 2.0 instead of 2) 

**Type of Changes:**  
- Enhancement

**Testing Notes:**  
Tested on following devices:
- POCO F3 (6.67”)
- Lenovo Legion Y700 (8.8”)
- Macbook Air M1 (13”)

**Linked Issue(s):**  
None

**Additional Context:**  
None

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [x] I have added or updated documentation as needed
- [x] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request
