### PR TITLE
feat: full backup/restore for settings, auth & offline progress

### DIFF
--- a/lib/controllers/services/backup_restore/backup_restore_service.dart
+++ b/lib/controllers/services/backup_restore/backup_restore_service.dart
@@ -3,7 +3,9 @@ import 'dart:io';
 
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
+import 'package:anymex/database/data_keys/keys.dart';
 import 'package:anymex/database/isar_models/custom_list.dart';
+import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/isar_models/offline_media.dart';
 import 'package:anymex/screens/library/controller/library_controller.dart';
 import 'package:anymex/utils/logger.dart';
@@ -19,6 +21,14 @@ import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../main.dart';
+
+const Set<String> _kExcludedKeys = {
+  General.isFirstTime.name,
+  General.libraryGridAutoMigrated.name,
+};
+
+final Set<String> _kAuthKeyNames =
+    AuthKeys.values.map((e) => e.name).toSet();
 
 class BackupRestoreService extends GetxController {
   final OfflineStorageController _storageController = Get.find();
@@ -36,7 +46,10 @@ class BackupRestoreService extends GetxController {
     return digest.toString().substring(0, 32);
   }
 
-  Future<Map<String, dynamic>> _buildBackupData() async {
+  Future<Map<String, dynamic>> _buildBackupData({
+    bool includeSettings = true,
+    bool includeAuth = false,
+  }) async {
     final animeCustomLists =
         await _storageController.getCustomListsByType(ItemType.anime);
     final mangaCustomLists =
@@ -63,7 +76,7 @@ class BackupRestoreService extends GetxController {
       (sum, list) => sum + (list.mediaIds?.length ?? 0),
     );
 
-    return {
+    final data = <String, dynamic>{
       'date': DateFormat('dd MM yyyy hh:mm a').format(DateTime.now()),
       'appVersion': '',
       'username': serviceHandler.onlineService.profileData.value.name ??
@@ -79,10 +92,34 @@ class BackupRestoreService extends GetxController {
       'mangaCustomLists': mangaCustomLists.map((e) => e.toJson()).toList(),
       'novelCustomLists': novelCustomLists.map((e) => e.toJson()).toList(),
     };
+
+    if (includeSettings) {
+      final settings = _exportSettings(includeAuth: false);
+      data['settings'] = settings;
+      data['settingsCount'] = settings.length;
+
+      if (includeAuth) {
+        final authOnly = _exportSettings(includeAuth: true)
+          ..removeWhere((k, _) => !_kAuthKeyNames.contains(k));
+        data['auth'] = authOnly;
+        data['hasAuth'] = authOnly.isNotEmpty;
+      } else {
+        data['hasAuth'] = false;
+      }
+    } else {
+      data['settingsCount'] = 0;
+      data['hasAuth'] = false;
+    }
+
+    return data;
   }
 
-  Future<void> _applyBackupData(Map<String, dynamic> data,
-      {bool merge = false}) async {
+  Future<void> _applyBackupData(
+    Map<String, dynamic> data, {
+    bool merge = false,
+    bool restoreSettings = true,
+    bool restoreAuth = false,
+  }) async {
     if (!merge) {
       await _storageController.clearCache();
     }
@@ -161,7 +198,54 @@ class BackupRestoreService extends GetxController {
       });
     }
 
+    if (restoreSettings && data.containsKey('settings')) {
+      _importSettings(
+        (data['settings'] as Map).cast<String, dynamic>(),
+        restoreAuth: false,
+      );
+    }
+
+    if (restoreAuth && data.containsKey('auth')) {
+      _importSettings(
+        (data['auth'] as Map).cast<String, dynamic>(),
+        restoreAuth: true,
+      );
+    }
+
     Get.delete<LibraryController>();
+  }
+
+  Map<String, dynamic> _exportSettings({bool includeAuth = false}) {
+    final all =
+        isar.collection<KeyValue>().filter().keyIsNotEmpty().findAllSync();
+    final result = <String, dynamic>{};
+    for (final kv in all) {
+      final k = kv.key;
+      if (_kExcludedKeys.contains(k)) continue;
+      if (!includeAuth && _kAuthKeyNames.contains(k)) continue;
+      if (kv.value == null) continue;
+      try {
+        result[k] = (jsonDecode(kv.value!) as Map<String, dynamic>)['val'];
+      } catch (_) {}
+    }
+    return result;
+  }
+
+  void _importSettings(
+    Map<String, dynamic> settings, {
+    bool restoreAuth = false,
+  }) {
+    isar.writeTxnSync(() {
+      final col = isar.collection<KeyValue>();
+      for (final entry in settings.entries) {
+        final k = entry.key;
+        if (_kExcludedKeys.contains(k)) continue;
+        if (!restoreAuth && _kAuthKeyNames.contains(k)) continue;
+        col.putSync(KeyValue()
+          ..key = k
+          ..value = jsonEncode({'val': entry.value}));
+      }
+    });
   }
 
   String _encryptData(Map<String, dynamic> data, String password) {
@@ -217,6 +301,8 @@ class BackupRestoreService extends GetxController {
   Future<String?> exportBackupToExternal({
     String? password,
     bool requestPath = true,
+    bool includeSettings = true,
+    bool includeAuth = false,
   }) async {
     try {
       if (Platform.isAndroid && requestPath) {
@@ -227,7 +313,10 @@ class BackupRestoreService extends GetxController {
         }
       }
 
-      final data = await _buildBackupData();
+      final data = await _buildBackupData(
+        includeSettings: includeSettings,
+        includeAuth: includeAuth,
+      );
       final packageInfo = await PackageInfo.fromPlatform();
       data['appVersion'] = packageInfo.version;
 
@@ -308,8 +397,13 @@ class BackupRestoreService extends GetxController {
     }
   }
 
-  Future<void> restoreBackup(String filePath,
-      {String? password, bool merge = false}) async {
+  Future<void> restoreBackup(
+    String filePath, {
+    String? password,
+    bool merge = false,
+    bool restoreSettings = true,
+    bool restoreAuth = false,
+  }) async {
     try {
       final file = File(filePath);
 
@@ -323,7 +417,12 @@ class BackupRestoreService extends GetxController {
           ? _decryptData(content, password)
           : jsonDecode(content) as Map<String, dynamic>;
 
-      await _applyBackupData(data, merge: merge);
+      await _applyBackupData(
+        data,
+        merge: merge,
+        restoreSettings: restoreSettings,
+        restoreAuth: restoreAuth,
+      );
 
       Logger.i('Backup restored successfully from: $filePath');
     } catch (e) {
@@ -434,6 +533,8 @@ class BackupRestoreService extends GetxController {
             (data['mangaCustomLists'] as List?)?.length ?? 0,
         'novelCustomListsCount':
             (data['novelCustomLists'] as List?)?.length ?? 0,
+        'settingsCount': data['settingsCount'] ?? 0,
+        'hasAuth': data['hasAuth'] ?? false,
       };
     } catch (e) {
       Logger.i('Failed to get backup info: $e');

--- a/lib/screens/settings/sub_settings/settings_backup.dart
+++ b/lib/screens/settings/sub_settings/settings_backup.dart
@@ -27,6 +27,8 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     final passwordController = TextEditingController();
     final confirmPasswordController = TextEditingController();
     bool usePassword = false;
+    bool includeSettings = true;
+    bool includeAuth = false;
 
     final result = await showDialog<bool>(
       context: context,
@@ -34,6 +36,8 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         passwordController: passwordController,
         confirmPasswordController: confirmPasswordController,
         onUsePasswordChanged: (value) => usePassword = value,
+        onIncludeSettingsChanged: (value) => includeSettings = value,
+        onIncludeAuthChanged: (value) => includeAuth = value,
       ),
     );
 
@@ -49,7 +53,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         password = passwordController.text;
       }
 
-      final path = await controller.exportBackupToExternal(password: password);
+      final path = await controller.exportBackupToExternal(
+        password: password,
+        includeSettings: includeSettings,
+        includeAuth: includeAuth,
+      );
       if (path != null && mounted) {
         snackBar("Backup saved successfully!");
       }

--- a/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
+++ b/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
@@ -740,12 +740,16 @@ class BackupPasswordDialog extends StatefulWidget {
   final TextEditingController passwordController;
   final TextEditingController confirmPasswordController;
   final Function(bool) onUsePasswordChanged;
+  final Function(bool) onIncludeSettingsChanged;
+  final Function(bool) onIncludeAuthChanged;
 
   const BackupPasswordDialog({
     super.key,
     required this.passwordController,
     required this.confirmPasswordController,
     required this.onUsePasswordChanged,
+    required this.onIncludeSettingsChanged,
+    required this.onIncludeAuthChanged,
   });
 
   @override
@@ -754,8 +758,47 @@ class BackupPasswordDialog extends StatefulWidget {
 
 class BackupPasswordDialogState extends State<BackupPasswordDialog> {
   bool _usePassword = false;
+  bool _includeSettings = true;
+  bool _includeAuth = false;
   bool _obscurePassword = true;
   bool _obscureConfirm = true;
+
+  Widget _buildCheckbox({
+    required bool value,
+    required ValueChanged<bool?>? onChanged,
+    required String title,
+    required String subtitle,
+  }) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.opaque(0.3),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: CheckboxListTile(
+        value: value,
+        onChanged: onChanged,
+        title: Text(
+          title,
+          style: TextStyle(
+            fontWeight: FontWeight.w600,
+            color: theme.colorScheme.onSurface,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 12,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        controlAffinity: ListTileControlAffinity.trailing,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -763,54 +806,88 @@ class BackupPasswordDialogState extends State<BackupPasswordDialog> {
 
     return Dialog(
       backgroundColor: theme.colorScheme.surfaceContainer,
-      child: Container(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primary.opaque(0.1),
-                    borderRadius: BorderRadius.circular(12),
+      child: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary.opaque(0.1),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(Icons.backup_rounded,
+                        color: theme.colorScheme.primary, size: 24),
                   ),
-                  child: Icon(Icons.backup_rounded,
-                      color: theme.colorScheme.primary, size: 24),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        "Backup Options",
-                        style: theme.textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          "Backup Options",
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
-                      Text(
-                        "Protect your backup",
-                        style: TextStyle(
-                          color: theme.colorScheme.onSurfaceVariant,
-                          fontSize: 13,
+                        Text(
+                          "Choose what to include",
+                          style: TextStyle(
+                            color: theme.colorScheme.onSurfaceVariant,
+                            fontSize: 13,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 24),
-            Container(
-              decoration: BoxDecoration(
-                color:
-                    theme.colorScheme.surfaceContainerHighest.opaque(0.3),
-                borderRadius: BorderRadius.circular(16),
+                ],
               ),
-              child: CheckboxListTile(
+              const SizedBox(height: 24),
+              _buildCheckbox(
+                value: true,
+                onChanged: null,
+                title: "Library",
+                subtitle: "Anime, manga & novel library (always included)",
+              ),
+              const SizedBox(height: 8),
+              _buildCheckbox(
+                value: _includeSettings,
+                onChanged: (value) {
+                  setState(() {
+                    _includeSettings = value ?? true;
+                    widget.onIncludeSettingsChanged(_includeSettings);
+                    if (!_includeSettings) {
+                      _includeAuth = false;
+                      widget.onIncludeAuthChanged(false);
+                    }
+                  });
+                },
+                title: "Settings",
+                subtitle: "All app preferences, player, reader & UI settings",
+              ),
+              const SizedBox(height: 8),
+              _buildCheckbox(
+                value: _includeAuth,
+                onChanged: _includeSettings
+                    ? (value) {
+                        setState(() {
+                          _includeAuth = value ?? false;
+                          widget.onIncludeAuthChanged(_includeAuth);
+                        });
+                      }
+                    : null,
+                title: "Logins",
+                subtitle: _includeSettings
+                    ? "AniList, MAL, Simkl auth tokens"
+                    : "Enable Settings first",
+              ),
+              const SizedBox(height: 8),
+              _buildCheckbox(
                 value: _usePassword,
                 onChanged: (value) {
                   setState(() {
@@ -818,113 +895,95 @@ class BackupPasswordDialogState extends State<BackupPasswordDialog> {
                     widget.onUsePasswordChanged(_usePassword);
                   });
                 },
-                title: Text(
-                  "Password Protect",
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    color: theme.colorScheme.onSurface,
-                  ),
-                ),
-                subtitle: Text(
-                  "Add extra security to your backup",
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                controlAffinity: ListTileControlAffinity.trailing,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
+                title: "Password Protect",
+                subtitle: "Add extra security to your backup",
               ),
-            ),
-            if (_usePassword) ...[
-              const SizedBox(height: 20),
-              TextField(
-                controller: widget.passwordController,
-                obscureText: _obscurePassword,
-                decoration: InputDecoration(
-                  labelText: "Password",
-                  hintText: "Enter password",
-                  prefixIcon: const Icon(Icons.lock_outline),
-                  suffixIcon: IconButton(
-                    icon: Icon(_obscurePassword
-                        ? Icons.visibility_outlined
-                        : Icons.visibility_off_outlined),
-                    onPressed: () {
-                      setState(() => _obscurePassword = !_obscurePassword);
-                    },
-                  ),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  filled: true,
-                  fillColor: theme.colorScheme.surfaceContainerHighest
-                      .opaque(0.3),
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: widget.confirmPasswordController,
-                obscureText: _obscureConfirm,
-                decoration: InputDecoration(
-                  labelText: "Confirm Password",
-                  hintText: "Re-enter password",
-                  prefixIcon: const Icon(Icons.lock_outline),
-                  suffixIcon: IconButton(
-                    icon: Icon(_obscureConfirm
-                        ? Icons.visibility_outlined
-                        : Icons.visibility_off_outlined),
-                    onPressed: () {
-                      setState(() => _obscureConfirm = !_obscureConfirm);
-                    },
-                  ),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  filled: true,
-                  fillColor: theme.colorScheme.surfaceContainerHighest
-                      .opaque(0.3),
-                ),
-              ),
-            ],
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: TextButton(
-                    onPressed: () => Navigator.of(context).pop(false),
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
+              if (_usePassword) ...[
+                const SizedBox(height: 20),
+                TextField(
+                  controller: widget.passwordController,
+                  obscureText: _obscurePassword,
+                  decoration: InputDecoration(
+                    labelText: "Password",
+                    hintText: "Enter password",
+                    prefixIcon: const Icon(Icons.lock_outline),
+                    suffixIcon: IconButton(
+                      icon: Icon(_obscurePassword
+                          ? Icons.visibility_outlined
+                          : Icons.visibility_off_outlined),
+                      onPressed: () =>
+                          setState(() => _obscurePassword = !_obscurePassword),
                     ),
-                    child: const Text("Cancel"),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    filled: true,
+                    fillColor:
+                        theme.colorScheme.surfaceContainerHighest.opaque(0.3),
                   ),
                 ),
-                const SizedBox(width: 12),
-                Expanded(
-                  flex: 2,
-                  child: ElevatedButton(
-                    onPressed: () => Navigator.of(context).pop(true),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.primary,
-                      foregroundColor: theme.colorScheme.onPrimary,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: widget.confirmPasswordController,
+                  obscureText: _obscureConfirm,
+                  decoration: InputDecoration(
+                    labelText: "Confirm Password",
+                    hintText: "Re-enter password",
+                    prefixIcon: const Icon(Icons.lock_outline),
+                    suffixIcon: IconButton(
+                      icon: Icon(_obscureConfirm
+                          ? Icons.visibility_outlined
+                          : Icons.visibility_off_outlined),
+                      onPressed: () =>
+                          setState(() => _obscureConfirm = !_obscureConfirm),
                     ),
-                    child: const Text(
-                      "Create Backup",
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(16),
                     ),
+                    filled: true,
+                    fillColor:
+                        theme.colorScheme.surfaceContainerHighest.opaque(0.3),
                   ),
                 ),
               ],
-            ),
-          ],
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text("Cancel"),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    flex: 2,
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.primary,
+                        foregroundColor: theme.colorScheme.onPrimary,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        "Create Backup",
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## What changed
Previously backup/restore only covered the library (anime/manga/novel) 
and custom lists. This PR extends it to cover everything the user cares about.

## What's now backed up
| Category | Notes |
|---|---|
| Library & custom lists | Unchanged, always included |
| All app settings | Player, reader, UI, theme, novel reader, tap zones, shaders |
| Extension repos & order | Active source, repo URLs, extension ordering |
| Gist sync config | GitHub token & username for gist sync |
| Watch/read progress | Critical for offline users with no AniList/MAL login |
| Offline video progress | Restored with the settings blob |
| Search history | Included automatically |
| Logins (opt-in) | AniList, MAL, Simkl tokens — off by default |

## How it works
- All settings live in Isar's `KeyValue` collection. `_exportSettings` 
  reads every row directly — no hardcoded key list.
- **New keys added to `keys.dart` are automatically included** in future 
  backups with zero changes needed here.
- Only two keys are permanently excluded: `isFirstTime` and 
  `libraryGridAutoMigrated` — device-specific flags that would break the 
  app if restored.
- Auth tokens are isolated in their own `auth` section so the user can 
  opt in/out independently.

## UI changes
- Backup dialog now has three tick options under **"Include in Backup"**:
  - **Library** — always on, cannot be unticked
  - **Settings** — on by default
  - **Logins** — off by default, disabled if Settings is unticked
- Restore sheet is unchanged — restores everything that's in the file, 
  no partial restore options.

## Files changed
- `lib/controllers/services/backup_restore/backup_restore_service.dart`
- `lib/screens/settings/sub_settings/settings_backup.dart`
- `lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart`
```