### PR TITLE
Added sauce_finder.dart in utils/ for reverse image search functionality

### DIFF
--- a/lib/utils/sauce_finder.dart
+++ b/lib/utils/sauce_finder.dart
@@ -39,6 +39,7 @@ class SauceFinder {
     if (_animeData != null) {
       final regex = RegExp(r'\] (.*?) - ');
 
+      final anilist_id = _animeData!['anilist'] ?? 0;
       final title = _animeData!['filename'] ?? 'Unknown';
       final name = regex.firstMatch(title)!.group(1) ?? 'Unknown';
       final episode = _animeData!['episode'] ?? 'N/A';

--- a/lib/utils/sauce_finder.dart
+++ b/lib/utils/sauce_finder.dart
@@ -39,7 +39,7 @@ class SauceFinder {
     if (_animeData != null) {
       final regex = RegExp(r'\] (.*?) - ');
 
-      final anilist_id = _animeData!['anilist'] ?? 0;
+      final anilistId = _animeData!['anilist'] ?? 0;
       final title = _animeData!['filename'] ?? 'Unknown';
       final name = regex.firstMatch(title)!.group(1) ?? 'Unknown';
       final episode = _animeData!['episode'] ?? 'N/A';

--- a/lib/utils/sauce_finder.dart
+++ b/lib/utils/sauce_finder.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:http/http.dart' as http;
+
+class SauceFinder {
+  File? _imageFile;
+  Map<String, dynamic>? _animeData;
+
+  Future<void> pickImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    if (pickedFile != null) {
+      _imageFile = File(pickedFile.path);
+      _animeData = null;
+      await searchAnime(_imageFile!);
+    }
+  }
+
+  Future<void> searchAnime(File imageFile) async {
+    final url = Uri.parse('https://api.trace.moe/search');
+    final request = http.MultipartRequest('POST', url);
+    request.files
+        .add(await http.MultipartFile.fromPath('image', imageFile.path));
+
+    final response = await request.send();
+
+    if (response.statusCode == 200) {
+      final respStr = await response.stream.bytesToString();
+      final jsonData = json.decode(respStr);
+
+      _animeData = jsonData['result'][0];
+    } else {
+      // Handle error
+      throw Exception('Failed to search: ${response.statusCode}');
+    }
+
+    if (_animeData != null) {
+      final regex = RegExp(r'\] (.*?) - ');
+
+      final title = _animeData!['filename'] ?? 'Unknown';
+      final name = regex.firstMatch(title)!.group(1) ?? 'Unknown';
+      final episode = _animeData!['episode'] ?? 'N/A';
+      final similarity = (_animeData!['similarity'] * 100).toStringAsFixed(2);
+    }
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_qjs/flutter_qjs_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -24,6 +25,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_qjs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterQjsPlugin");
   flutter_qjs_plugin_register_with_registrar(flutter_qjs_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
   dynamic_color
+  file_selector_linux
   flutter_qjs
   isar_flutter_libs
   media_kit_libs_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import desktop_webview_window
 import device_info_plus
 import dynamic_color
 import file_picker
+import file_selector_macos
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_qjs
@@ -32,6 +33,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterQjsPlugin.register(with: registry.registrar(forPlugin: "FlutterQjsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -470,6 +470,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.5"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   fixnum:
     dependency: transitive
     description:
@@ -830,6 +862,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   inno_bundle:
     dependency: "direct dev"
     description:
@@ -1965,5 +2061,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   hugeicons: ^0.0.7
   iconly: ^1.0.1
   iconsax: ^0.0.8
+  image_picker: ^1.1.2
   install_plugin: ^2.1.0
   intl: ^0.20.1
   isar: ^3.1.0+1

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_qjs/flutter_qjs_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
@@ -26,6 +27,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
   FlutterQjsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
   dynamic_color
+  file_selector_windows
   flutter_inappwebview_windows
   flutter_qjs
   isar_flutter_libs


### PR DESCRIPTION
# Pull Request

**Title:**  
Added sauce_finder.dart in utils/ for reverse image search functionality

**Description:**
1. Added a SauceFinder utility class in the utils directory.
2. Allows users to pick an image from their gallery.
3. Sends the image to the [trace.moe](https://trace.moe/) API to identify the anime source.
4. Parses and stores metadata such as:
    Anime title
    Episode number
    Similarity score
5.Implements error handling for failed API requests.

**Type of Changes:**  
- Feature

@RyanYuuki @itsmechinmoy @Shebyyy 

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request