### PR TITLE
fix: player orientation flipping in landscape mode

### DIFF
--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -445,10 +445,10 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
 
         const double slightLeanThreshold = 0.05;
         if (averageX >= slightLeanThreshold) {
-          return DeviceOrientation.landscapeRight;
+          return DeviceOrientation.landscapeLeft;
         }
         if (averageX <= -slightLeanThreshold) {
-          return DeviceOrientation.landscapeLeft;
+          return DeviceOrientation.landscapeRight;
         }
       }
     } catch (_) {}


### PR DESCRIPTION
**Title:**  
Fix player orientation flipping in landscape mode

**Description:**  
landscapeLeft/landscapeRight returns were swapped.  The UI was flipping to the opposite landscape orientation.

**Type of Changes:**  
- Bug Fix

**Testing Notes:**  
Android emulator

**Linked Issue(s):**  
https://anymex-support-ai.onrender.com/todo/31

**Submission Checklist:**
- [ ✅] I have read and followed the project's contributing guidelines
- [ ✅] My code follows the code style of this project
- [ ✅] I have tested the changes and ensured they do not break existing functionality
- [✅ ] I have added or updated documentation as needed
- [ ✅] I have linked related issues in the description above
- [ ✅] I have tagged the appropriate reviewers for this pull request