### PR TITLE
manga_page_view version upgrade

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   json_annotation: ^4.9.0
   json_path: ^0.7.4
   kenburns_nullsafety: ^1.0.1
-  manga_page_view: ^1.0.1
+  manga_page_view: ^1.0.5
   
   # repo => https://github.com/media-kit/media-kit
   media_kit: ^1.2.0


### PR DESCRIPTION

# Pull Request

**Title:**  
Upgrading `manga_page_view` to latest version (1.0.5)

**Description:**  
Just a small change on the page handling code that potentially fix touch navigation issues on iOS devices, which affects the following
- Swapping pages on "paged" mode
- Zoom gestures (double-tap, double-tap-drag, pinch)
- Edge gestures (for going to previous/next chapters)

Do let me know if the issue still occurs. I do not have a working iPhone so i can only test this on simulator.

**Summary of Changes:**  
Bumped `manga_page_view` to 1.0.5. [Changelog](https://pub.dev/packages/manga_page_view/changelog)

**Type of Changes:**  
- Bug Fix

**Testing Notes:**  
Tested on iOS simulator (iOS 18.5)

**Linked Issue(s):**  
-

**Additional Context:**  
-

**Submission Checklist:**
- [X] I have read and followed the project's contributing guidelines
- [X] My code follows the code style of this project
- [X] I have tested the changes and ensured they do not break existing functionality
- [X] I have added or updated documentation as needed
- [X] I have linked related issues in the description above
- [X] I have tagged the appropriate reviewers for this pull request
