### PR TITLE
Fix: some profile fixes + tweaks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,7 @@ SIMKL_CLIENT_SECRET=0
 MAL_CLIENT_ID=0
 MAL_CLIENT_SECRET=0
 CALLBACK_SCHEME=anymex://callback
+COMMENTS_BASE_URL=https://whzwmfxngelicmjyxwmr.supabase.co/functions/v1
 ```
 
 You can however create your own API keys and populate the values as necessary.

--- a/lib/screens/anime/studio_details_page.dart
+++ b/lib/screens/anime/studio_details_page.dart
@@ -4,6 +4,8 @@ import 'package:anymex/screens/anime/details_page.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
+import 'package:anymex/widgets/media_items/media_peek_popup.dart';
+import 'package:anymex_extension_runtime_bridge/Models/Source.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
@@ -396,6 +398,22 @@ class _StudioDetailsSheetContentState extends State<StudioDetailsSheetContent> {
     return SizedBox(
       width: 120,
       child: GestureDetector(
+        onSecondaryTap: () {
+          MediaPeekPopup.showIfUntracked(
+            context,
+            media,
+            ItemType.anime,
+            media.id.toString(),
+          );
+        },
+        onLongPress: () {
+          MediaPeekPopup.showIfUntracked(
+            context,
+            media,
+            ItemType.anime,
+            media.id.toString(),
+          );
+        },
         onTap: () {
           navigate(
             () => AnimeDetailsPage(

--- a/lib/screens/anime/widgets/character_staff_sheet.dart
+++ b/lib/screens/anime/widgets/character_staff_sheet.dart
@@ -9,6 +9,7 @@ import 'package:anymex/widgets/custom_widgets/anymex_image.dart';
 import 'package:anymex/widgets/custom_widgets/fullscreen_image_viewer.dart';
 
 import 'package:anymex/screens/anime/details_page.dart';
+import 'package:anymex/widgets/media_items/media_peek_popup.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -21,6 +22,7 @@ import 'package:anymex/models/Media/voice_actor.dart';
 
 import 'package:anymex/utils/logger.dart';
 import 'package:iconsax/iconsax.dart';
+import 'package:anymex_extension_runtime_bridge/Models/Source.dart';
 
 import 'package:url_launcher/url_launcher.dart';
 
@@ -1103,6 +1105,24 @@ class _CharacterStaffSheetContentState
           return SizedBox(
             width: 120,
             child: GestureDetector(
+              onSecondaryTap: () {
+                final isManga = item.type.toUpperCase() == 'MANGA';
+                MediaPeekPopup.showIfUntracked(
+                  context,
+                  item,
+                  isManga ? ItemType.manga : ItemType.anime,
+                  tag,
+                );
+              },
+              onLongPress: () {
+                final isManga = item.type.toUpperCase() == 'MANGA';
+                MediaPeekPopup.showIfUntracked(
+                  context,
+                  item,
+                  isManga ? ItemType.manga : ItemType.anime,
+                  tag,
+                );
+              },
               onTap: () {
                 Navigator.of(context, rootNavigator: true).push(
                   MaterialPageRoute(

--- a/lib/screens/profile/activity_details_page.dart
+++ b/lib/screens/profile/activity_details_page.dart
@@ -10,11 +10,14 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:anymex/utils/al_about_me.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/widgets/non_widgets/activity_composer_sheet.dart';
+import 'package:anymex/screens/profile/widgets/profile_common.dart';
 
 void showActivityDetailsSheet(BuildContext context, AnilistActivity activity) {
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
+    isDismissible: false,
+    enableDrag: false,
     backgroundColor: Colors.transparent,
     builder: (context) {
       return ActivityDetailsSheet(activity: activity);
@@ -175,33 +178,64 @@ class _ActivityDetailsSheetState extends State<ActivityDetailsSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding:
-          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-      child: DraggableScrollableSheet(
-        initialChildSize: 0.9,
-        maxChildSize: 0.95,
-        minChildSize: 0.5,
-        builder: (context, scrollController) {
-          return Container(
-            decoration: BoxDecoration(
-              color: context.theme.colorScheme.surface,
-              borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(20)),
-            ),
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 12.0),
-                  child: Container(
-                    width: 40,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: Colors.grey.withOpacity(0.3),
-                      borderRadius: BorderRadius.circular(2),
+    return WillPopScope(
+      onWillPop: () => confirmDiscardComposer(
+        context,
+        composerKey: _composerKey,
+        discardTitle: 'Discard reply?',
+        discardMessage:
+            'You have unsent text. Closing now will lose your reply.',
+      ),
+      child: Padding(
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: DraggableScrollableSheet(
+          initialChildSize: 0.9,
+          maxChildSize: 0.95,
+          minChildSize: 0.5,
+          builder: (context, scrollController) {
+            return Container(
+              decoration: BoxDecoration(
+                color: context.theme.colorScheme.surface,
+                borderRadius:
+                    const BorderRadius.vertical(top: Radius.circular(20)),
+              ),
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 8, 8, 0),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Center(
+                            child: Container(
+                              width: 40,
+                              height: 4,
+                              decoration: BoxDecoration(
+                                color: Colors.grey.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(2),
+                              ),
+                            ),
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.close),
+                          onPressed: () async {
+                            final discard = await confirmDiscardComposer(
+                              context,
+                              composerKey: _composerKey,
+                              discardTitle: 'Discard reply?',
+                              discardMessage:
+                                  'You have unsent text. Closing now will lose your reply.',
+                            );
+                            if (discard && context.mounted) {
+                              Navigator.pop(context);
+                            }
+                          },
+                        ),
+                      ],
                     ),
                   ),
-                ),
                 Expanded(
                   child: RefreshIndicator(
                     onRefresh: _fetchReplies,
@@ -270,11 +304,12 @@ class _ActivityDetailsSheetState extends State<ActivityDetailsSheet> {
                     onSubmit: (text, {isPrivate = false}) => _postReply(text),
                   ),
                 ),
-              ], 
-            ), 
-          ); 
-        },
-      ), 
+              ],
+              ),
+            );
+          },
+        ),
+      ),
     ); 
   }
 

--- a/lib/screens/profile/profile_page.dart
+++ b/lib/screens/profile/profile_page.dart
@@ -365,14 +365,12 @@ class _ProfilePageState extends State<ProfilePage>
     return Glow(
       child: Scaffold(
         backgroundColor: context.theme.colorScheme.surface,
-        extendBody: false,
+        extendBody: true,
         bottomNavigationBar: isDesktop
             ? null
             : ResponsiveNavBar(
                 isDesktop: false,
                 currentIndex: _selectedTab,
-                margin: EdgeInsets.zero,
-                borderRadius: BorderRadius.zero,
                 items: _profileNavItems,
               ),
         body: _ready
@@ -383,93 +381,117 @@ class _ProfilePageState extends State<ProfilePage>
   }
 
   void _showCreateActivitySheet(BuildContext context) {
+    final composerKey = GlobalKey<ActivityComposerSheetState>();
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
       backgroundColor: context.theme.colorScheme.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
       builder: (context) {
-        return Padding(
-          padding: EdgeInsets.only(
-            bottom: MediaQuery.of(context).viewInsets.bottom,
-            left: 16,
-            right: 16,
-            top: 20,
+        return WillPopScope(
+          onWillPop: () => confirmDiscardComposer(
+            context,
+            composerKey: composerKey,
+            discardTitle: 'Discard status?',
+            discardMessage:
+                'You have unsent text. Closing now will lose your status.',
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    "Create Status",
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: context.theme.colorScheme.onSurface,
+          child: Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+              left: 16,
+              right: 16,
+              top: 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      "Create Status",
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: context.theme.colorScheme.onSurface,
+                      ),
                     ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Container(
-                padding: const EdgeInsets.only(
-                  left: 12,
-                  right: 12,
-                  top: 8,
-                  bottom: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: context.theme.colorScheme.surfaceContainer,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: ActivityComposerSheet(
-                  isModal: true,
-                  hintText: "What's on your mind?",
-                  onSubmit: (text, {isPrivate = false}) async {
-                    final anilistAuth = Get.find<AnilistAuth>();
-                    try {
-                      await anilistAuth.createActivity(text);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('Status posted successfully!'),
-                            backgroundColor: Colors.green,
-                          ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () async {
+                        final discard = await confirmDiscardComposer(
+                          context,
+                          composerKey: composerKey,
+                          discardTitle: 'Discard status?',
+                          discardMessage:
+                              'You have unsent text. Closing now will lose your status.',
                         );
-                        _fetchActivities(); // refresh listt
-                      }
-                      return true;
-                    } catch (e) {
-                      if (context.mounted) {
-                        String errorMessage = 'Failed to post status.';
-                        final errStr = e.toString();
-                        if (errStr.contains('validation')) {
-                          errorMessage =
-                              'Failed: ${errStr.split('"text":[').last.split(']').first.replaceAll('"', '')}';
+                        if (discard && context.mounted) {
+                          Navigator.pop(context);
                         }
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(errorMessage),
-                            backgroundColor: context.theme.colorScheme.error,
-                          ),
-                        );
-                      }
-                      return false;
-                    }
-                  },
+                      },
+                    ),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 20),
-            ],
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.only(
+                    left: 12,
+                    right: 12,
+                    top: 8,
+                    bottom: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.theme.colorScheme.surfaceContainer,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: ActivityComposerSheet(
+                    key: composerKey,
+                    isModal: true,
+                    hintText: "What's on your mind?",
+                    onSubmit: (text, {isPrivate = false}) async {
+                      final anilistAuth = Get.find<AnilistAuth>();
+                      try {
+                        await anilistAuth.createActivity(text);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Status posted successfully!'),
+                              backgroundColor: Colors.green,
+                            ),
+                          );
+                          _fetchActivities(); // refresh listt
+                        }
+                        return true;
+                      } catch (e) {
+                        if (context.mounted) {
+                          String errorMessage = 'Failed to post status.';
+                          final errStr = e.toString();
+                          if (errStr.contains('validation')) {
+                            errorMessage =
+                                'Failed: ${errStr.split('"text":[').last.split(']').first.replaceAll('"', '')}';
+                          }
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(errorMessage),
+                              backgroundColor: context.theme.colorScheme.error,
+                            ),
+                          );
+                        }
+                        return false;
+                      }
+                    },
+                  ),
+                ),
+                const SizedBox(height: 20),
+              ],
+            ),
           ),
         );
       },
@@ -615,6 +637,7 @@ class _ProfilePageState extends State<ProfilePage>
                 padding: const EdgeInsets.symmetric(vertical: 2.0),
                 child: ActivityCard(
                   activity: activity,
+                  onDeleted: () => _handleActivityDeleted(activity),
                   onTap: () {
                     if (activity.type == 'ANIME_LIST') {
                       final media = Media(
@@ -709,6 +732,20 @@ class _ProfilePageState extends State<ProfilePage>
       context,
       activityFilters: _activityFilters,
       onApply: () => _fetchActivities(),
+    );
+  }
+
+  void _handleActivityDeleted(AnilistActivity activity) {
+    if (!mounted) return;
+    setState(() {
+      _activities.removeWhere((a) => a.id == activity.id);
+    });
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Activity deleted'),
+        duration: Duration(milliseconds: 1200),
+      ),
     );
   }
 
@@ -958,7 +995,7 @@ class _ProfilePageState extends State<ProfilePage>
         buildActivitySection(),
         buildAboutSection(),
         buildFavouritesSection(),
-        const SizedBox(height: 50),
+        SizedBox(height: isDesktop ? 50 : 120),
       ],
     );
   }

--- a/lib/screens/profile/user_profile_page.dart
+++ b/lib/screens/profile/user_profile_page.dart
@@ -396,14 +396,12 @@ class _UserProfilePageState extends State<UserProfilePage>
     return Glow(
       child: Scaffold(
         backgroundColor: context.theme.colorScheme.surface,
-        extendBody: false,
+        extendBody: true,
         bottomNavigationBar: isDesktop
             ? null
             : ResponsiveNavBar(
                 isDesktop: false,
                 currentIndex: _selectedTab,
-                margin: EdgeInsets.zero,
-                borderRadius: BorderRadius.zero,
                 items: _profileNavItems,
               ),
         body: _buildBody(context, isDesktop),
@@ -552,6 +550,7 @@ class _UserProfilePageState extends State<UserProfilePage>
                   child: ActivityCard(
                     isOwnProfile: isOwner,
                     activity: activity,
+                    onDeleted: () => _handleActivityDeleted(activity),
                     onTap: () {
                       if (activity.type == 'ANIME_LIST') {
                         final media = Media(
@@ -648,6 +647,20 @@ class _UserProfilePageState extends State<UserProfilePage>
       context,
       activityFilters: _activityFilters,
       onApply: () => _fetchActivities(),
+    );
+  }
+
+  void _handleActivityDeleted(AnilistActivity activity) {
+    if (!mounted) return;
+    setState(() {
+      _activities.removeWhere((a) => a.id == activity.id);
+    });
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Activity deleted'),
+        duration: Duration(milliseconds: 1200),
+      ),
     );
   }
 
@@ -857,7 +870,7 @@ class _UserProfilePageState extends State<UserProfilePage>
         buildActivitySection(),
         buildAboutSection(),
         buildFavouritesSection(),
-        const SizedBox(height: 50),
+        SizedBox(height: isDesktop ? 50 : 120),
       ],
     );
   }
@@ -918,94 +931,119 @@ class _UserProfilePageState extends State<UserProfilePage>
   }
 
   void _showCreateMessageSheet(BuildContext context) {
+    final composerKey = GlobalKey<ActivityComposerSheetState>();
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
       backgroundColor: context.theme.colorScheme.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
       builder: (context) {
-        return Padding(
-          padding: EdgeInsets.only(
-            bottom: MediaQuery.of(context).viewInsets.bottom,
-            left: 16,
-            right: 16,
-            top: 20,
+        return WillPopScope(
+          onWillPop: () => confirmDiscardComposer(
+            context,
+            composerKey: composerKey,
+            discardTitle: 'Discard message?',
+            discardMessage:
+                'You have unsent text. Closing now will lose your message.',
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    "Message ${_userProfile?.name ?? 'User'}",
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: context.theme.colorScheme.onSurface,
+          child: Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+              left: 16,
+              right: 16,
+              top: 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      "Message ${_userProfile?.name ?? 'User'}",
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: context.theme.colorScheme.onSurface,
+                      ),
                     ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Container(
-                padding: const EdgeInsets.only(
-                  left: 12,
-                  right: 12,
-                  top: 8,
-                  bottom: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: context.theme.colorScheme.surfaceContainer,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: ActivityComposerSheet(
-                  isModal: true,
-                  hintText: "Write a message...",
-                  showPrivateToggle: true,
-                  onSubmit: (text, {isPrivate = false}) async {
-                    final anilistAuth = Get.find<AnilistAuth>();
-                    try {
-                      await anilistAuth.createMessageActivity(
-                          widget.userId, text, isPrivate);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(isPrivate 
-                                ? 'Private message sent successfully!' 
-                                : 'Message posted successfully!'),
-                            backgroundColor: Colors.green,
-                          ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () async {
+                        final discard = await confirmDiscardComposer(
+                          context,
+                          composerKey: composerKey,
+                          discardTitle: 'Discard message?',
+                          discardMessage:
+                              'You have unsent text. Closing now will lose your message.',
                         );
-                      }
-                      _refreshActivityTab(showMessage: false);
-                      return true;
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text('Failed to post message: $e'),
-                            backgroundColor: Colors.red,
-                          ),
-                        );
-                      }
-                      return false;
-                    }
-                  },
+                        if (discard && context.mounted) {
+                          Navigator.pop(context);
+                        }
+                      },
+                    ),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 16),
-            ],
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.only(
+                    left: 12,
+                    right: 12,
+                    top: 8,
+                    bottom: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.theme.colorScheme.surfaceContainer,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: ActivityComposerSheet(
+                    key: composerKey,
+                    isModal: true,
+                    hintText: "Write a message...",
+                    showPrivateToggle: true,
+                    onSubmit: (text, {isPrivate = false}) async {
+                      final anilistAuth = Get.find<AnilistAuth>();
+                      try {
+                        await anilistAuth.createMessageActivity(
+                            widget.userId, text, isPrivate);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(isPrivate
+                                  ? 'Private message sent successfully!'
+                                  : 'Message posted successfully!'),
+                              backgroundColor: Colors.green,
+                            ),
+                          );
+                        }
+                        _refreshActivityTab(showMessage: false);
+                        return true;
+                      } catch (e) {
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('Failed to post message: $e'),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                        }
+                        return false;
+                      }
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+            ),
           ),
         );
       },
     );
   }
+
 }

--- a/lib/screens/profile/widgets/favorites_section.dart
+++ b/lib/screens/profile/widgets/favorites_section.dart
@@ -7,12 +7,18 @@ import 'package:anymex/screens/anime/widgets/character_staff_sheet.dart';
 import 'package:anymex/screens/manga/details_page.dart';
 import 'package:anymex/screens/profile/widgets/stats_overview_cards.dart';
 import 'package:anymex/utils/function.dart';
+import 'package:anymex/widgets/media_items/media_peek_popup.dart';
+import 'package:anymex_extension_runtime_bridge/Models/Source.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:iconly/iconly.dart';
 
 class FavoritesSection extends StatelessWidget {
+  static const double _firstSectionTopGap = 20;
+  static const double _sectionGap = 14;
+  static const double _headerToContentGap = 10;
+
   final Profile user;
   final bool needsPadding;
 
@@ -28,7 +34,7 @@ class FavoritesSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (user.favourites?.anime.isNotEmpty ?? false) ...[
-          const SizedBox(height: 20),
+          const SizedBox(height: _firstSectionTopGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -38,11 +44,11 @@ class FavoritesSection extends StatelessWidget {
               icon: IconlyBold.video,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: _headerToContentGap),
           _buildMediaFavCarousel(context, user.favourites!.anime, true),
         ],
         if (user.favourites?.manga.isNotEmpty ?? false) ...[
-          const SizedBox(height: 10),
+          const SizedBox(height: _sectionGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -52,11 +58,11 @@ class FavoritesSection extends StatelessWidget {
               icon: IconlyBold.document,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: _headerToContentGap),
           _buildMediaFavCarousel(context, user.favourites!.manga, false),
         ],
         if (user.favourites?.characters.isNotEmpty ?? false) ...[
-          const SizedBox(height: 10),
+          const SizedBox(height: _sectionGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -66,7 +72,7 @@ class FavoritesSection extends StatelessWidget {
               icon: IconlyBold.profile,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: _headerToContentGap),
           _buildPersonCarousel(
               context,
               <PersonItem>[
@@ -76,7 +82,7 @@ class FavoritesSection extends StatelessWidget {
               true),
         ],
         if (user.favourites?.staff.isNotEmpty ?? false) ...[
-          const SizedBox(height: 10),
+          const SizedBox(height: _sectionGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -86,7 +92,7 @@ class FavoritesSection extends StatelessWidget {
               icon: Icons.people_rounded,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: _headerToContentGap),
           _buildPersonCarousel(
               context,
               <PersonItem>[
@@ -96,7 +102,7 @@ class FavoritesSection extends StatelessWidget {
               false),
         ],
         if (user.favourites?.studios.isNotEmpty ?? false) ...[
-          const SizedBox(height: 10),
+          const SizedBox(height: _sectionGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -106,7 +112,7 @@ class FavoritesSection extends StatelessWidget {
               icon: Icons.business_rounded,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: _headerToContentGap),
           Padding(
             padding: needsPadding
                 ? const EdgeInsets.symmetric(horizontal: 20.0)
@@ -183,20 +189,40 @@ class FavoritesSection extends StatelessWidget {
     FavouriteMedia item,
     bool isAnime,
   ) {
-    return GestureDetector(
-      onTap: () {
-        if (item.id != null) {
-          final media = Media(
-            id: item.id!,
+    final mediaId = item.id;
+    final mediaTag = item.title ?? 'fav-${item.id}';
+    final media = mediaId == null
+        ? null
+        : Media(
+            id: mediaId,
             title: item.title ?? '?',
             poster: item.cover ?? '',
             serviceType: ServicesType.anilist,
           );
-          final tag = item.title ?? 'fav-${item.id}';
+
+    return GestureDetector(
+      onSecondaryTap: () {
+        MediaPeekPopup.showIfUntracked(
+          context,
+          media,
+          isAnime ? ItemType.anime : ItemType.manga,
+          mediaTag,
+        );
+      },
+      onLongPress: () {
+        MediaPeekPopup.showIfUntracked(
+          context,
+          media,
+          isAnime ? ItemType.anime : ItemType.manga,
+          mediaTag,
+        );
+      },
+      onTap: () {
+        if (media != null) {
           if (isAnime) {
-            navigate(() => AnimeDetailsPage(media: media, tag: tag));
+            navigate(() => AnimeDetailsPage(media: media, tag: mediaTag));
           } else {
-            navigate(() => MangaDetailsPage(media: media, tag: tag));
+            navigate(() => MangaDetailsPage(media: media, tag: mediaTag));
           }
         }
       },
@@ -207,7 +233,7 @@ class FavoritesSection extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Hero(
-              tag: item.title ?? 'fav-${item.id}',
+              tag: mediaTag,
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(12),
                 child: item.cover != null
@@ -230,15 +256,18 @@ class FavoritesSection extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 5),
-            Text(
-              item.title ?? '',
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w500,
-                color: context.theme.colorScheme.onSurface,
+            SizedBox(
+              height: 30,
+              child: Text(
+                item.title ?? '',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  color: context.theme.colorScheme.onSurface,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
             ),
           ],
         ),
@@ -252,7 +281,7 @@ class FavoritesSection extends StatelessWidget {
     bool isCharacter,
   ) {
     return SizedBox(
-      height: 128,
+      height: 108,
       child: ListView.builder(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         scrollDirection: Axis.horizontal,
@@ -326,16 +355,19 @@ class FavoritesSection extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 6),
-            Text(
-              name ?? '',
-              style: TextStyle(
-                fontSize: 10.5,
-                fontWeight: FontWeight.w500,
-                color: context.theme.colorScheme.onSurface,
+            SizedBox(
+              height: 26,
+              child: Text(
+                name ?? '',
+                style: TextStyle(
+                  fontSize: 10.5,
+                  fontWeight: FontWeight.w500,
+                  color: context.theme.colorScheme.onSurface,
+                ),
+                maxLines: 2,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.ellipsis,
               ),
-              maxLines: 2,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
             ),
           ],
         ),

--- a/lib/screens/profile/widgets/list_status_card.dart
+++ b/lib/screens/profile/widgets/list_status_card.dart
@@ -80,35 +80,42 @@ class ListStatusCard extends StatelessWidget {
                 : (typeStr == 'COMPLETED' && isAnime)
                     ? 'COMPLETED TV'
                     : typeStr;
+            final canOpen = count > 0;
 
             return InkWell(
-              onTap: () async {
-                showDialog(
-                  context: context,
-                  barrierDismissible: false,
-                  builder: (_) =>
-                      const Center(child: CircularProgressIndicator()),
-                );
+              onTap: canOpen
+                  ? () async {
+                      showDialog(
+                        context: context,
+                        barrierDismissible: false,
+                        builder: (_) =>
+                            const Center(child: CircularProgressIndicator()),
+                      );
 
-                final auth = Get.find<AnilistAuth>();
-                final type = isAnime ? 'ANIME' : 'MANGA';
-                final lists = await auth.fetchUserMediaList(userId, type);
+                      final auth = Get.find<AnilistAuth>();
+                      final type = isAnime ? 'ANIME' : 'MANGA';
+                      final lists = await auth.fetchUserMediaList(userId, type);
 
-                if (context.mounted) Navigator.pop(context);
+                      if (context.mounted) Navigator.pop(context);
 
-                final data = lists['All'] ?? [];
-                if (isAnime) {
-                  Get.to(() => AnimeList(
-                        data: data,
-                        title: "Anime",
-                        initialTab: mappedTabForNav,
-                      ));
-                } else {
-                  Get.to(() => AnilistMangaList(
-                        initialTab: mappedTabForNav,
-                      ));
-                }
-              },
+                      final data = lists['All'] ?? [];
+                      if (isAnime) {
+                        Get.to(() => AnimeList(
+                              data: data,
+                              title: "Anime",
+                              initialTab: mappedTabForNav,
+                              userName: userName,
+                            ));
+                      } else {
+                        Get.to(() => AnilistMangaList(
+                              data: data,
+                              title: "Manga",
+                              initialTab: mappedTabForNav,
+                              userName: userName,
+                            ));
+                      }
+                    }
+                  : null,
               child: Padding(
                 padding: EdgeInsets.symmetric(vertical: isDesktop ? 4.0 : 1.5),
                 child: Column(

--- a/lib/screens/profile/widgets/profile_common.dart
+++ b/lib/screens/profile/widgets/profile_common.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
+import 'package:anymex/widgets/non_widgets/activity_composer_sheet.dart';
 import 'package:get/get.dart';
 
 String getFollowLabel({bool? isFollowing, bool? isFollower}) {
@@ -7,6 +8,38 @@ String getFollowLabel({bool? isFollowing, bool? isFollower}) {
   if (isFollowing == true) return 'Following';
   if (isFollower == true) return 'Follows you';
   return 'Follow';
+}
+
+Future<bool> confirmDiscardComposer(
+  BuildContext context, {
+  required GlobalKey<ActivityComposerSheetState> composerKey,
+  required String discardTitle,
+  required String discardMessage,
+}) async {
+  final hasUnsavedText =
+      (composerKey.currentState?.text.trim().isNotEmpty ?? false);
+  if (!hasUnsavedText) return true;
+
+  final discard = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: Text(discardTitle),
+          content: Text(discardMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('Keep editing'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('Discard'),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+
+  return discard;
 }
 
 Widget buildProfileSheetOption(

--- a/lib/screens/profile/widgets/profile_stats_tab.dart
+++ b/lib/screens/profile/widgets/profile_stats_tab.dart
@@ -36,6 +36,7 @@ class _ProfileStatsTabState extends State<ProfileStatsTab> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = context.colors;
+    final bottomSpace = MediaQuery.of(context).size.width > 900 ? 32.0 : 120.0;
     final anime = widget.user.stats?.animeStats;
     final manga = widget.user.stats?.mangaStats;
 
@@ -150,7 +151,7 @@ class _ProfileStatsTabState extends State<ProfileStatsTab> {
               ),
             ),
 
-          const SizedBox(height: 32),
+          SizedBox(height: bottomSpace),
         ],
       ),
     );
@@ -842,7 +843,8 @@ class _ProfileStatsTabState extends State<ProfileStatsTab> {
       final userId = int.tryParse(widget.user.id ?? '0') ?? 0;
       final lists = await auth.fetchUserMediaList(userId, type);
 
-      if (context.mounted) Navigator.pop(context);
+      if (!mounted) return;
+      Navigator.pop(context);
 
       final data = lists['All'] ?? [];
       

--- a/lib/services/commentum_service.dart
+++ b/lib/services/commentum_service.dart
@@ -7,12 +7,20 @@ import 'package:anymex/database/comments/model/comment.dart';
 import 'package:anymex/models/Anilist/anilist_profile.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/utils/logger.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 
 class CommentumService extends GetxController {
-  static const String baseUrl =
-      'https://whzwmfxngelicmjyxwmr.supabase.co/functions/v1';
+  String get _baseUrl {
+    final envBase = (dotenv.env['COMMENTS_BASE_URL'] ?? '').trim();
+    if (envBase.isEmpty) {
+      throw StateError('COMMENTS_BASE_URL is missing in .env');
+    }
+    return envBase.endsWith('/')
+        ? envBase.substring(0, envBase.length - 1)
+        : envBase;
+  }
 
   final RxString currentUserRole = 'user'.obs;
 
@@ -33,7 +41,7 @@ class CommentumService extends GetxController {
     try {
       final response = await http.get(
         Uri.parse(
-            '$baseUrl/media?media_id=$mediaId&client_type=$_clientType&page=$page&limit=$limit&sort=$sort'),
+            '$_baseUrl/media?media_id=$mediaId&client_type=$_clientType&page=$page&limit=$limit&sort=$sort'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -110,7 +118,7 @@ class CommentumService extends GetxController {
       Logger.i('Creating comment with body: ${json.encode(requestBody)}');
 
       final response = await http.post(
-        Uri.parse('$baseUrl/comments'),
+        Uri.parse('$_baseUrl/comments'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -154,7 +162,7 @@ class CommentumService extends GetxController {
 
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/comments'),
+        Uri.parse('$_baseUrl/comments'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -223,7 +231,7 @@ class CommentumService extends GetxController {
       }
 
       final response = await http.post(
-        Uri.parse('$baseUrl/comments'),
+        Uri.parse('$_baseUrl/comments'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -255,7 +263,7 @@ class CommentumService extends GetxController {
 
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/votes'),
+        Uri.parse('$_baseUrl/votes'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -301,7 +309,7 @@ class CommentumService extends GetxController {
 
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/reports'),
+        Uri.parse('$_baseUrl/reports'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -344,7 +352,7 @@ class CommentumService extends GetxController {
 
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/reports'),
+        Uri.parse('$_baseUrl/reports'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -389,7 +397,7 @@ class CommentumService extends GetxController {
 
     try {
       final response = await http.post(
-        Uri.parse('$baseUrl/moderation'),
+        Uri.parse('$_baseUrl/moderation'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -451,7 +459,7 @@ class CommentumService extends GetxController {
       if (shadowBan) body['shadow_ban'] = shadowBan;
 
       final response = await http.post(
-        Uri.parse('$baseUrl/moderation'),
+        Uri.parse('$_baseUrl/moderation'),
         headers: {
           'Content-Type': 'application/json',
         },
@@ -518,7 +526,7 @@ class CommentumService extends GetxController {
       if (token == null) return 'user';
 
       final response = await http.post(
-        Uri.parse('$baseUrl/users/role'),
+        Uri.parse('$_baseUrl/users/role'),
         headers: {
           'Content-Type': 'application/json',
         },

--- a/lib/widgets/media_items/media_item.dart
+++ b/lib/widgets/media_items/media_item.dart
@@ -105,10 +105,21 @@ class GridAnimeCard extends StatelessWidget {
     final itemType = isManga ? ItemType.manga : ItemType.anime;
 
     return GestureDetector(
+      onSecondaryTap: () {
+        MediaPeekPopup.showIfUntracked(
+          context,
+          media.data,
+          itemType,
+          media.title,
+        );
+      },
       onLongPress: () {
-        if (media.data.userStatus == null || media.data.userStatus!.isEmpty) {
-          MediaPeekPopup.show(context, media.data, itemType, media.title);
-        }
+        MediaPeekPopup.showIfUntracked(
+          context,
+          media.data,
+          itemType,
+          media.title,
+        );
       },
       child: SizedBox(
         width: cardWidth,

--- a/lib/widgets/media_items/media_peek_popup.dart
+++ b/lib/widgets/media_items/media_peek_popup.dart
@@ -48,6 +48,17 @@ class MediaPeekPopup extends StatefulWidget {
     );
   }
 
+  static void showIfUntracked(
+    BuildContext context,
+    Media? media,
+    ItemType type,
+    String tag,
+  ) {
+    if (media == null) return;
+    if ((media.userStatus ?? '').isNotEmpty) return;
+    show(context, media, type, tag);
+  }
+
   @override
   State<MediaPeekPopup> createState() => _MediaPeekPopupState();
 }

--- a/lib/widgets/non_widgets/activity_card.dart
+++ b/lib/widgets/non_widgets/activity_card.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:anymex/models/Anilist/anilist_activity.dart';
@@ -19,6 +21,7 @@ class ActivityCard extends StatefulWidget {
   final AnilistActivity activity;
   final VoidCallback? onTap;
   final VoidCallback? onReplyTap;
+  final VoidCallback? onDeleted;
   final bool isOwnProfile;
 
   const ActivityCard({
@@ -26,6 +29,7 @@ class ActivityCard extends StatefulWidget {
     required this.activity,
     this.onTap,
     this.onReplyTap,
+    this.onDeleted,
     this.isOwnProfile = false,
   });
 
@@ -165,7 +169,7 @@ class _ActivityCardState extends State<ActivityCard> {
                     final auth = Get.find<AnilistAuth>();
                     final success = await auth.deleteActivity(activity.id);
                     if (success) {
-                      // Caller handle refresh
+                      widget.onDeleted?.call();
                     }
                   },
                 ),
@@ -447,12 +451,22 @@ class _ActivityCardState extends State<ActivityCard> {
     return RepaintBoundary(
         child: InkWell(
       onTap: widget.onTap,
-      borderRadius: BorderRadius.circular(12),
+      borderRadius: BorderRadius.circular(20),
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
         decoration: BoxDecoration(
           color: context.theme.colorScheme.surfaceContainer,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: context.theme.colorScheme.outlineVariant.withOpacity(0.22),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: context.theme.colorScheme.shadow.withOpacity(0.06),
+              blurRadius: 16,
+              offset: const Offset(0, 6),
+            ),
+          ],
         ),
         clipBehavior: Clip.antiAlias,
         child: Stack(
@@ -460,18 +474,71 @@ class _ActivityCardState extends State<ActivityCard> {
             if (activity.mediaBannerUrl != null ||
                 activity.mediaCoverUrl != null)
               Positioned.fill(
-                child: CachedNetworkImage(
-                  imageUrl:
-                      (activity.mediaBannerUrl ?? activity.mediaCoverUrl)!,
-                  fit: BoxFit.cover,
+                child: ImageFiltered(
+                  imageFilter: ui.ImageFilter.blur(sigmaX: 3.2, sigmaY: 3.2),
+                  child: CachedNetworkImage(
+                    imageUrl:
+                        (activity.mediaBannerUrl ?? activity.mediaCoverUrl)!,
+                    fit: BoxFit.cover,
+                    filterQuality: FilterQuality.low,
+                  ),
                 ),
               ),
             if (activity.mediaBannerUrl != null ||
                 activity.mediaCoverUrl != null)
               Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: context.theme.colorScheme.surface.withOpacity(0.78),
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          context.theme.colorScheme.surface.withOpacity(0.42),
+                          context.theme.colorScheme.surface.withOpacity(0.10),
+                        ],
+                        stops: const [0.0, 0.52],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            if (activity.mediaBannerUrl != null ||
+                activity.mediaCoverUrl != null)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
+                        colors: [
+                          Colors.transparent,
+                          context.theme.colorScheme.surface.withOpacity(0.20),
+                          context.theme.colorScheme.surface.withOpacity(0.48),
+                        ],
+                        stops: const [0.26, 0.64, 1.0],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            if (activity.mediaBannerUrl != null ||
+                activity.mediaCoverUrl != null)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: RadialGradient(
+                        center: const Alignment(0.42, -0.05),
+                        radius: 0.95,
+                        colors: [
+                          context.theme.colorScheme.surface.withOpacity(0.22),
+                          Colors.transparent,
+                        ],
+                        stops: const [0.0, 1.0],
+                      ),
+                    ),
                   ),
                 ),
               ),
@@ -586,7 +653,7 @@ class _ActivityCardState extends State<ActivityCard> {
                         children: [
                           if (activity.mediaCoverUrl != null)
                             ClipRRect(
-                              borderRadius: BorderRadius.circular(8),
+                              borderRadius: BorderRadius.circular(12),
                               child: CachedNetworkImage(
                                 imageUrl: activity.mediaCoverUrl!,
                                 width: 105,
@@ -687,61 +754,34 @@ class _ActivityCardState extends State<ActivityCard> {
                                 ],
                                 if (isListActivity) const Spacer(),
                                 const SizedBox(height: 12),
-                                Row(
-                                  children: [
-                                    InkWell(
-                                      onTap: _toggleLike,
-                                      onLongPress: () =>
-                                          _showLikedBySheet(context),
-                                      borderRadius: BorderRadius.circular(16),
-                                      child: Row(
-                                        children: [
-                                          Icon(
-                                            activity.isLiked
-                                                ? Icons.favorite
-                                                : Icons.favorite_border,
-                                            size: 18,
-                                            color: activity.isLiked
-                                                ? Colors.red
-                                                : Colors.grey,
-                                          ),
-                                          const SizedBox(width: 6),
-                                          Text(
-                                            '${activity.likeCount}',
-                                            style: TextStyle(
-                                              fontSize: 13,
-                                              fontWeight: FontWeight.bold,
-                                              color: activity.isLiked
-                                                  ? Colors.red
-                                                  : Colors.grey,
-                                            ),
-                                          ),
-                                        ],
+                                Builder(builder: (context) {
+                                  final colorScheme = context.theme.colorScheme;
+                                  final likeColor = activity.isLiked
+                                      ? Colors.redAccent
+                                      : colorScheme.onSurfaceVariant;
+
+                                  return Row(
+                                    children: [
+                                      _ActivityActionChip(
+                                        icon: activity.isLiked
+                                            ? Icons.favorite
+                                            : Icons.favorite_outline,
+                                        count: '${activity.likeCount}',
+                                        foreground: likeColor,
+                                        onTap: _toggleLike,
+                                        onLongPress: () =>
+                                            _showLikedBySheet(context),
                                       ),
-                                    ),
-                                    const SizedBox(width: 16),
-                                    InkWell(
-                                      onTap: widget.onReplyTap,
-                                      borderRadius: BorderRadius.circular(16),
-                                      child: Row(
-                                        children: [
-                                          const Icon(Icons.chat_bubble_outline,
-                                              size: 18, color: Colors.grey),
-                                          if (activity.replyCount > 0) ...[
-                                            const SizedBox(width: 6),
-                                            Text(
-                                              '${activity.replyCount}',
-                                              style: const TextStyle(
-                                                  fontSize: 13,
-                                                  fontWeight: FontWeight.bold,
-                                                  color: Colors.grey),
-                                            ),
-                                          ],
-                                        ],
+                                      const SizedBox(width: 8),
+                                      _ActivityActionChip(
+                                        icon: Icons.chat_bubble_outline,
+                                        count: '${activity.replyCount}',
+                                        foreground: colorScheme.onSurfaceVariant,
+                                        onTap: widget.onReplyTap,
                                       ),
-                                    ),
-                                  ],
-                                ),
+                                    ],
+                                  );
+                                }),
                               ],
                             ),
                           ),
@@ -873,6 +913,67 @@ class _ActivityAnilistCard extends StatefulWidget {
   State<_ActivityAnilistCard> createState() => _ActivityAnilistCardState();
 }
 
+class _ActivityActionChip extends StatelessWidget {
+  const _ActivityActionChip({
+    required this.icon,
+    required this.count,
+    required this.foreground,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  final IconData icon;
+  final String count;
+  final Color foreground;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.theme.colorScheme;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: BackdropFilter(
+        filter: ui.ImageFilter.blur(sigmaX: 2.0, sigmaY: 2.0),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            onLongPress: onLongPress,
+            borderRadius: BorderRadius.circular(14),
+            child: Ink(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withOpacity(0.34),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(
+                  color: colorScheme.outlineVariant.withOpacity(0.32),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 18, color: foreground),
+                  const SizedBox(width: 6),
+                  Text(
+                    count,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: foreground,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _ActivityAnilistCardState extends State<_ActivityAnilistCard> {
   Future<dynamic>? _dataFuture;
 
@@ -899,8 +1000,11 @@ class _ActivityAnilistCardState extends State<_ActivityAnilistCard> {
             width: 260,
             decoration: BoxDecoration(
               color: context.theme.colorScheme.surfaceContainerHighest
-                  .withOpacity(0.35),
-              borderRadius: BorderRadius.circular(10),
+                  .withOpacity(0.42),
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: context.theme.colorScheme.outlineVariant.withOpacity(0.22),
+              ),
             ),
           );
         }
@@ -917,7 +1021,7 @@ class _ActivityAnilistCardState extends State<_ActivityAnilistCard> {
         final String format = media.format?.toString() ?? '';
 
         return InkWell(
-          borderRadius: BorderRadius.circular(10),
+          borderRadius: BorderRadius.circular(14),
           onTap: () {
             if (widget.isManga) {
               navigate(() => MangaDetailsPage(media: media, tag: title));
@@ -927,20 +1031,27 @@ class _ActivityAnilistCardState extends State<_ActivityAnilistCard> {
           },
           child: Container(
             width: 260,
-            padding: const EdgeInsets.all(8),
+            padding: const EdgeInsets.all(10),
             decoration: BoxDecoration(
               color: context.theme.colorScheme.surfaceContainerHighest
-                  .withOpacity(0.35),
-              borderRadius: BorderRadius.circular(10),
+                  .withOpacity(0.52),
+              borderRadius: BorderRadius.circular(14),
               border: Border.all(
                 color:
-                    context.theme.colorScheme.outlineVariant.withOpacity(0.2),
+                    context.theme.colorScheme.outlineVariant.withOpacity(0.28),
               ),
+              boxShadow: [
+                BoxShadow(
+                  color: context.theme.colorScheme.shadow.withOpacity(0.05),
+                  blurRadius: 14,
+                  offset: const Offset(0, 5),
+                ),
+              ],
             ),
             child: Row(
               children: [
                 ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
+                  borderRadius: BorderRadius.circular(10),
                   child: CachedNetworkImage(
                     imageUrl: poster,
                     width: 54,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
     flutter_svg: ^2.0.10
     # flutter_local_notifications: ^18.0.1
     flutter_markdown: ^0.7.6
+    markdown: ^7.3.0
     flutter_native_splash: ^2.4.4
     flutter_web_auth_2: ^4.0.2
     get: ^4.6.6


### PR DESCRIPTION
## Changes

- **Environment Config:** Moved the hardcoded Comments Base URL to `.env` (no fallback to hardcoded)
- **Profile Layout Fixes:**  fixed the  nav bar...so  no longer overlaps the bottom content and some spacing fix
- **DIscard confirmation:** Added a "Discard confirmation" dialog across all composer sheets (status, messages, replies) to prevent accidental exiting
- **Instant Activity Deletes:**  fixed, the feed refreshes instantly without needing a full page reload when deleted a statsus
- **Peek :** Added `onSecondaryTap` and `onLongPress` logic for "peek" popups across Studio, Staff, Favorites, in profiles
- **Visual Polish:** updated cards with rounded corners, banner blurs, and cleaner glass-ass buttons.....

