### PR TITLE
feat: Remember selected source per title (anime/manga)

### DIFF
--- a/lib/controllers/source/source_controller.dart
+++ b/lib/controllers/source/source_controller.dart
@@ -315,30 +315,27 @@ class SourceController extends GetxController implements BaseService {
     return list.firstWhereOrNull((s) => s.id.toString() == savedId);
   }
 
-  Source? getExtensionByValue(String value, {String? mediaId}) => _activateByName(
-      installedExtensions,
-      value,
-      activeSource,
-      SourceKeys.activeSourceId,
-      'ANIME',
-      mediaId: mediaId);
+  void savePreferredSource(String titleId, String sourceId) {
+    DynamicKeys.stickySource.set(titleId, sourceId);
+  }
+
+  String? getPreferredSource(String titleId) {
+    return DynamicKeys.stickySource.get<String?>(titleId);
+  }
+
+  Source? getExtensionByValue(String value, {String? mediaId}) =>
+      _activateByName(installedExtensions, value, activeSource,
+          SourceKeys.activeSourceId, 'ANIME',
+          mediaId: mediaId);
 
   Source? getMangaExtensionByName(String name, {String? mediaId}) =>
-      _activateByName(
-          installedMangaExtensions,
-          name,
-          activeMangaSource,
-          SourceKeys.activeMangaSourceId,
-          'MANGA',
+      _activateByName(installedMangaExtensions, name, activeMangaSource,
+          SourceKeys.activeMangaSourceId, 'MANGA',
           mediaId: mediaId);
 
   Source? getNovelExtensionByName(String name, {String? mediaId}) =>
-      _activateByName(
-          installedNovelExtensions,
-          name,
-          activeNovelSource,
-          SourceKeys.activeNovelSourceId,
-          'NOVEL',
+      _activateByName(installedNovelExtensions, name, activeNovelSource,
+          SourceKeys.activeNovelSourceId, 'NOVEL',
           mediaId: mediaId);
 
   Source? _activateByName(

--- a/lib/screens/anime/details_page.dart
+++ b/lib/screens/anime/details_page.dart
@@ -293,6 +293,7 @@ class _AnimeDetailsPageState extends State<AnimeDetailsPage> {
         _processExtensionData(tempData);
       } else {
         _fetchSecondaryData(tempData);
+        await _restorePreferredSource();
         Future.wait([_mapToService(), _syncMediaIds(), _fetchFillerInfo()]);
       }
     } catch (e) {
@@ -316,6 +317,18 @@ class _AnimeDetailsPageState extends State<AnimeDetailsPage> {
       }
     } catch (e) {
       Logger.i("Secondary Data Fetch Failed => $e");
+    }
+  }
+
+  Future<void> _restorePreferredSource() async {
+    final titleId = widget.media.id.toString();
+    final savedSourceId = sourceController.getPreferredSource(titleId);
+    if (savedSourceId != null) {
+      final savedSource =
+          sourceController.getSavedSource(titleId, ItemType.anime);
+      if (savedSource != null) {
+        sourceController.setActiveSource(savedSource, mediaId: titleId);
+      }
     }
   }
 

--- a/lib/screens/manga/details_page.dart
+++ b/lib/screens/manga/details_page.dart
@@ -33,6 +33,7 @@ import 'package:anymex/widgets/custom_widgets/anymex_button.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:anymex/widgets/custom_widgets/custom_textspan.dart';
+import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
@@ -208,6 +209,7 @@ class _MangaDetailsPageState extends State<MangaDetailsPage> {
         _processExtensionData(tempData);
       } else {
         _fetchSecondaryData(tempData);
+        await _restorePreferredSource();
         await _mapToService();
       }
     } catch (e, stackTrace) {
@@ -228,6 +230,18 @@ class _MangaDetailsPageState extends State<MangaDetailsPage> {
       }
     } catch (e) {
       Logger.i("Secondary Data Fetch Failed => $e");
+    }
+  }
+
+  Future<void> _restorePreferredSource() async {
+    final titleId = widget.media.id.toString();
+    final savedSourceId = sourceController.getPreferredSource(titleId);
+    if (savedSourceId != null) {
+      final savedSource =
+          sourceController.getSavedSource(titleId, ItemType.manga);
+      if (savedSource != null) {
+        sourceController.setActiveSource(savedSource, mediaId: titleId);
+      }
     }
   }
 


### PR DESCRIPTION
## Remember selected source per title (anime/manga) 
Feature: Remember selected source per title (anime/manga) with default fallback

## Description
adds a per-title source preference for anime and manga details pages.

## Type of Changes
- Feature
- Enhancement

## Linked Issue(s)
- [#368](https://github.com/RyanYuuki/AnymeX/issues/368)
- [#222](https://github.com/RyanYuuki/AnymeX/issues/222)
- https://github.com/RyanYuuki/AnymeX/pull/372 (this guy closed his pr for some reason)

## Submission Checklist
- [✅] I have read and followed the project's contributing guidelines
- [✅] My code follows the code style of this project
- [✅] I have tested the changes and ensured they do not break existing functionality
- [✅] I have added or updated documentation as needed
- [✅] I have linked related issues in the description above
- [✅] I have tagged the appropriate reviewers for this pull request