### PR TITLE
Feature: Anime adaptation details in manga details page

### DIFF
--- a/lib/models/mangaupdates/anime_adaptation.dart
+++ b/lib/models/mangaupdates/anime_adaptation.dart
@@ -1,0 +1,20 @@
+class AnimeAdaptation {
+  final String? animeStart;
+  final String? animeEnd;
+  final bool hasAdaptation;
+  final String? error;
+
+  AnimeAdaptation({
+    this.animeStart,
+    this.animeEnd,
+    required this.hasAdaptation,
+    this.error,
+  });
+
+  @override
+  String toString() {
+    if (error != null) return 'Error: $error';
+    if (!hasAdaptation) return 'No anime adaptation found';
+    return 'Anime: ${animeStart ?? 'Unknown'} - ${animeEnd ?? 'Ongoing'}';
+  }
+}

--- a/lib/screens/manga/widgets/manga_stats.dart
+++ b/lib/screens/manga/widgets/manga_stats.dart
@@ -1,11 +1,13 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:anymex/models/Media/media.dart';
+import 'package:anymex/models/mangaupdates/anime_adaptation.dart';
 import 'package:anymex/screens/home_page.dart';
 import 'package:anymex/screens/search/search_view.dart';
 import 'package:anymex/utils/fallback/fallback_anime.dart';
 import 'package:anymex/utils/fallback/fallback_manga.dart';
 import 'package:anymex/utils/function.dart';
+import 'package:anymex/utils/anime_adaptation_util.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:flutter/material.dart';
@@ -45,6 +47,61 @@ class MangaStats extends StatelessWidget {
                   label: "Total Chapters", value: data.totalChapters ?? '??'),
               StateItem(label: "Premiered", value: data.premiered),
             ],
+          ),
+        ),
+        const SizedBox(height: 30),
+        const AnymexText(
+          text: "Adaptation Details",
+          variant: TextVariant.bold,
+          size: 17,
+        ),
+        const SizedBox(height: 10),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: FutureBuilder<AnimeAdaptation>(
+            future: MangaAnimeUtil.getAnimeAdaptation(data.romajiTitle),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return CircularProgressIndicator();
+              }
+
+              if (snapshot.hasError) {
+                return Text('Error: ${snapshot.error}',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.primary));
+              }
+
+              final adaptation = snapshot.data!;
+
+              if (adaptation.error != null) {
+                return Text('Error: ${adaptation.error}',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.primary));
+              }
+
+              if (!adaptation.hasAdaptation) {
+                return Text('No anime adaptation found',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.primary));
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const StateItem(label: "Anime Start", value: ''),
+                  AdaptationInfoColumn(
+                    input: adaptation.animeStart ?? 'Unknown',
+                  ),
+                  SizedBox(
+                    height: 10,
+                  ),
+                  const StateItem(label: "Anime End", value: ''),
+                  AdaptationInfoColumn(
+                    input: adaptation.animeEnd ?? 'Unknown',
+                  ),
+                ],
+              );
+            },
           ),
         ),
         const SizedBox(height: 30),
@@ -151,6 +208,27 @@ class StateItem extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class AdaptationInfoColumn extends StatelessWidget {
+  final String input;
+
+  const AdaptationInfoColumn({super.key, required this.input});
+
+  @override
+  Widget build(BuildContext context) {
+    List<String> chapters = input.split(" / ");
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: chapters
+          .map((chapter) => Text(
+                chapter,
+                style: TextStyle(color: Theme.of(context).colorScheme.primary),
+              ))
+          .toList(),
     );
   }
 }

--- a/lib/utils/anime_adaptation_util.dart
+++ b/lib/utils/anime_adaptation_util.dart
@@ -1,0 +1,80 @@
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:anymex/models/mangaupdates/anime_adaptation.dart';
+
+class MangaAnimeUtil {
+  static const String _baseUrl = 'https://api.mangaupdates.com/v1';
+
+  /// Get anime adaptation details for a manga title
+  /// Returns AnimeAdaptation object with start/end dates
+  static Future<AnimeAdaptation> getAnimeAdaptation(String mangaTitle) async {
+    try {
+      // Search for manga
+      final searchResults = await _searchManga(mangaTitle);
+
+      if (searchResults.isEmpty) {
+        return AnimeAdaptation(
+          hasAdaptation: false,
+          error: 'No manga found with title: $mangaTitle',
+        );
+      }
+
+      // Get series details
+      final seriesId = searchResults[0]['record']['series_id'] as int;
+      final seriesDetails = await _getSeriesDetails(seriesId);
+
+      // Check for anime adaptation
+      if (seriesDetails['anime'] != null) {
+        final animeData = seriesDetails['anime'];
+        final start = animeData['start'] as String?;
+        final end = animeData['end'] as String?;
+
+        if (start != null || end != null) {
+          return AnimeAdaptation(
+            animeStart: start,
+            animeEnd: end,
+            hasAdaptation: true,
+          );
+        }
+      }
+
+      return AnimeAdaptation(hasAdaptation: false);
+    } catch (error) {
+      return AnimeAdaptation(
+        hasAdaptation: false,
+        error: error.toString(),
+      );
+    }
+  }
+
+  // Private helper methods
+  static Future<List<dynamic>> _searchManga(String title) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/series/search'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'search': title,
+        'type': 'Manga',
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body);
+      return data['results'] ?? [];
+    } else {
+      throw Exception('Search failed with status: ${response.statusCode}');
+    }
+  }
+
+  static Future<Map<String, dynamic>> _getSeriesDetails(int seriesId) async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/series/$seriesId'),
+    );
+
+    if (response.statusCode == 200) {
+      return json.decode(response.body);
+    } else {
+      throw Exception('Failed to get series details: ${response.statusCode}');
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

**Title:**  
Anime adaptation details in manga details page

**Description:**  
Displays how chapters of manga and seasons of anime are related

**Type of Changes:**  
- Feature

<img height="400" alt="Screenshot_20250729-182558_AnymeX" src="https://github.com/user-attachments/assets/ef069b0d-bbb8-4c84-b3f7-d441672e7350" />

@RyanYuuki @itsmechinmoy @Shebyyy 

P.S. I tried making this expandable but I can't implement in a pretty way or had alignment issues. So for now it is not implemented.😭


**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [x] I have tagged the appropriate reviewers for this pull request