### PR TITLE
feat: watch time calculator to anime progress container

### DIFF
--- a/lib/screens/anime/details_page.dart
+++ b/lib/screens/anime/details_page.dart
@@ -751,7 +751,7 @@ class _AnimeDetailsPageState extends State<AnimeDetailsPage> {
             ],
           ),
 
-          if (totalEps > 0 && epDuration != null && epDuration > 0) ...[
+          if (displayTotal > 0 && epDuration != null && epDuration > 0) ...[
             const SizedBox(height: 10),
             Row(
               children: [


### PR DESCRIPTION
Adds a watch time calculator to the anime details page.
The progress section now calculates watch time using the anime's episode count and episode duration, and displays three stats:
- Total time – estimated total time to watch the entire series
- Watched time – time based on completed episodes
- Remaining time – estimated time left to finish the series

The calculator handles edge cases:
- Hides time stats entirely if episode duration is unknown
- Falls back to aired episode count (via nextAiringEpisode) when total episodes is not yet known (e.g. ongoing anime)

![Screenshot_20260313_122702](https://github.com/user-attachments/assets/3aca97e9-f105-483d-874c-6ad79b305bc8)
![Screenshot_20260313_143954](https://github.com/user-attachments/assets/c6453d82-f6ef-47f7-bd9d-8e7c743f747d)

