### PR TITLE
Reverse Search Results so recents are at the top

### DIFF
--- a/lib/screens/search/widgets/inline_search_history.dart
+++ b/lib/screens/search/widgets/inline_search_history.dart
@@ -46,6 +46,8 @@ class InlineSearchHistory extends StatelessWidget {
     if (searchTerms.isEmpty) {
       return const SizedBox.shrink();
     }
+    
+    final displayedTerms = searchTerms.reversed.toList();
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 12.0),
@@ -139,10 +141,10 @@ class InlineSearchHistory extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
               child: ListView.separated(
                 physics: const BouncingScrollPhysics(),
-                itemCount: searchTerms.length,
+                itemCount: displayedTerms.length,
                 separatorBuilder: (context, index) => const SizedBox(height: 8),
                 itemBuilder: (context, index) {
-                  final term = searchTerms[index];
+                  final term = displayedTerms[index];
 
                   return Material(
                     color: Colors.transparent,


### PR DESCRIPTION
# Pull Request

**Title:**  
Provide a concise and descriptive title for your pull request

**Description:**  
Made the ui clearer with recent searches being at the top of the search history, instead of at the bottom.

**Summary of Changes:**  
Change sorting of history so recent items are at the top.

**Type of Changes:**  
- Bug Fix

**Testing Notes:**  
Android Emulator

**Linked Issue(s):**  
https://discord.com/channels/1303000390505336893/1438973836245860436/1438973836245860436

**Submission Checklist:**
- [ ✅] I have read and followed the project's contributing guidelines
- [ ✅] My code follows the code style of this project
- [ ✅] I have tested the changes and ensured they do not break existing functionality
- [ ✅] I have added or updated documentation as needed
- [ ✅] I have linked related issues in the description above
- [ ✅] I have tagged the appropriate reviewers for this pull request