### PR TITLE
Volume Button Navigation for Manga Reader

### DIFF
--- a/lib/screens/manga/controller/reader_controller.dart
+++ b/lib/screens/manga/controller/reader_controller.dart
@@ -10,6 +10,7 @@ import 'package:anymex/controllers/source/source_controller.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/models/Offline/Hive/chapter.dart';
 import 'package:dartotsu_extension_bridge/dartotsu_extension_bridge.dart';
+import 'package:anymex/services/volume_key_handler.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -86,6 +87,9 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
       MangaPageViewDirection.down.obs;
 
   final RxBool showControls = true.obs;
+  final RxBool volumeKeysEnabled = false.obs;
+  final RxBool invertVolumeKeys = false.obs;
+
   final Rx<LoadingState> loadingState = LoadingState.loading.obs;
   final RxString errorMessage = ''.obs;
 
@@ -103,7 +107,10 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
   Timer? _overscrollResetTimer;
 
   bool _isNavigating = false;
+
   late Worker _rpcWorker;
+  final VolumeKeyHandler _volumeKeyHandler = VolumeKeyHandler();
+  StreamSubscription? _volumeSubscription;
 
   @override
   void onInit() {
@@ -118,6 +125,98 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
           totalChapters: chapterList.length.toString(),
           currentPage: e);
     });
+    
+  }
+
+  void _enableVolumeKeys() {
+     _volumeKeyHandler.enableInterception();
+     _volumeSubscription?.cancel();
+     _volumeSubscription = _volumeKeyHandler.volumeEvents.listen((event) {
+       _handleVolumeEvent(event);
+     });
+  }
+
+  void _handleVolumeEvent(String event) {
+   
+   
+    if (Get.isBottomSheetOpen == true || Get.isDialogOpen == true || Get.isOverlaysOpen == true) {
+      return;
+    }
+
+   
+    if (showControls.value) {
+      toggleControls();
+      return;
+    }
+
+   
+    if (event == 'up') {
+      if (invertVolumeKeys.value) {
+        _navigateForward();
+      } else {
+        _navigateBackward();
+      }
+    } else if (event == 'down') {
+      if (invertVolumeKeys.value) {
+        _navigateBackward();
+      } else {
+        _navigateForward();
+      }
+    }
+  }
+
+  void _disableVolumeKeys() {
+     _volumeKeyHandler.disableInterception();
+     _volumeSubscription?.cancel();
+     _volumeSubscription = null;
+  }
+
+  void _navigateForward() {
+    if (readingLayout.value == MangaPageViewMode.continuous) {
+       final double offset = (Get.height * 0.7) * scrollSpeedMultiplier.value;
+       scrollOffsetController?.animateScroll(
+          offset: offset,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut);
+    } else {
+       pageController?.nextPage(
+          duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+    }
+  }
+
+  void _navigateBackward() {
+     if (readingLayout.value == MangaPageViewMode.continuous) {
+       final double offset = (Get.height * 0.7) * scrollSpeedMultiplier.value;
+       scrollOffsetController?.animateScroll(
+          offset: -offset,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut);
+    } else {
+       pageController?.previousPage(
+          duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+    }
+  }
+
+  void toggleVolumeKeys() {
+    volumeKeysEnabled.value = !volumeKeysEnabled.value;
+    if (volumeKeysEnabled.value) {
+      _enableVolumeKeys();
+    } else {
+      _disableVolumeKeys();
+    }
+    savePreferences();
+  }
+
+  
+  void pauseVolumeKeys() {
+    _disableVolumeKeys();
+  }
+
+
+  void resumeVolumeKeys() {
+    if (volumeKeysEnabled.value) {
+      _enableVolumeKeys();
+    }
   }
 
   @override
@@ -133,6 +232,7 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
     );
 
     _rpcWorker.dispose();
+    _disableVolumeKeys();
 
     _overscrollResetTimer?.cancel();
     pageController?.dispose();
@@ -154,6 +254,9 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
         break;
       case AppLifecycleState.resumed:
         Logger.i('App resumed');
+        if (volumeKeysEnabled.value) {
+          _enableVolumeKeys();
+        }
         break;
       case AppLifecycleState.inactive:
         Logger.i('App inactive');
@@ -161,6 +264,7 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
       case AppLifecycleState.hidden:
         Logger.i('App hidden - saving progress');
         _performSave(reason: 'App hidden');
+        _disableVolumeKeys();
         break;
     }
   }
@@ -267,6 +371,15 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
         settingsController.preferences.get('preload_pages', defaultValue: 3);
     showPageIndicator.value = settingsController.preferences
         .get('show_page_indicator', defaultValue: false);
+    volumeKeysEnabled.value = settingsController.preferences
+        .get('volume_keys_enabled', defaultValue: false);
+    invertVolumeKeys.value = settingsController.preferences
+        .get('invert_volume_keys', defaultValue: false);
+    
+   
+    if (volumeKeysEnabled.value) {
+      _enableVolumeKeys();
+    }
   }
 
   void _savePreferences() {
@@ -284,6 +397,10 @@ class ReaderController extends GetxController with WidgetsBindingObserver {
     settingsController.preferences.put('preload_pages', preloadPages.value);
     settingsController.preferences
         .put('show_page_indicator', showPageIndicator.value);
+    settingsController.preferences
+        .put('volume_keys_enabled', volumeKeysEnabled.value);
+    settingsController.preferences
+        .put('invert_volume_keys', invertVolumeKeys.value);
   }
 
   void _setupPositionListener() {

--- a/lib/screens/manga/widgets/reader/reader_view.dart
+++ b/lib/screens/manga/widgets/reader/reader_view.dart
@@ -284,6 +284,7 @@ class _ReaderViewState extends State<ReaderView> with TickerProviderStateMixin {
     return ScrollablePositionedList.builder(
       itemCount: widget.controller.pageList.length,
       itemScrollController: widget.controller.itemScrollController,
+      scrollOffsetController: widget.controller.scrollOffsetController,
       itemPositionsListener: widget.controller.itemPositionsListener,
       scrollOffsetListener: widget.controller.scrollOffsetListener,
       initialScrollIndex: (widget.controller.currentPageIndex.value - 1)

--- a/lib/screens/manga/widgets/reader/settings_view.dart
+++ b/lib/screens/manga/widgets/reader/settings_view.dart
@@ -11,6 +11,11 @@ class ReaderSettings {
   ReaderSettings({required this.controller});
 
   void showSettings(BuildContext context) {
+    final wasVolumeEnabled = controller.volumeKeysEnabled.value;
+    if (wasVolumeEnabled) {
+      controller.pauseVolumeKeys();
+    }
+    
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
@@ -175,6 +180,29 @@ class ReaderSettings {
                       onChanged: (val) => controller.togglePageIndicator(),
                     );
                   }),
+                  if (Platform.isAndroid)
+                    Obx(() {
+                      return CustomSwitchTile(
+                        icon: Iconsax.volume_high,
+                        title: "Volume Keys Navigation",
+                        description: "Use volume keys to change pages",
+                        switchValue: controller.volumeKeysEnabled.value,
+                        onChanged: (val) => controller.toggleVolumeKeys(),
+                      );
+                    }),
+                  if (Platform.isAndroid)
+                    Obx(() {
+                      return CustomSwitchTile(
+                        icon: Iconsax.arrow_swap_horizontal,
+                        title: "Invert Volume Keys",
+                        description: "Swap Up/Down actions",
+                        switchValue: controller.invertVolumeKeys.value,
+                        onChanged: (val) {
+                          controller.invertVolumeKeys.value = val;
+                          controller.savePreferences();
+                        },
+                      );
+                    }),
                   Obx(() {
                     return Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 10.0),
@@ -226,7 +254,7 @@ class ReaderSettings {
                           },
                           onChangedEnd: (e) => controller.savePreferences(),
                           description:
-                              'Adjust Key Scrolling Speed (Up, Down, Left, Right)',
+                              'Adjust Key & Volume Scrolling Speed',
                           icon: Icons.speed,
                           min: 1.0,
                           max: 5.0,
@@ -241,6 +269,11 @@ class ReaderSettings {
           ),
         );
       },
-    );
+    ).then((_) {
+     
+      if (wasVolumeEnabled) {
+        controller.resumeVolumeKeys();
+      }
+    });
   }
 }

--- a/lib/services/volume_key_handler.dart
+++ b/lib/services/volume_key_handler.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class VolumeKeyHandler {
+  static const MethodChannel _channel = MethodChannel('com.ryan.anymex/volume');
+  static const EventChannel _eventChannel =
+      EventChannel('com.ryan.anymex/volume_events');
+
+  Stream<String>? _stream;
+
+  Future<void> enableInterception() async {
+    try {
+      if (defaultTargetPlatform != TargetPlatform.android) return;
+      await _channel.invokeMethod('enable');
+    } catch (e) {
+      debugPrint('Failed to enable volume key interception: $e');
+    }
+  }
+
+  Future<void> disableInterception() async {
+    try {
+      if (defaultTargetPlatform != TargetPlatform.android) return;
+      await _channel.invokeMethod('disable');
+    } catch (e) {
+      debugPrint('Failed to disable volume key interception: $e');
+    }
+  }
+
+  Stream<String> get volumeEvents {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return const Stream.empty();
+    }
+    _stream ??=
+        _eventChannel.receiveBroadcastStream().map((event) => event.toString());
+    return _stream!;
+  }
+}


### PR DESCRIPTION
### Pull Request
**Title** :  
Volume button Navigation

**Description**:
Added volume button navigation for the manga reader (requested in #47).
Ahh.. This setting lets you scroll/change pages using your phone's volume keys, similar to how it works in Dantotsu and other Manga reader apps...
### Changes :
- Added a handler to catch volume button presses on Android.
- Added settings to enable/disable it.
- Added an "Invert Keys" option to swap up/down (maybe users will need it so i added yeah).
- Made the scrolling relative to the screen height (70% ig) so it feels consistent on different devices.
###  Type of Changes: 
- Feature

<img src="https://github.com/user-attachments/assets/0141a5d5-ffa1-4666-aa39-acde1e78492d" width="400">



https://github.com/user-attachments/assets/0482dc4c-ce25-4876-952f-0f19ed2b5f5b







