### PR TITLE
Fixed indicator bug in Carousel

### DIFF
--- a/lib/widgets/common/big_carousel.dart
+++ b/lib/widgets/common/big_carousel.dart
@@ -186,7 +186,7 @@ class _BigCarouselState extends State<BigCarousel> {
           const SizedBox(height: 16),
           AnimatedSmoothIndicator(
             activeIndex: activeIndex,
-            count: widget.data.length,
+            count: newData.length,
             effect: WormEffect(
               dotHeight: 8,
               dotWidth: 8,


### PR DESCRIPTION
# Pull Request

**Title:**  
Fixed indicator bug in Carousel

**Description:**  
Shows more indicators than the actual slides present in Carousel

**Type of Changes:**  
- Bug Fix

**Before and After:**
<img height="400" alt="Screenshot_20250719-021548" src="https://github.com/user-attachments/assets/198baa2e-a12b-4ccd-a378-698dc786cddd" /> <img height="400" alt="Screenshot_20250719-021935" src="https://github.com/user-attachments/assets/154ec33b-296d-4087-ad10-52fd054c2871" />

@RyanYuuki @itsmechinmoy @Shebyyy @aayush2622 

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request