### PR TITLE
Revert IOS Page Transition

### DIFF
--- a/lib/constants/themes.dart
+++ b/lib/constants/themes.dart
@@ -17,7 +17,8 @@ ThemeData lightMode = ThemeData(
   pageTransitionsTheme: PageTransitionsTheme(
     builders: {
       for (var platform in TargetPlatform.values)
-        platform: const SharedAxisTransition(),
+        if (platform != TargetPlatform.iOS) // Exclude iOS
+          platform: const SharedAxisTransition(),
     },
   ),
   textTheme: const TextTheme(
@@ -82,7 +83,8 @@ ThemeData darkMode = ThemeData(
   pageTransitionsTheme: PageTransitionsTheme(
     builders: {
       for (var platform in TargetPlatform.values)
-        platform: const SharedAxisTransition(),
+        if (platform != TargetPlatform.iOS) // Exclude iOS
+          platform: const SharedAxisTransition(),
     },
   ),
   inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
# Pull Request

**Description:**  
Revert Old ios page transition by excluding ios in pageTransitionsTheme in themes.dart

**Type of Changes:**  
- Enhancement

**Testing Notes:**  
Cant test as I don't have a apple device

**Linked Issue(s):**  
<img width="1446" height="89" alt="image" src="https://github.com/user-attachments/assets/3d7e78ac-6bca-4b44-844c-b2b82f3df439" />

**Submission Checklist:**
- [ ✅] I have read and followed the project's contributing guidelines
- [✅ ] My code follows the code style of this project
- [ ✅] I have tested the changes and ensured they do not break existing functionality
- [ ✅] I have added or updated documentation as needed
- [✅ ] I have linked related issues in the description above
- [ ✅] I have tagged the appropriate reviewers for this pull request
-->