### PR TITLE
Manga reader: more settings and UI adjustments

### DIFF
--- a/lib/screens/manga/controller/reader_controller.dart
+++ b/lib/screens/manga/controller/reader_controller.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: deprecated_member_use
-
 import 'dart:async';
 import 'dart:developer';
 
@@ -12,7 +10,7 @@ import 'package:anymex/core/Eval/dart/model/page.dart';
 import 'package:anymex/core/Search/get_pages.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/models/Offline/Hive/chapter.dart';
-import 'package:anymex/screens/manga/reading_page.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:manga_page_view/manga_page_view.dart';
 
@@ -29,11 +27,13 @@ class ReaderController extends GetxController {
   final OfflineStorageController offlineStorageController =
       Get.find<OfflineStorageController>();
 
-  final Rx<ReadingMode> activeMode = ReadingMode.webtoon.obs;
   final RxInt currentPageIndex = 1.obs;
   final RxDouble pageWidthMultiplier = 1.0.obs;
   final RxDouble scrollSpeedMultiplier = 1.0.obs;
   final RxBool spacedPages = false.obs;
+  final Rx<MangaPageViewMode> readingLayout = MangaPageViewMode.continuous.obs;
+  final Rx<MangaPageViewDirection> readingDirection =
+      MangaPageViewDirection.down.obs;
 
   final defaultWidth = 400.obs;
   final defaultSpeed = 300.obs;
@@ -44,14 +44,19 @@ class ReaderController extends GetxController {
 
   MangaPageViewController? pageViewController;
 
+  PageController? pageController;
+
   void _initializeControllers() {
     pageViewController = MangaPageViewController();
-    pageViewController?.addPageChangeListener(onPageChanged);
   }
 
   void _getPreferences() {
-    activeMode.value = ReadingMode.values[
-        settingsController.preferences.get('reading_mode', defaultValue: 0)];
+    readingLayout.value = MangaPageViewMode.values[settingsController
+        .preferences
+        .get('reading_layout', defaultValue: 0 /* continuous */)];
+    readingDirection.value = MangaPageViewDirection.values[settingsController
+        .preferences
+        .get('reading_direction', defaultValue: 1 /* down */)];
     pageWidthMultiplier.value =
         settingsController.preferences.get('image_width') ?? 1;
     scrollSpeedMultiplier.value =
@@ -61,7 +66,10 @@ class ReaderController extends GetxController {
   }
 
   void _savePreferences() {
-    settingsController.preferences.put('reading_mode', activeMode.value.index);
+    settingsController.preferences
+        .put('reading_layout', readingLayout.value.index);
+    settingsController.preferences
+        .put('reading_direction', readingDirection.value.index);
     settingsController.preferences
         .put('image_width', pageWidthMultiplier.value);
     settingsController.preferences
@@ -191,8 +199,13 @@ class ReaderController extends GetxController {
     }
   }
 
-  void changeActiveMode(ReadingMode readingMode) async {
-    activeMode.value = readingMode;
+  void changeReadingLayout(MangaPageViewMode mode) async {
+    readingLayout.value = mode;
+    savePreferences();
+  }
+
+  void changeReadingDirection(MangaPageViewDirection direction) async {
+    readingDirection.value = direction;
     savePreferences();
   }
 

--- a/lib/screens/manga/controller/reader_controller.dart
+++ b/lib/screens/manga/controller/reader_controller.dart
@@ -30,10 +30,12 @@ class ReaderController extends GetxController {
   final RxInt currentPageIndex = 1.obs;
   final RxDouble pageWidthMultiplier = 1.0.obs;
   final RxDouble scrollSpeedMultiplier = 1.0.obs;
-  final RxBool spacedPages = false.obs;
+
   final Rx<MangaPageViewMode> readingLayout = MangaPageViewMode.continuous.obs;
   final Rx<MangaPageViewDirection> readingDirection =
       MangaPageViewDirection.down.obs;
+  final RxBool spacedPages = false.obs;
+  final RxBool overscrollToChapter = true.obs;
 
   final defaultWidth = 400.obs;
   final defaultSpeed = 300.obs;
@@ -43,8 +45,6 @@ class ReaderController extends GetxController {
   final RxString errorMessage = ''.obs;
 
   MangaPageViewController? pageViewController;
-
-  PageController? pageController;
 
   void _initializeControllers() {
     pageViewController = MangaPageViewController();
@@ -63,6 +63,8 @@ class ReaderController extends GetxController {
         settingsController.preferences.get('scroll_speed') ?? 1;
     spacedPages.value =
         settingsController.preferences.get('spaced_pages', defaultValue: false);
+    overscrollToChapter.value = settingsController.preferences
+        .get('overscroll_to_chapter', defaultValue: true);
   }
 
   void _savePreferences() {
@@ -75,6 +77,8 @@ class ReaderController extends GetxController {
     settingsController.preferences
         .put('scroll_speed', scrollSpeedMultiplier.value);
     settingsController.preferences.put('spaced_pages', spacedPages.value);
+    settingsController.preferences
+        .put('overscroll_to_chapter', overscrollToChapter.value);
   }
 
   void onPageChanged(int index) async {
@@ -133,6 +137,11 @@ class ReaderController extends GetxController {
 
   void toggleSpacedPages() {
     spacedPages.value = !spacedPages.value;
+    savePreferences();
+  }
+
+  void toggleOverscrollToChapter() {
+    overscrollToChapter.value = !overscrollToChapter.value;
     savePreferences();
   }
 

--- a/lib/screens/manga/controller/reader_controller.dart
+++ b/lib/screens/manga/controller/reader_controller.dart
@@ -33,6 +33,7 @@ class ReaderController extends GetxController {
   final RxInt currentPageIndex = 1.obs;
   final RxDouble pageWidthMultiplier = 1.0.obs;
   final RxDouble scrollSpeedMultiplier = 1.0.obs;
+  final RxBool spacedPages = false.obs;
 
   final defaultWidth = 400.obs;
   final defaultSpeed = 300.obs;
@@ -55,6 +56,8 @@ class ReaderController extends GetxController {
         settingsController.preferences.get('image_width') ?? 1;
     scrollSpeedMultiplier.value =
         settingsController.preferences.get('scroll_speed') ?? 1;
+    spacedPages.value =
+        settingsController.preferences.get('spaced_pages', defaultValue: false);
   }
 
   void _savePreferences() {
@@ -63,6 +66,7 @@ class ReaderController extends GetxController {
         .put('image_width', pageWidthMultiplier.value);
     settingsController.preferences
         .put('scroll_speed', scrollSpeedMultiplier.value);
+    settingsController.preferences.put('spaced_pages', spacedPages.value);
   }
 
   void onPageChanged(int index) async {
@@ -117,6 +121,11 @@ class ReaderController extends GetxController {
     log(showControls.value.toString());
     showControls.value = !showControls.value;
     log(showControls.value.toString());
+  }
+
+  void toggleSpacedPages() {
+    spacedPages.value = !spacedPages.value;
+    savePreferences();
   }
 
   void navigateToChapter(int index) async {
@@ -184,6 +193,7 @@ class ReaderController extends GetxController {
 
   void changeActiveMode(ReadingMode readingMode) async {
     activeMode.value = readingMode;
+    savePreferences();
   }
 
   void savePreferences() => _savePreferences();

--- a/lib/screens/manga/reading_page.dart
+++ b/lib/screens/manga/reading_page.dart
@@ -9,12 +9,6 @@ import 'package:get/get.dart';
 
 import 'package:anymex/models/Offline/Hive/chapter.dart';
 
-enum ReadingMode {
-  webtoon,
-  ltr,
-  rtl,
-}
-
 class ReadingPage extends StatefulWidget {
   final Media anilistData;
   final List<Chapter> chapterList;

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -10,6 +10,9 @@ import 'package:get/get.dart';
 import 'package:manga_page_view/manga_page_view.dart';
 
 class ReaderView extends StatelessWidget {
+  // Size to use when images aren't ready (loading/failing)
+  static const initialPageSize = Size(300, 300);
+
   final ReaderController controller;
 
   const ReaderView({
@@ -128,6 +131,7 @@ class ReaderView extends StatelessWidget {
               desktopSize: controller.defaultWidth.value *
                   controller.pageWidthMultiplier.value),
           edgeIndicatorContainerSize: 240,
+          initialPageSize: initialPageSize,
           precacheAhead: currentLayout == MangaPageViewMode.paged ? 2 : 0,
           precacheBehind: currentLayout == MangaPageViewMode.paged ? 2 : 0,
         ),
@@ -201,9 +205,6 @@ class ReaderView extends StatelessWidget {
   }
 
   Widget _buildImage(BuildContext context, PageUrl page, int index) {
-    // Size to use when images aren't ready (loading/failing)
-    const initialSize = Size(512, 512);
-
     return StatefulBuilder(
       builder: (context, setState) {
         return CachedNetworkImage(
@@ -215,7 +216,7 @@ class ReaderView extends StatelessWidget {
           fit: BoxFit.contain,
           progressIndicatorBuilder: (context, url, progress) {
             return SizedBox.fromSize(
-              size: initialSize,
+              size: initialPageSize,
               child: Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -232,7 +233,7 @@ class ReaderView extends StatelessWidget {
           },
           errorWidget: (context, url, error) {
             return SizedBox.fromSize(
-              size: initialSize,
+              size: initialPageSize,
               child: Container(
                 color: Colors.grey.withOpacity(0.1),
                 child: Column(

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -102,27 +102,23 @@ class ReaderView extends StatelessWidget {
         controller.chapterList.indexOf(controller.currentChapter.value!) <
             controller.chapterList.length - 1;
     final isLoaded = controller.loadingState.value == LoadingState.loaded;
-
+    final currentLayout = controller.readingLayout.value;
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: () => controller.toggleControls(),
       onDoubleTap: () {},
       child: MangaPageView(
-        mode: controller.activeMode.value == ReadingMode.webtoon
-            ? MangaPageViewMode.continuous
-            : MangaPageViewMode.paged,
-        direction: switch (controller.activeMode.value) {
-          ReadingMode.webtoon => MangaPageViewDirection.down,
-          ReadingMode.rtl => MangaPageViewDirection.left,
-          ReadingMode.ltr => MangaPageViewDirection.right,
-        },
+        mode: controller.readingLayout.value,
+        direction: controller.readingDirection.value,
         controller: controller.pageViewController,
         options: MangaPageViewOptions(
           padding: MediaQuery.paddingOf(context),
           mainAxisOverscroll: false,
           crossAxisOverscroll: false,
-          minZoomLevel:
-              controller.activeMode.value == ReadingMode.webtoon ? 0.5 : 1.0,
+          minZoomLevel: switch (currentLayout) {
+            MangaPageViewMode.continuous => 0.75,
+            MangaPageViewMode.paged => 1.0
+          },
           maxZoomLevel: 8.0,
           spacing: controller.spacedPages.value ? 20 : 0,
           pageWidthLimit: getResponsiveSize(context,
@@ -130,6 +126,8 @@ class ReaderView extends StatelessWidget {
               desktopSize: controller.defaultWidth.value *
                   controller.pageWidthMultiplier.value),
           edgeIndicatorContainerSize: 240,
+          precacheAhead: currentLayout == MangaPageViewMode.paged ? 2 : 0,
+          precacheBehind: currentLayout == MangaPageViewMode.paged ? 2 : 0,
         ),
         pageCount: controller.pageList.length,
         pageBuilder: (context, index) {
@@ -201,6 +199,9 @@ class ReaderView extends StatelessWidget {
   }
 
   Widget _buildImage(BuildContext context, PageUrl page, int index) {
+    // Size to use when images aren't ready (loading/failing)
+    const initialSize = Size(512, 512);
+
     return StatefulBuilder(
       builder: (context, setState) {
         return CachedNetworkImage(
@@ -210,62 +211,66 @@ class ReaderView extends StatelessWidget {
               ? {'Referer': sourceController.activeMangaSource.value!.baseUrl!}
               : page.headers,
           fit: BoxFit.contain,
-          progressIndicatorBuilder: (context, url, progress) => SizedBox(
-            height: Get.height / 2,
-            width: double.infinity,
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  AnymexProgressIndicator(
-                    value: progress.progress,
-                  ),
-                  const SizedBox(height: 8),
-                  Text('Loading page ${index + 1}...'),
-                ],
+          progressIndicatorBuilder: (context, url, progress) {
+            return SizedBox.fromSize(
+              size: initialSize,
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    AnymexProgressIndicator(
+                      value: progress.progress,
+                    ),
+                    const SizedBox(height: 8),
+                    Text('Loading page ${index + 1}...'),
+                  ],
+                ),
               ),
-            ),
-          ),
-          errorWidget: (context, url, error) => Container(
-            height: Get.height / 2,
-            width: double.infinity,
-            color: Colors.grey.withOpacity(0.1),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.broken_image_outlined,
-                  size: 48,
-                  color: Colors.grey.withOpacity(0.7),
+            );
+          },
+          errorWidget: (context, url, error) {
+            return SizedBox.fromSize(
+              size: initialSize,
+              child: Container(
+                color: Colors.grey.withOpacity(0.1),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.broken_image_outlined,
+                      size: 48,
+                      color: Colors.grey.withOpacity(0.7),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Failed to load page ${index + 1}',
+                      style: const TextStyle(color: Colors.grey),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        // Force refresh the specific image
+                        final imageProvider = CachedNetworkImageProvider(
+                          page.url,
+                          headers: page.headers,
+                        );
+                        await imageProvider.evict();
+                        // Trigger rebuild of only this image widget
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.refresh, size: 16),
+                      label: const Text('Retry'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 6),
+                        textStyle: const TextStyle(fontSize: 12),
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  'Failed to load page ${index + 1}',
-                  style: const TextStyle(color: Colors.grey),
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton.icon(
-                  onPressed: () async {
-                    // Force refresh the specific image
-                    final imageProvider = CachedNetworkImageProvider(
-                      page.url,
-                      headers: page.headers,
-                    );
-                    await imageProvider.evict();
-                    // Trigger rebuild of only this image widget
-                    setState(() {});
-                  },
-                  icon: const Icon(Icons.refresh, size: 16),
-                  label: const Text('Retry'),
-                  style: ElevatedButton.styleFrom(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
-                ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -96,6 +96,13 @@ class ReaderView extends StatelessWidget {
   }
 
   Widget _buildContentView(BuildContext context) {
+    final hasPreviousChapter =
+        controller.chapterList.indexOf(controller.currentChapter.value!) > 0;
+    final hasNextChapter =
+        controller.chapterList.indexOf(controller.currentChapter.value!) <
+            controller.chapterList.length - 1;
+    final isLoaded = controller.loadingState.value == LoadingState.loaded;
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: () => controller.toggleControls(),
@@ -117,56 +124,78 @@ class ReaderView extends StatelessWidget {
           minZoomLevel:
               controller.activeMode.value == ReadingMode.webtoon ? 0.5 : 1.0,
           maxZoomLevel: 8.0,
+          spacing: controller.spacedPages.value ? 20 : 0,
           pageWidthLimit: getResponsiveSize(context,
               mobileSize: double.infinity,
               desktopSize: controller.defaultWidth.value *
                   controller.pageWidthMultiplier.value),
+          edgeIndicatorContainerSize: 240,
         ),
         pageCount: controller.pageList.length,
         pageBuilder: (context, index) {
           return _buildImage(context, controller.pageList[index], index);
         },
         onPageChange: (index) => controller.onPageChanged(index),
+
+        // For previous/next chapter switching
         startEdgeDragIndicatorBuilder: (context, info) {
-          return Center(
-            child: AnimatedScale(
-              scale: info.isTriggered ? 1.5 : 1,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.elasticOut,
-              child: Icon(
-                Icons.skip_previous_rounded,
-                color: info.isTriggered ? Colors.white : Colors.white54,
-                size: 36,
+          return Column(
+            spacing: 16,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AnimatedScale(
+                scale: info.isTriggered ? 1.6 : 1,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.elasticOut,
+                child: Icon(
+                  hasPreviousChapter
+                      ? Icons.skip_previous_rounded
+                      : Icons.block_rounded,
+                  color: info.isTriggered ? Colors.white : Colors.white54,
+                  size: 36,
+                ),
               ),
-            ),
+              Text(
+                hasPreviousChapter ? 'Previous chapter' : "No previous chapter",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                    color: info.isTriggered ? Colors.white : Colors.white54),
+              )
+            ],
           );
         },
         endEdgeDragIndicatorBuilder: (context, info) {
-          return Center(
-            child: AnimatedScale(
-              scale: info.isTriggered ? 1.5 : 1,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.elasticOut,
-              child: Icon(
-                Icons.skip_next_rounded,
-                color: info.isTriggered ? Colors.white : Colors.white54,
-                size: 36,
+          return Column(
+            spacing: 16,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AnimatedScale(
+                scale: info.isTriggered ? 1.6 : 1,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.elasticOut,
+                child: Icon(
+                  hasNextChapter
+                      ? Icons.skip_next_rounded
+                      : Icons.block_rounded,
+                  color: info.isTriggered ? Colors.white : Colors.white54,
+                  size: 36,
+                ),
               ),
-            ),
+              Text(
+                hasNextChapter ? 'Next chapter' : "No next chapter",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                    color: info.isTriggered ? Colors.white : Colors.white54),
+              )
+            ],
           );
         },
-        onStartEdgeDrag:
-            controller.chapterList.indexOf(controller.currentChapter.value!) >
-                        0 &&
-                    controller.loadingState.value == LoadingState.loaded
-                ? () => controller.chapterNavigator(false)
-                : null,
-        onEndEdgeDrag:
-            controller.chapterList.indexOf(controller.currentChapter.value!) <
-                        controller.chapterList.length - 1 &&
-                    controller.loadingState.value == LoadingState.loaded
-                ? () => controller.chapterNavigator(true)
-                : null,
+        onStartEdgeDrag: hasPreviousChapter && isLoaded
+            ? () => controller.chapterNavigator(false)
+            : null,
+        onEndEdgeDrag: hasNextChapter && isLoaded
+            ? () => controller.chapterNavigator(true)
+            : null,
       ),
     );
   }

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -103,6 +103,8 @@ class ReaderView extends StatelessWidget {
             controller.chapterList.length - 1;
     final isLoaded = controller.loadingState.value == LoadingState.loaded;
     final currentLayout = controller.readingLayout.value;
+    final canOverscroll = controller.overscrollToChapter.value;
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: () => controller.toggleControls(),
@@ -188,10 +190,10 @@ class ReaderView extends StatelessWidget {
             ],
           );
         },
-        onStartEdgeDrag: hasPreviousChapter && isLoaded
+        onStartEdgeDrag: hasPreviousChapter && canOverscroll && isLoaded
             ? () => controller.chapterNavigator(false)
             : null,
-        onEndEdgeDrag: hasNextChapter && isLoaded
+        onEndEdgeDrag: hasNextChapter && canOverscroll && isLoaded
             ? () => controller.chapterNavigator(true)
             : null,
       ),

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -216,13 +216,13 @@ class ReaderView extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton.icon(
-                  onPressed: () {
+                  onPressed: () async {
                     // Force refresh the specific image
                     final imageProvider = CachedNetworkImageProvider(
                       page.url,
                       headers: page.headers,
                     );
-                    imageProvider.evict();
+                    await imageProvider.evict();
                     // Trigger rebuild of only this image widget
                     setState(() {});
                   },

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -127,6 +127,15 @@ class ReaderSettings {
                     onChanged: (val) => controller.toggleSpacedPages(),
                   );
                 }),
+                Obx(() {
+                  return CustomSwitchTile(
+                    icon: Iconsax.arrow,
+                    title: "Overscroll",
+                    description: "To Prev/Next Chapter",
+                    switchValue: controller.overscrollToChapter.value,
+                    onChanged: (val) => controller.toggleOverscrollToChapter(),
+                  );
+                }),
                 if (!Platform.isAndroid && !Platform.isIOS)
                   Obx(() {
                     return CustomSliderTile(

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 import 'package:anymex/screens/manga/controller/reader_controller.dart';
-import 'package:anymex/screens/manga/reading_page.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/widgets/common/custom_tiles.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:iconsax/iconsax.dart';
+import 'package:manga_page_view/manga_page_view.dart';
 
 class ReaderSettings {
   final ReaderController controller;
@@ -37,50 +37,92 @@ class ReaderSettings {
                   ),
                 ),
                 Obx(() {
+                  final currentLayout = controller.readingLayout.value;
                   return CustomTile(
                     title: 'Layout',
-                    description:
-                        'Currently: ${controller.activeMode.value.name.toUpperCase()}',
+                    description: switch (currentLayout) {
+                      MangaPageViewMode.continuous => 'Continuous',
+                      MangaPageViewMode.paged => 'Paged',
+                    },
                     icon: Iconsax.card,
-                    postFix: 0.height(),
+                    postFix: Row(
+                      spacing: 4,
+                      children: [
+                        for (final layout in [
+                          MangaPageViewMode.continuous,
+                          MangaPageViewMode.paged
+                        ])
+                          IconButton.filled(
+                            isSelected: layout == currentLayout,
+                            tooltip: switch (layout) {
+                              MangaPageViewMode.continuous => 'Continuous',
+                              MangaPageViewMode.paged => 'Paged',
+                            },
+                            icon: switch (layout) {
+                              MangaPageViewMode.continuous =>
+                                const Icon(Iconsax.slider_vertical),
+                              MangaPageViewMode.paged =>
+                                const Icon(Iconsax.grid_9),
+                            },
+                            onPressed: () {
+                              controller.changeReadingLayout(layout);
+                            },
+                          )
+                      ],
+                    ),
                   );
                 }),
                 Obx(() {
-                  final selections = List<bool>.generate(
-                    ReadingMode.values.length,
-                    (index) =>
-                        index ==
-                        ReadingMode.values.indexOf(controller.activeMode.value),
-                  );
-                  return Center(
-                    child: ToggleButtons(
-                      isSelected: selections,
-                      onPressed: (int index) {
-                        final mode = ReadingMode.values[index];
-                        controller.changeActiveMode(mode);
-                      },
-                      children: const [
-                        Tooltip(
-                          message: 'Webtoon',
-                          child: Icon(Icons.view_day),
-                        ),
-                        Tooltip(
-                          message: 'LTR',
-                          child: Icon(Icons.format_textdirection_l_to_r),
-                        ),
-                        Tooltip(
-                          message: 'RTL',
-                          child: Icon(Icons.format_textdirection_r_to_l),
-                        ),
+                  final currentDirection = controller.readingDirection.value;
+                  return CustomTile(
+                    title: 'Direction',
+                    description: switch (currentDirection) {
+                      MangaPageViewDirection.down => "Top-Down",
+                      MangaPageViewDirection.right => "LTR",
+                      MangaPageViewDirection.up => "Bottom-Up",
+                      MangaPageViewDirection.left => "RTL",
+                    },
+                    icon: Iconsax.direct_right,
+                    postFix: Row(
+                      spacing: 4,
+                      children: [
+                        for (final direction in [
+                          MangaPageViewDirection.down,
+                          MangaPageViewDirection.right,
+                          MangaPageViewDirection.up,
+                          MangaPageViewDirection.left,
+                        ])
+                          IconButton.filled(
+                            isSelected: direction == currentDirection,
+                            tooltip: switch (direction) {
+                              MangaPageViewDirection.down => "Top-Down",
+                              MangaPageViewDirection.right => "LTR",
+                              MangaPageViewDirection.up => "Bottom-Up",
+                              MangaPageViewDirection.left => "RTL",
+                            },
+                            icon: switch (direction) {
+                              MangaPageViewDirection.down =>
+                                const Icon(Iconsax.arrow_down),
+                              MangaPageViewDirection.right =>
+                                const Icon(Iconsax.arrow_right_1),
+                              MangaPageViewDirection.up =>
+                                const Icon(Iconsax.arrow_up_3),
+                              MangaPageViewDirection.left =>
+                                const Icon(Iconsax.arrow_left),
+                            },
+                            onPressed: () {
+                              controller.changeReadingDirection(direction);
+                            },
+                          )
                       ],
                     ),
                   );
                 }),
                 Obx(() {
                   return CustomSwitchTile(
-                    icon: Icons.fast_forward,
+                    icon: Iconsax.pharagraphspacing,
                     title: "Spaced Pages",
-                    description: "Add gaps between pages. Continuous mode only",
+                    description: "Continuous Mode only",
                     switchValue: controller.spacedPages.value,
                     onChanged: (val) => controller.toggleSpacedPages(),
                   );
@@ -94,7 +136,7 @@ class ReaderSettings {
                         controller.pageWidthMultiplier.value = value;
                       },
                       onChangedEnd: (e) => controller.savePreferences(),
-                      description: 'Only Works with webtoon mode',
+                      description: 'Continuous Mode only',
                       icon: Icons.image_aspect_ratio_rounded,
                       min: 1.0,
                       max: 4.0,
@@ -125,14 +167,5 @@ class ReaderSettings {
         );
       },
     );
-  }
-
-  List<bool> createSelectionRange() {
-    final ReaderController controller = Get.find<ReaderController>();
-    const readingModes = ReadingMode.values;
-    final trueIndex = readingModes.indexOf(controller.activeMode.value);
-    final newRange = [false, false, false];
-    newRange[trueIndex] = true;
-    return newRange;
   }
 }

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -16,161 +16,166 @@ class ReaderSettings {
       context: context,
       backgroundColor: Colors.transparent,
       builder: (BuildContext context) {
-        return Container(
-          padding: const EdgeInsets.symmetric(vertical: 20),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-          ),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16.0, horizontal: 10),
-                  child: Center(
-                    child: Text(
-                      'Reader Settings',
-                      style: TextStyle(
-                          fontSize: 18, fontFamily: 'Poppins-SemiBold'),
+        const topCornerRadius = BorderRadius.vertical(top: Radius.circular(16));
+        return ClipRRect(
+          borderRadius: topCornerRadius,
+          child: Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+            ),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Padding(
+                    padding:
+                        EdgeInsets.symmetric(vertical: 16.0, horizontal: 10),
+                    child: Center(
+                      child: Text(
+                        'Reader Settings',
+                        style: TextStyle(
+                            fontSize: 18, fontFamily: 'Poppins-SemiBold'),
+                      ),
                     ),
                   ),
-                ),
-                Obx(() {
-                  final currentLayout = controller.readingLayout.value;
-                  return CustomTile(
-                    title: 'Layout',
-                    description: switch (currentLayout) {
-                      MangaPageViewMode.continuous => 'Continuous',
-                      MangaPageViewMode.paged => 'Paged',
-                    },
-                    icon: Iconsax.card,
-                    postFix: Row(
-                      spacing: 4,
-                      children: [
-                        for (final layout in [
-                          MangaPageViewMode.continuous,
-                          MangaPageViewMode.paged
-                        ])
-                          IconButton.filled(
-                            isSelected: layout == currentLayout,
-                            tooltip: switch (layout) {
-                              MangaPageViewMode.continuous => 'Continuous',
-                              MangaPageViewMode.paged => 'Paged',
-                            },
-                            icon: switch (layout) {
-                              MangaPageViewMode.continuous =>
-                                const Icon(Iconsax.slider_vertical),
-                              MangaPageViewMode.paged =>
-                                const Icon(Iconsax.grid_9),
-                            },
-                            onPressed: () {
-                              controller.changeReadingLayout(layout);
-                            },
-                          )
-                      ],
-                    ),
-                  );
-                }),
-                Obx(() {
-                  final currentDirection = controller.readingDirection.value;
-                  return CustomTile(
-                    title: 'Direction',
-                    description: switch (currentDirection) {
-                      MangaPageViewDirection.down => "Top-Down",
-                      MangaPageViewDirection.right => "LTR",
-                      MangaPageViewDirection.up => "Bottom-Up",
-                      MangaPageViewDirection.left => "RTL",
-                    },
-                    icon: Iconsax.direct_right,
-                    postFix: Row(
-                      spacing: 4,
-                      children: [
-                        for (final direction in [
-                          MangaPageViewDirection.down,
-                          MangaPageViewDirection.right,
-                          MangaPageViewDirection.up,
-                          MangaPageViewDirection.left,
-                        ])
-                          IconButton.filled(
-                            isSelected: direction == currentDirection,
-                            tooltip: switch (direction) {
-                              MangaPageViewDirection.down => "Top-Down",
-                              MangaPageViewDirection.right => "LTR",
-                              MangaPageViewDirection.up => "Bottom-Up",
-                              MangaPageViewDirection.left => "RTL",
-                            },
-                            icon: switch (direction) {
-                              MangaPageViewDirection.down =>
-                                const Icon(Iconsax.arrow_down),
-                              MangaPageViewDirection.right =>
-                                const Icon(Iconsax.arrow_right_1),
-                              MangaPageViewDirection.up =>
-                                const Icon(Iconsax.arrow_up_3),
-                              MangaPageViewDirection.left =>
-                                const Icon(Iconsax.arrow_left),
-                            },
-                            onPressed: () {
-                              controller.changeReadingDirection(direction);
-                            },
-                          )
-                      ],
-                    ),
-                  );
-                }),
-                Obx(() {
-                  return CustomSwitchTile(
-                    icon: Iconsax.pharagraphspacing,
-                    title: "Spaced Pages",
-                    description: "Continuous Mode only",
-                    switchValue: controller.spacedPages.value,
-                    onChanged: (val) => controller.toggleSpacedPages(),
-                  );
-                }),
-                Obx(() {
-                  return CustomSwitchTile(
-                    icon: Iconsax.arrow,
-                    title: "Overscroll",
-                    description: "To Prev/Next Chapter",
-                    switchValue: controller.overscrollToChapter.value,
-                    onChanged: (val) => controller.toggleOverscrollToChapter(),
-                  );
-                }),
-                if (!Platform.isAndroid && !Platform.isIOS)
                   Obx(() {
-                    return CustomSliderTile(
-                      title: 'Image Width',
-                      sliderValue: controller.pageWidthMultiplier.value,
-                      onChanged: (double value) {
-                        controller.pageWidthMultiplier.value = value;
+                    final currentLayout = controller.readingLayout.value;
+                    return CustomTile(
+                      title: 'Layout',
+                      description: switch (currentLayout) {
+                        MangaPageViewMode.continuous => 'Continuous',
+                        MangaPageViewMode.paged => 'Paged',
                       },
-                      onChangedEnd: (e) => controller.savePreferences(),
-                      description: 'Continuous Mode only',
-                      icon: Icons.image_aspect_ratio_rounded,
-                      min: 1.0,
-                      max: 4.0,
-                      divisions: 39,
+                      icon: Iconsax.card,
+                      postFix: Row(
+                        spacing: 4,
+                        children: [
+                          for (final layout in [
+                            MangaPageViewMode.continuous,
+                            MangaPageViewMode.paged
+                          ])
+                            IconButton.filled(
+                              isSelected: layout == currentLayout,
+                              tooltip: switch (layout) {
+                                MangaPageViewMode.continuous => 'Continuous',
+                                MangaPageViewMode.paged => 'Paged',
+                              },
+                              icon: switch (layout) {
+                                MangaPageViewMode.continuous =>
+                                  const Icon(Iconsax.slider_vertical),
+                                MangaPageViewMode.paged =>
+                                  const Icon(Iconsax.grid_9),
+                              },
+                              onPressed: () {
+                                controller.changeReadingLayout(layout);
+                              },
+                            )
+                        ],
+                      ),
                     );
                   }),
-                if (!Platform.isAndroid && !Platform.isIOS)
                   Obx(() {
-                    return CustomSliderTile(
-                      title: 'Scroll Multiplier',
-                      sliderValue: controller.scrollSpeedMultiplier.value,
-                      onChanged: (double value) {
-                        controller.scrollSpeedMultiplier.value = value;
+                    final currentDirection = controller.readingDirection.value;
+                    return CustomTile(
+                      title: 'Direction',
+                      description: switch (currentDirection) {
+                        MangaPageViewDirection.down => "Top-Down",
+                        MangaPageViewDirection.right => "LTR",
+                        MangaPageViewDirection.up => "Bottom-Up",
+                        MangaPageViewDirection.left => "RTL",
                       },
-                      onChangedEnd: (e) => controller.savePreferences(),
-                      description:
-                          'Adjust Key Scrolling Speed (Up, Down, Left, Right)',
-                      icon: Icons.speed,
-                      min: 1.0,
-                      max: 5.0,
-                      divisions: 9,
+                      icon: Iconsax.direct_right,
+                      postFix: Row(
+                        spacing: 4,
+                        children: [
+                          for (final direction in [
+                            MangaPageViewDirection.down,
+                            MangaPageViewDirection.right,
+                            MangaPageViewDirection.up,
+                            MangaPageViewDirection.left,
+                          ])
+                            IconButton.filled(
+                              isSelected: direction == currentDirection,
+                              tooltip: switch (direction) {
+                                MangaPageViewDirection.down => "Top-Down",
+                                MangaPageViewDirection.right => "LTR",
+                                MangaPageViewDirection.up => "Bottom-Up",
+                                MangaPageViewDirection.left => "RTL",
+                              },
+                              icon: switch (direction) {
+                                MangaPageViewDirection.down =>
+                                  const Icon(Iconsax.arrow_down),
+                                MangaPageViewDirection.right =>
+                                  const Icon(Iconsax.arrow_right_1),
+                                MangaPageViewDirection.up =>
+                                  const Icon(Iconsax.arrow_up_3),
+                                MangaPageViewDirection.left =>
+                                  const Icon(Iconsax.arrow_left),
+                              },
+                              onPressed: () {
+                                controller.changeReadingDirection(direction);
+                              },
+                            )
+                        ],
+                      ),
                     );
                   }),
-                20.height()
-              ],
+                  Obx(() {
+                    return CustomSwitchTile(
+                      icon: Iconsax.pharagraphspacing,
+                      title: "Spaced Pages",
+                      description: "Continuous Mode only",
+                      switchValue: controller.spacedPages.value,
+                      onChanged: (val) => controller.toggleSpacedPages(),
+                    );
+                  }),
+                  Obx(() {
+                    return CustomSwitchTile(
+                      icon: Iconsax.arrow,
+                      title: "Overscroll",
+                      description: "To Prev/Next Chapter",
+                      switchValue: controller.overscrollToChapter.value,
+                      onChanged: (val) =>
+                          controller.toggleOverscrollToChapter(),
+                    );
+                  }),
+                  if (!Platform.isAndroid && !Platform.isIOS)
+                    Obx(() {
+                      return CustomSliderTile(
+                        title: 'Image Width',
+                        sliderValue: controller.pageWidthMultiplier.value,
+                        onChanged: (double value) {
+                          controller.pageWidthMultiplier.value = value;
+                        },
+                        onChangedEnd: (e) => controller.savePreferences(),
+                        description: 'Continuous Mode only',
+                        icon: Icons.image_aspect_ratio_rounded,
+                        min: 1.0,
+                        max: 4.0,
+                        divisions: 39,
+                      );
+                    }),
+                  if (!Platform.isAndroid && !Platform.isIOS)
+                    Obx(() {
+                      return CustomSliderTile(
+                        title: 'Scroll Multiplier',
+                        sliderValue: controller.scrollSpeedMultiplier.value,
+                        onChanged: (double value) {
+                          controller.scrollSpeedMultiplier.value = value;
+                        },
+                        onChangedEnd: (e) => controller.savePreferences(),
+                        description:
+                            'Adjust Key Scrolling Speed (Up, Down, Left, Right)',
+                        icon: Icons.speed,
+                        min: 1.0,
+                        max: 5.0,
+                        divisions: 9,
+                      );
+                    }),
+                  20.height()
+                ],
+              ),
             ),
           ),
         );

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -58,7 +58,6 @@ class ReaderSettings {
                       onPressed: (int index) {
                         final mode = ReadingMode.values[index];
                         controller.changeActiveMode(mode);
-                        controller.savePreferences();
                       },
                       children: const [
                         Tooltip(
@@ -75,6 +74,15 @@ class ReaderSettings {
                         ),
                       ],
                     ),
+                  );
+                }),
+                Obx(() {
+                  return CustomSwitchTile(
+                    icon: Icons.fast_forward,
+                    title: "Spaced Pages",
+                    description: "Add gaps between pages. Continuous mode only",
+                    switchValue: controller.spacedPages.value,
+                    onChanged: (val) => controller.toggleSpacedPages(),
                   );
                 }),
                 if (!Platform.isAndroid && !Platform.isIOS)

--- a/lib/screens/manga/widgets/reader/top_controls.dart
+++ b/lib/screens/manga/widgets/reader/top_controls.dart
@@ -130,7 +130,7 @@ class ReaderTopControls extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                   Text(
-                    'Ch ${controller.currentChapter.value!.number}/${controller.chapterList.last.number}',
+                    'Chapter ${controller.currentChapter.value?.number?.round() ?? '-'} of ${controller.chapterList.last.number?.round() ?? '-'}',
                     style: TextStyle(
                       color: Colors.white.withOpacity(0.7),
                       fontSize: 10,

--- a/lib/widgets/common/custom_tiles.dart
+++ b/lib/widgets/common/custom_tiles.dart
@@ -270,7 +270,7 @@ class CustomSliderTile extends StatelessWidget {
         return KeyEventResult.ignored;
       },
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
+        padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
         child: Column(
           children: [
             Row(


### PR DESCRIPTION
# Pull Request
**Title:**  
Manga reader: more settings and adjustments

**Description:**  
Continuing from the last PR I made.
Introduces new settings for layout, direction and toggle switches, as well as other minor UI adjustments

**Summary of Changes:**  
- Removed reading mode settings (Webtoon / LTR / RTL)
- Added new settings
  - Layout (Continuous and Paged)
  - Direction (Up, Down, Left, Right)
    - Continuous with Down is equivalent to Webtoon
    - Page with Left or Right correspond to RTL/LTR respectively
  - Spaced Paged (on/off) - Adds 20px gap between pages (applicable in Continuous mode only)
  - Overscroll (on/off) - Ability to now disable prev/next chapter scrolling 
  
- Other adjustments
  - Changed default empty space size when image is loading or failed
  - Cache evicting shall await before refreshing failed pages
  - Make chapter indicator texts on top bar a bit nicer (now says "Chapter 1 of 32" instead of "Ch 1.0 of 32.0")
  - Overscroll chapter now has texts plus a disabled state when cannot scroll

**Type of Changes:**  
- Feature

**Testing Notes:**  
N/A

**Linked Issue(s):**  
N/A

**Additional Context:**  
N/A

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [x] I have added or updated documentation as needed
- [x] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request