### PR TITLE
feat: add instant center tap zone and player menu anim toggl

### DIFF
--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -388,6 +388,13 @@ class Settings extends GetxController {
     PlayerSettingsKeys.enableScreenshot.set(value);
   }
 
+  bool get playerMenuAnimation =>
+      _getPlayerSetting((s) => s.playerMenuAnimation);
+  set playerMenuAnimation(bool value) {
+    playerSettings.update((s) => s?.playerMenuAnimation = value);
+    PlayerSettingsKeys.playerMenuAnimation.set(value);
+  }
+
   bool get enableSwipeControls =>
       _getPlayerSetting((s) => s.enableSwipeControls);
   set enableSwipeControls(bool value) {

--- a/lib/database/data_keys/keys.dart
+++ b/lib/database/data_keys/keys.dart
@@ -212,6 +212,7 @@ enum PlayerSettingsKeys {
   subtitleOpacity,
   subtitleBottomMargin,
   subtitleOutlineType,
+  playerMenuAnimation,
 }
 
 enum UISettingsKeys {

--- a/lib/models/player/player_adaptor.dart
+++ b/lib/models/player/player_adaptor.dart
@@ -30,6 +30,7 @@ class PlayerSettings {
   double subtitleBottomMargin;
   String subtitleOutlineType;
   bool enableScreenshot;
+  bool playerMenuAnimation;
 
   PlayerSettings({
     this.speed = 1.0,
@@ -61,6 +62,7 @@ class PlayerSettings {
     this.subtitleOutlineType = "Outline",
     this.autoSkipFiller = false,
     this.enableScreenshot = true,
+    this.playerMenuAnimation = true,
   });
 
   factory PlayerSettings.fromDB() {
@@ -128,6 +130,8 @@ class PlayerSettings {
           PlayerSettingsKeys.autoSkipFiller.get<bool>(defaults.autoSkipFiller),
       enableScreenshot: PlayerSettingsKeys.enableScreenshot
           .get<bool>(defaults.enableScreenshot),
+      playerMenuAnimation: PlayerSettingsKeys.playerMenuAnimation
+          .get<bool>(defaults.playerMenuAnimation),
     );
   }
 }

--- a/lib/screens/anime/watch/controls/bottom_controls.dart
+++ b/lib/screens/anime/watch/controls/bottom_controls.dart
@@ -67,11 +67,15 @@ class BottomControls extends StatelessWidget {
         child: AnimatedSlide(
           offset:
               controller.showControls.value ? Offset.zero : const Offset(0, 1),
-          duration: const Duration(milliseconds: 400),
+          duration: controller.playerSettings.playerMenuAnimation
+              ? const Duration(milliseconds: 400)
+              : Duration.zero,
           curve: Curves.easeOutCubic,
           child: AnimatedOpacity(
             opacity: controller.showControls.value ? 1.0 : 0.0,
-            duration: const Duration(milliseconds: 300),
+            duration: controller.playerSettings.playerMenuAnimation
+                ? const Duration(milliseconds: 300)
+                : Duration.zero,
             curve: Curves.easeOut,
             child: Container(
               width: double.infinity,

--- a/lib/screens/anime/watch/controls/center_controls.dart
+++ b/lib/screens/anime/watch/controls/center_controls.dart
@@ -25,11 +25,15 @@ class CenterControls extends StatelessWidget {
           alignment: Alignment.center,
           child: AnimatedScale(
             scale: controller.showControls.value ? 1.0 : 0.8,
-            duration: const Duration(milliseconds: 400),
+            duration: controller.playerSettings.playerMenuAnimation
+                ? const Duration(milliseconds: 400)
+                : Duration.zero,
             curve: Curves.easeOutBack,
             child: AnimatedOpacity(
               opacity: controller.showControls.value ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 300),
+              duration: controller.playerSettings.playerMenuAnimation
+                  ? const Duration(milliseconds: 300)
+                  : Duration.zero,
               curve: Curves.easeOut,
               child: isDesktop
                   ? _buildDesktopLayout(theme)

--- a/lib/screens/anime/watch/controls/top_controls.dart
+++ b/lib/screens/anime/watch/controls/top_controls.dart
@@ -40,11 +40,15 @@ class TopControls extends StatelessWidget {
         child: AnimatedSlide(
           offset:
               controller.showControls.value ? Offset.zero : const Offset(0, -1),
-          duration: const Duration(milliseconds: 400),
+          duration: controller.playerSettings.playerMenuAnimation
+              ? const Duration(milliseconds: 400)
+              : Duration.zero,
           curve: Curves.easeOutCubic,
           child: AnimatedOpacity(
             opacity: controller.showControls.value ? 1.0 : 0.0,
-            duration: const Duration(milliseconds: 300),
+            duration: controller.playerSettings.playerMenuAnimation
+                ? const Duration(milliseconds: 300)
+                : Duration.zero,
             curve: Curves.easeOut,
             child: Container(
               width: double.infinity,

--- a/lib/screens/anime/watch/controls/widgets/double_tap_seek.dart
+++ b/lib/screens/anime/watch/controls/widgets/double_tap_seek.dart
@@ -31,7 +31,6 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
   Timer? _seekDebounceTimer;
   Timer? _setRateDebounceTimer;
 
-  bool _isInSeekMode = false;
   static const Duration _seekModeTimeout = Duration(milliseconds: 1500);
   static const Duration _indicatorTimeout = Duration(milliseconds: 1000);
   static const Duration _seekDebounceTimeout = Duration(milliseconds: 500);
@@ -111,7 +110,6 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
     if (widget.controller.isLocked.value) return;
 
     setState(() {
-      _isInSeekMode = true;
       if (isLeft) {
         _leftTapCount += 1;
         _rightTapCount = 0;
@@ -155,7 +153,6 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
     _seekModeTimer = Timer(_seekModeTimeout, () {
       if (mounted) {
         setState(() {
-          _isInSeekMode = false;
           _leftTapCount = 0;
           _rightTapCount = 0;
         });
@@ -486,36 +483,12 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
         ));
   }
 
-  void _handleDoubleTap(TapDownDetails details) {
-    if (widget.controller.isLocked.value) return;
-    final screenWidth = MediaQuery.of(context).size.width;
-    final tapPosition = details.globalPosition;
-    final isLeft = tapPosition.dx < screenWidth / 2;
-
-    if (isLeft) {
-      _handleLeftSeek();
-    } else {
-      _handleRightSeek();
-    }
-  }
-
-  void _handleSingleTap(TapDownDetails details) {
+  void _handleSingleTap() {
     if (widget.controller.isLocked.value) {
       widget.controller.toggleControls();
       return;
     }
-    if (_isInSeekMode) {
-      final screenWidth = MediaQuery.of(context).size.width;
-      final tapX = details.localPosition.dx;
-
-      if (tapX < screenWidth * 0.3) {
-        _handleLeftSeek();
-      } else if (tapX > screenWidth * 0.7) {
-        _handleRightSeek();
-      }
-    } else {
-      widget.controller.toggleControls();
-    }
+    widget.controller.toggleControls();
   }
 
   void _handleKeyboard(KeyEvent event) {
@@ -570,8 +543,6 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
                   widget.controller.onVerticalDragUpdate(context, details);
                 }
               },
-              onTapDown: _handleSingleTap,
-              onDoubleTapDown: _handleDoubleTap,
               onLongPressStart: (details) {
                 _initialSwipeY = details.globalPosition.dy;
                 _startHold();
@@ -587,29 +558,63 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
                 color: Colors.transparent,
                 child: Stack(
                   children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          flex: 35,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onTap: _handleSingleTap,
+                            onDoubleTapDown: (details) => _handleLeftSeek(),
+                            child: Container(color: Colors.transparent),
+                          ),
+                        ),
+                        Expanded(
+                          flex: 30,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onTap: _handleSingleTap,
+                            child: Container(color: Colors.transparent),
+                          ),
+                        ),
+                        Expanded(
+                          flex: 35,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onTap: _handleSingleTap,
+                            onDoubleTapDown: (details) => _handleRightSeek(),
+                            child: Container(color: Colors.transparent),
+                          ),
+                        ),
+                      ],
+                    ),
                     Positioned(
                       left: 0,
                       top: 0,
                       bottom: 0,
-                      child: _buildSeekIndicator(
-                        isLeft: true,
-                        tapCount: _leftTapCount,
+                      child: IgnorePointer(
+                        child: _buildSeekIndicator(
+                          isLeft: true,
+                          tapCount: _leftTapCount,
+                        ),
                       ),
                     ),
                     Positioned(
                       right: 0,
                       top: 0,
                       bottom: 0,
-                      child: _buildSeekIndicator(
-                        isLeft: false,
-                        tapCount: _rightTapCount,
+                      child: IgnorePointer(
+                        child: _buildSeekIndicator(
+                          isLeft: false,
+                          tapCount: _rightTapCount,
+                        ),
                       ),
                     ),
                     Positioned(
                       left: 0,
                       right: 0,
                       top: MediaQuery.of(context).size.height * 0.05,
-                      child: _buildSpeedIndicator(),
+                      child: IgnorePointer(child: _buildSpeedIndicator()),
                     ),
                   ],
                 ),

--- a/lib/screens/settings/sub_settings/settings_player.dart
+++ b/lib/screens/settings/sub_settings/settings_player.dart
@@ -456,7 +456,8 @@ class _SettingsPlayerState extends State<SettingsPlayer> {
     final currentType = normalizeSubtitleOutlineType(
         settings.playerSettings.value.subtitleOutlineType);
     if (currentType != settings.playerSettings.value.subtitleOutlineType) {
-      settings.playerSettings.update((s) => s?.subtitleOutlineType = currentType);
+      settings.playerSettings
+          .update((s) => s?.subtitleOutlineType = currentType);
       PlayerSettingsKeys.subtitleOutlineType.set(currentType);
     }
 
@@ -940,6 +941,15 @@ class _SettingsPlayerState extends State<SettingsPlayer> {
                                   switchValue: settings.enableScreenshot,
                                   onChanged: (val) =>
                                       settings.enableScreenshot = val),
+                              CustomSwitchTile(
+                                  padding: const EdgeInsets.all(10),
+                                  icon: Icons.animation_rounded,
+                                  title: "Player Menu Animation",
+                                  description:
+                                      "Disable to show player menu instantly without animation",
+                                  switchValue: settings.playerMenuAnimation,
+                                  onChanged: (val) =>
+                                      settings.playerMenuAnimation = val),
                               CustomSliderTile(
                                 sliderValue: settings.seekDuration.toDouble(),
                                 max: 50,
@@ -1188,8 +1198,8 @@ class _SettingsPlayerState extends State<SettingsPlayer> {
                                         outlineWidth: settings
                                             .subtitleOutlineWidth
                                             .toDouble(),
-                                        outlineColor: colorOptions[
-                                                settings.subtitleOutlineColor] ??
+                                        outlineColor: colorOptions[settings
+                                                .subtitleOutlineColor] ??
                                             colorOptions['Black']!,
                                       ),
                                     ),


### PR DESCRIPTION

Introduces a new "Player Menu Animation" toggle to let users disable control menu animations for instant feedback. Additionally, redesigned the gesture detection in the video player to use three distinct zones. The center zone (30%) now bypasses double-tap detection entirely, allowing single taps to instantly show/hide the player menu without the default Flutter gesture delay.

<img width="1127" height="713" alt="image" src="https://github.com/user-attachments/assets/9675df40-03b8-4615-b765-54c12793a773" />

<!--
# Pull Request
**Description:**  
Submit changes or improvements to AnymeX

**Title:**  
Provide a concise and descriptive title for your pull request

**Description:**  
Clearly describe the purpose and scope of your pull request

**Summary of Changes:**  
Outline the key changes introduced in this pull request

**Type of Changes:**  
- Bug Fix
- Feature
- Enhancement
- Documentation

**Testing Notes:**  
Provide details on how this change has been tested

**Linked Issue(s):**  
Mention any related issues using their GitHub issue numbers

**Additional Context:**  
Include any other relevant information or context for your pull request

**Submission Checklist:**
- [ ] I have read and followed the project's contributing guidelines
- [ ] My code follows the code style of this project
- [ ] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [ ] I have tagged the appropriate reviewers for this pull request
-->