### PR TITLE
Intelligent server selection

### DIFF
--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -619,7 +619,8 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
       scoredTracks.add({'track': track, 'score': score});
     }
 
-    scoredTracks.sort((a, b) => (b['score'] as int).compareTo(a['score'] as int));
+    scoredTracks
+        .sort((a, b) => (b['score'] as int).compareTo(a['score'] as int));
 
     if (scoredTracks.isNotEmpty && scoredTracks.first['score'] > 0) {
       return scoredTracks.first['track'] as model.Video;


### PR DESCRIPTION
**Title:**  
Smarter server selector??

**Description:**  
Previously, if you picked 1080p dub for for an episode (just an example), and you finished that episode the next episode would start playing from the first server on the server list, but now it correctly picks the the same server just for the next episode (so it would pick 1080p dub again)

**Summary of Changes:**  
Picks the correct server for the next episode because previously it would pick the first server on the server list. (atleast in my testing)

**Type of Changes:**  
- Enhancement/Fix

**Testing Notes:**  
Android emulator

**Submission Checklist:**
- [ ✅] I have read and followed the project's contributing guidelines
- [ ✅] My code follows the code style of this project
- [✅ ] I have tested the changes and ensured they do not break existing functionality
- [ ✅] I have added or updated documentation as needed
- [✅ ] I have linked related issues in the description above
- [✅ ] I have tagged the appropriate reviewers for this pull request