### PR TITLE
feat(profiles): add multi-account system with lock, security recovery & skip mode

### DIFF
--- a/lib/controllers/cacher/cache_controller.dart
+++ b/lib/controllers/cacher/cache_controller.dart
@@ -1,12 +1,15 @@
 import 'dart:convert';
 
 import 'package:anymex/controllers/service_handler/service_handler.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/utils/logger.dart';
 import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
 import 'package:get/get.dart';
 
 final cacheController = Get.find<CacheController>();
+
+const _kCacheStorageKey = '__recently_opened_cache__';
 
 class CacheController extends GetxController {
   RxList<String> cachedAnilistData = <String>[].obs;
@@ -17,6 +20,67 @@ class CacheController extends GetxController {
   RxString detailsData = ''.obs;
 
   RxList<String> get currentPool => getCacheContainer();
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadFromStorage();
+  }
+
+  void saveToStorage() {
+    try {
+      final service = Get.find<ServiceHandler>().serviceType.value;
+      final String serviceKey = service.name;
+      final List<String> pool = getCacheContainer().toList();
+
+      KvHelper.set<List<String>>('${_kCacheStorageKey}_$serviceKey', pool);
+      Logger.i('Saved recently opened cache for ${service.name}: ${pool.length} items');
+    } catch (e) {
+      Logger.i('Error saving cache to storage: $e');
+    }
+  }
+
+  void loadFromStorage() {
+    _loadFromStorage();
+  }
+
+  void _loadFromStorage() {
+    try {
+      final service = Get.find<ServiceHandler>().serviceType.value;
+      final String serviceKey = service.name;
+      final List<String>? saved = KvHelper.get<List<String>>(
+        '${_kCacheStorageKey}_$serviceKey',
+        defaultVal: [],
+      );
+
+      if (saved != null && saved.isNotEmpty) {
+        final targetPool = getCacheContainer();
+        targetPool.assignAll(saved);
+        Logger.i('Loaded recently opened cache for ${service.name}: ${saved.length} items');
+      } else {
+        final targetPool = getCacheContainer();
+        targetPool.clear();
+      }
+    } catch (e) {
+      Logger.i('Error loading cache from storage: $e');
+    }
+  }
+
+  void clearAllCache() {
+    try {
+      final services = ['anilist', 'mal', 'simkl', 'extensions'];
+      for (final service in services) {
+        KvHelper.remove('${_kCacheStorageKey}_$service');
+      }
+      cachedAnilistData.clear();
+      cachedMalData.clear();
+      cachedSimklData.clear();
+      cachedExtensionData.clear();
+      Logger.i('Cleared all recently opened cache');
+    } catch (e) {
+      Logger.i('Error clearing cache: $e');
+    }
+  }
 
   void addCache(Map<String, dynamic> data) {
     if (!data.containsKey('id') ||
@@ -51,6 +115,20 @@ class CacheController extends GetxController {
             'Warning: currentPool index out of sync for ID $id, adding as new');
         currentPool.add(encodedData);
       }
+    }
+
+    _persistCurrentPool();
+  }
+
+  void _persistCurrentPool() {
+    try {
+      final service = Get.find<ServiceHandler>().serviceType.value;
+      final String serviceKey = service.name;
+      final pool = currentPool.length > 30
+          ? currentPool.sublist(currentPool.length - 30)
+          : currentPool.toList();
+      KvHelper.set<List<String>>('${_kCacheStorageKey}_$serviceKey', pool);
+    } catch (e) {
     }
   }
 

--- a/lib/controllers/offline/offline_storage_controller.dart
+++ b/lib/controllers/offline/offline_storage_controller.dart
@@ -27,7 +27,7 @@ class OfflineStorageController extends GetxController {
   String? get _pid {
     final prefix = KvHelper.profilePrefix;
     if (prefix.isEmpty) return null;
-    return prefix.replaceAll('_', '');
+    return prefix.substring(0, prefix.length - 1);
   }
 
   void migrateOrphanedData() {

--- a/lib/controllers/offline/offline_storage_controller.dart
+++ b/lib/controllers/offline/offline_storage_controller.dart
@@ -5,6 +5,7 @@ import 'package:anymex/database/isar_models/chapter.dart';
 import 'package:anymex/database/isar_models/custom_list.dart';
 import 'package:anymex/database/isar_models/episode.dart';
 import 'package:anymex/database/isar_models/offline_media.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/main.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/utils/logger.dart';
@@ -23,23 +24,69 @@ class OfflineStorageController extends GetxController {
       ? Get.find<GistSyncController>()
       : null;
 
+  String? get _pid {
+    final prefix = KvHelper.profilePrefix;
+    if (prefix.isEmpty) return null;
+    return prefix.replaceAll('_', '');
+  }
+
+  void migrateOrphanedData() {
+    final pid = _pid;
+    if (pid == null) return;
+
+    try {
+      isar.writeTxnSync(() {
+        final col = isar.offlineMedias;
+        final orphans =
+            col.where().findAllSync().where((m) => m.profileId == null).toList();
+        if (orphans.isNotEmpty) {
+          for (final m in orphans) {
+            m.profileId = pid;
+            col.putSync(m);
+          }
+        }
+
+        final listCol = isar.customLists;
+        final listOrphans = listCol
+            .where().findAllSync().where((l) => l.profileId == null).toList();
+        if (listOrphans.isNotEmpty) {
+          for (final l in listOrphans) {
+            l.profileId = pid;
+            listCol.putSync(l);
+          }
+        }
+      });
+    } catch (e) {
+      Logger.i('Error migrating orphaned library data: $e');
+    }
+  }
+
   Stream<List<OfflineMedia>> watchAnimeLibrary() {
+    migrateOrphanedData();
     return isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(1)
         .watch(fireImmediately: true);
   }
 
   Stream<List<OfflineMedia>> watchMangaLibrary() {
+    migrateOrphanedData();
     return isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(0)
         .watch(fireImmediately: true);
   }
 
   Stream<List<OfflineMedia>> watchNovelLibrary() {
+    migrateOrphanedData();
     return isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(2)
         .watch(fireImmediately: true);
   }
@@ -47,19 +94,28 @@ class OfflineStorageController extends GetxController {
   Stream<OfflineMedia?> watchMediaById(String mediaId) {
     return isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaIdEqualTo(mediaId)
         .watch(fireImmediately: true)
         .map((list) => list.isNotEmpty ? list.first : null);
   }
 
   Stream<List<CustomList>> watchCustomLists(ItemType mediaType) {
-    return isar.customLists.where().watch(fireImmediately: true);
+    return isar.customLists
+        .filter()
+        .profileIdEqualTo(_pid)
+        .and()
+        .mediaTypeIndexEqualTo(mediaType.index)
+        .watch(fireImmediately: true);
   }
 
   Stream<CustomListData> watchCustomListData(
       String listName, ItemType mediaType) async* {
     await for (final customList in isar.customLists
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .listNameEqualTo(listName)
         .and()
         .mediaTypeIndexEqualTo(mediaType.index)
@@ -79,6 +135,8 @@ class OfflineStorageController extends GetxController {
 
       final mediaItems = await isar.offlineMedias
           .filter()
+          .profileIdEqualTo(_pid)
+          .and()
           .anyOf(
               mediaIds,
               (q, String id) => q
@@ -98,6 +156,8 @@ class OfflineStorageController extends GetxController {
       {int offset = 0, int limit = 50}) async {
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(1)
         .offset(offset)
         .limit(limit)
@@ -108,6 +168,8 @@ class OfflineStorageController extends GetxController {
       {int offset = 0, int limit = 50}) async {
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(0)
         .offset(offset)
         .limit(limit)
@@ -118,6 +180,8 @@ class OfflineStorageController extends GetxController {
       {int offset = 0, int limit = 50}) async {
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(2)
         .offset(offset)
         .limit(limit)
@@ -131,6 +195,8 @@ class OfflineStorageController extends GetxController {
   }) async {
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(mediaType.index)
         .offset(offset)
         .limit(limit)
@@ -140,6 +206,8 @@ class OfflineStorageController extends GetxController {
   Future<List<CustomList>> getCustomListsFromType(ItemType type) async {
     return await isar.customLists
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(type.index)
         .findAll();
   }
@@ -150,6 +218,8 @@ class OfflineStorageController extends GetxController {
   ) async {
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(mediaType.index)
         .group((q) => q
             .nameContains(query, caseSensitive: false)
@@ -161,7 +231,12 @@ class OfflineStorageController extends GetxController {
   }
 
   OfflineMedia? getMediaById(String mediaId) {
-    return isar.offlineMedias.filter().mediaIdEqualTo(mediaId).findFirstSync();
+    return isar.offlineMedias
+        .filter()
+        .profileIdEqualTo(_pid)
+        .and()
+        .mediaIdEqualTo(mediaId)
+        .findFirstSync();
   }
 
   OfflineMedia? getAnimeById(String id) => getMediaById(id);
@@ -235,13 +310,19 @@ class OfflineStorageController extends GetxController {
   Future<List<CustomList>> getCustomListsByType(ItemType type) async {
     return await isar.customLists
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(type.index)
         .findAll();
   }
 
   Future<CustomList?> getCustomListByName(String listName,
       {ItemType? mediaType}) async {
-    var query = isar.customLists.filter().listNameEqualTo(listName);
+    var query = isar.customLists
+        .filter()
+        .profileIdEqualTo(_pid)
+        .and()
+        .listNameEqualTo(listName);
     if (mediaType != null) {
       return await query.mediaTypeIndexEqualTo(mediaType.index).findFirst();
     }
@@ -260,6 +341,7 @@ class OfflineStorageController extends GetxController {
 
     await isar.writeTxn(() async {
       await isar.customLists.put(CustomList(
+        profileId: _pid,
         listName: listName,
         mediaIds: [],
         mediaTypeIndex: mediaType.index,
@@ -351,11 +433,16 @@ class OfflineStorageController extends GetxController {
 
     return await isar.offlineMedias
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .anyOf(list.mediaIds!, (q, String id) => q.mediaIdEqualTo(id))
         .findAll();
   }
 
   Future<void> addMediaToLibrary(OfflineMedia original) async {
+    if (original.profileId == null) {
+      original.profileId = _pid;
+    }
     final existing = getMediaById(original.mediaId ?? "");
 
     if (existing != null) return;
@@ -703,7 +790,7 @@ class OfflineStorageController extends GetxController {
 
   Future<Map<String, dynamic>> getNovelStats() async {
     final allNovels =
-        await isar.offlineMedias.filter().mediaTypeIndexEqualTo(2).findAll();
+        await isar.offlineMedias.filter().profileIdEqualTo(_pid).and().mediaTypeIndexEqualTo(2).findAll();
 
     int completedNovels = 0;
     int readingNovels = 0;
@@ -740,6 +827,7 @@ class OfflineStorageController extends GetxController {
   ) {
     final handler = Get.find<ServiceHandler>();
     return OfflineMedia(
+      profileId: _pid,
       mediaId: original.id,
       jname: original.romajiTitle,
       name: original.title,
@@ -774,8 +862,21 @@ class OfflineStorageController extends GetxController {
 
   Future<void> clearCache() async {
     await isar.writeTxn(() async {
-      await isar.offlineMedias.clear();
-      await isar.customLists.clear();
+      final mediaToDelete = isar.offlineMedias
+          .filter()
+          .profileIdEqualTo(_pid)
+          .findAllSync();
+      for (final m in mediaToDelete) {
+        await isar.offlineMedias.delete(m.id);
+      }
+
+      final listsToDelete = isar.customLists
+          .filter()
+          .profileIdEqualTo(_pid)
+          .findAllSync();
+      for (final l in listsToDelete) {
+        await isar.customLists.delete(l.id);
+      }
     });
 
     Logger.i('Cache cleared successfully');
@@ -785,6 +886,8 @@ class OfflineStorageController extends GetxController {
       {required ItemType mediaType}) {
     final lists = isar.customLists
         .filter()
+        .profileIdEqualTo(_pid)
+        .and()
         .mediaTypeIndexEqualTo(mediaType.index)
         .findAllSync();
 
@@ -797,6 +900,8 @@ class OfflineStorageController extends GetxController {
 
       final mediaItems = isar.offlineMedias
           .filter()
+          .profileIdEqualTo(_pid)
+          .and()
           .anyOf(
             mediaIds,
             (q, String id) => q
@@ -845,6 +950,7 @@ class OfflineStorageController extends GetxController {
           await isar.customLists.put(existingList);
         } else {
           await isar.customLists.put(CustomList(
+            profileId: _pid,
             listName: updatedListData.listName,
             mediaIds: updatedListData.listData
                 .map((media) => media.mediaId ?? '')

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -4,6 +4,7 @@ import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
 import 'package:anymex/controllers/services/mal/mal_service.dart';
 import 'package:anymex/controllers/services/simkl/simkl_service.dart';
+import 'package:anymex/database/data_keys/keys.dart';
 import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/main.dart';
@@ -25,6 +26,8 @@ class ProfileManager extends GetxController {
   RxList<AppProfile> profiles = <AppProfile>[].obs;
   Rx<AppProfile?> currentProfile = Rx<AppProfile?>(null);
   RxString currentProfileId = ''.obs;
+  RxBool isProfileReady = false.obs;
+  RxString autoStartProfileId = ''.obs;
 
   @override
   void onInit() {
@@ -36,6 +39,11 @@ class ProfileManager extends GetxController {
     final raw = _readGlobal(_kProfilesKey);
     if (raw != null && raw.isNotEmpty) {
       profiles.value = AppProfile.fromJsonList(raw);
+    }
+
+    final savedAutoStart = _readGlobal(_kAutoStartProfileIdKey);
+    if (savedAutoStart != null && savedAutoStart.isNotEmpty) {
+      autoStartProfileId.value = savedAutoStart;
     }
 
     final savedId = _readGlobal(_kCurrentProfileIdKey);
@@ -61,9 +69,8 @@ class ProfileManager extends GetxController {
 
   bool get hasSingleProfile => profiles.length == 1;
 
-  String? get autoStartProfileId {
-    return _readGlobal(_kAutoStartProfileIdKey);
-  }
+  bool get hasAutoStart => autoStartProfileId.value.isNotEmpty &&
+      profiles.any((p) => p.id == autoStartProfileId.value);
 
   AppProfile? createProfile({
     required String name,
@@ -98,19 +105,28 @@ class ProfileManager extends GetxController {
 
     if (autoStart) {
       _writeGlobal(_kAutoStartProfileIdKey, profile.id);
+      autoStartProfileId.value = profile.id;
     }
 
-    await _reauthServices();
+    final handler = Get.find<ServiceHandler>();
+    final serviceIndex = ServiceKeys.serviceType.get<int>(0);
+    handler.serviceType.value = ServicesType.values[serviceIndex];
+
+    isProfileReady.value = true;
+
+    _reauthServices();
 
     return profile;
   }
 
-  Future<void> _reauthServices() async {
+  void _reauthServices() {
     try {
       final handler = Get.find<ServiceHandler>();
-      await handler.autoLogin();
-      await handler.fetchHomePage();
-      updateServiceBadges();
+      handler.autoLogin().then((_) {
+        handler.fetchHomePage();
+      }).then((_) {
+        updateServiceBadges();
+      });
     } catch (e) {
       Logger.i('Error re-authenticating on profile switch: $e');
     }
@@ -228,8 +244,9 @@ class ProfileManager extends GetxController {
     profiles.removeWhere((p) => p.id == profileId);
     _saveProfiles();
 
-    if (autoStartProfileId == profileId) {
+    if (autoStartProfileId.value == profileId) {
       _writeGlobal(_kAutoStartProfileIdKey, '');
+      autoStartProfileId.value = '';
     }
 
     return true;
@@ -237,6 +254,7 @@ class ProfileManager extends GetxController {
 
   void resetAutoStart() {
     _writeGlobal(_kAutoStartProfileIdKey, '');
+    autoStartProfileId.value = '';
   }
 
   void _updateProfile(AppProfile updated) {

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -56,7 +56,7 @@ class ProfileManager extends GetxController {
       if (profile != null) {
         currentProfile.value = profile;
         currentProfileId.value = profile.id;
-        KvHelper.profilePrefix = 'prof_${profile.id}_';
+        KvHelper.profilePrefix = '${profile.id}_';
       }
     }
   }
@@ -104,7 +104,7 @@ class ProfileManager extends GetxController {
 
     currentProfile.value = profile;
     currentProfileId.value = profile.id;
-    KvHelper.profilePrefix = 'prof_${profile.id}_';
+    KvHelper.profilePrefix = '${profile.id}_';
     _saveCurrentProfileId();
 
     if (autoStart) {
@@ -234,7 +234,7 @@ class ProfileManager extends GetxController {
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return false;
 
-    final prefix = 'prof_${profile.id}_';
+    final prefix = '${profile.id}_';
     try {
       final col = isar.collection<KeyValue>();
       final allKeys = col.where().findAllSync();

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -376,6 +376,7 @@ class ProfileManager extends GetxController {
     if (index == -1) return;
 
     profiles[index] = updated;
+    profiles.refresh();
     if (currentProfile.value?.id == updated.id) {
       currentProfile.value = updated;
     }
@@ -392,6 +393,19 @@ class ProfileManager extends GetxController {
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return;
     _updateProfile(profile.copyWith(avatarPath: avatarPath));
+  }
+
+  void restoreProfileFromBackup(String profileId, AppProfile source) {
+    final index = profiles.indexWhere((p) => p.id == profileId);
+    if (index == -1) return;
+    final updated = profiles[index].copyWith(
+      lockHash: source.lockHash,
+      lockType: source.lockType,
+      anilistLinked: source.anilistLinked,
+      malLinked: source.malLinked,
+      simklLinked: source.simklLinked,
+    );
+    _updateProfile(updated);
   }
 
   static String? _readGlobal(String key) {

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -18,12 +18,13 @@ import 'package:get/get.dart';
 import 'package:isar_community/isar.dart';
 
 const int kMaxProfiles = 5;
-const int kMaxPinAttempts = 5;
+const int kMaxLockAttempts = 5;
 const int kLockoutMinutes = 5;
 
 const String _kProfilesKey = '__app_profiles__';
 const String _kCurrentProfileIdKey = '__current_profile_id__';
 const String _kAutoStartProfileIdKey = '__auto_start_profile_id__';
+const String _kMultiProfileEnabledKey = '__multi_profile_enabled__';
 
 class ProfileManager extends GetxController {
   RxList<AppProfile> profiles = <AppProfile>[].obs;
@@ -32,6 +33,7 @@ class ProfileManager extends GetxController {
   RxBool isProfileReady = false.obs;
   RxString autoStartProfileId = ''.obs;
   RxBool showProfileSelection = false.obs;
+  RxBool isMultiProfileEnabled = false.obs;
 
   @override
   void onInit() {
@@ -48,6 +50,11 @@ class ProfileManager extends GetxController {
     final savedAutoStart = _readGlobal(_kAutoStartProfileIdKey);
     if (savedAutoStart != null && savedAutoStart.isNotEmpty) {
       autoStartProfileId.value = savedAutoStart;
+    }
+
+    final savedMultiProfile = _readGlobal(_kMultiProfileEnabledKey);
+    if (savedMultiProfile == 'true') {
+      isMultiProfileEnabled.value = true;
     }
 
     final savedId = _readGlobal(_kCurrentProfileIdKey);
@@ -90,7 +97,34 @@ class ProfileManager extends GetxController {
 
     profiles.add(profile);
     _saveProfiles();
+    if (profiles.isNotEmpty) {
+      isMultiProfileEnabled.value = true;
+      _writeGlobal(_kMultiProfileEnabledKey, 'true');
+    }
     return profile;
+  }
+
+  AppProfile createDefaultProfile() {
+    final profile = AppProfile(
+      id: 'prof_${DateTime.now().millisecondsSinceEpoch}',
+      name: 'My Profile',
+    );
+
+    profiles.add(profile);
+    _saveProfiles();
+    return profile;
+  }
+
+  Future<void> skipMultiProfileSetup() async {
+    final profile = createDefaultProfile();
+    await switchToProfile(profile.id);
+    isMultiProfileEnabled.value = false;
+    _writeGlobal(_kMultiProfileEnabledKey, 'false');
+  }
+
+  void enableMultiProfile() {
+    isMultiProfileEnabled.value = true;
+    _writeGlobal(_kMultiProfileEnabledKey, 'true');
   }
 
   Future<AppProfile?> switchToProfile(String profileId,
@@ -152,52 +186,90 @@ class ProfileManager extends GetxController {
     final hash = sha256.convert(bytes).toString();
 
     _updateProfile(profile.copyWith(
-        pinHash: hash, failedPinAttempts: 0, lockedUntil: null));
+        lockHash: hash,
+        lockType: 'pin',
+        failedAttempts: 0,
+        lockedUntil: null));
     return true;
   }
 
-  bool removePin(String profileId) {
+  bool setPassword(String profileId, String password) {
+    if (password.length < 4 || password.length > 32) return false;
+
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return false;
 
-    _updateProfile(
-        profile.copyWith(pinHash: null, failedPinAttempts: 0, lockedUntil: null));
+    final bytes = utf8.encode(password);
+    final hash = sha256.convert(bytes).toString();
+
+    _updateProfile(profile.copyWith(
+        lockHash: hash,
+        lockType: 'password',
+        failedAttempts: 0,
+        lockedUntil: null));
     return true;
   }
 
-  bool? verifyPin(String profileId, String pin) {
+  bool setPattern(String profileId, List<int> pattern) {
+    if (pattern.length < 4) return false;
+
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    final patternStr = pattern.join(',');
+    final bytes = utf8.encode(patternStr);
+    final hash = sha256.convert(bytes).toString();
+
+    _updateProfile(profile.copyWith(
+        lockHash: hash,
+        lockType: 'pattern',
+        failedAttempts: 0,
+        lockedUntil: null));
+    return true;
+  }
+
+  bool removeLock(String profileId) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    _updateProfile(profile.copyWith(clearLock: true));
+    return true;
+  }
+
+  bool? verifyLock(String profileId, String input) {
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return false;
 
     if (profile.isLocked) return null;
 
-    final bytes = utf8.encode(pin);
+    final bytes = utf8.encode(input);
     final hash = sha256.convert(bytes).toString();
 
-    if (hash == profile.pinHash) {
+    if (hash == profile.lockHash) {
       _updateProfile(
-          profile.copyWith(failedPinAttempts: 0, lockedUntil: null));
+          profile.copyWith(failedAttempts: 0, lockedUntil: null));
       return true;
     } else {
-      final newAttempts = profile.failedPinAttempts + 1;
+      final newAttempts = profile.failedAttempts + 1;
       DateTime? lockedUntil;
 
-      if (newAttempts >= kMaxPinAttempts) {
+      if (newAttempts >= kMaxLockAttempts) {
         lockedUntil =
             DateTime.now().add(Duration(minutes: kLockoutMinutes));
       }
 
       _updateProfile(profile.copyWith(
-        failedPinAttempts: newAttempts,
+        failedAttempts: newAttempts,
         lockedUntil: lockedUntil,
       ));
       return false;
     }
   }
 
-  void setAniListLinked(bool linked) {
-    if (currentProfile.value == null) return;
+  bool setAniListLinked(bool linked) {
+    if (currentProfile.value == null) return false;
     _updateProfile(currentProfile.value!.copyWith(anilistLinked: linked));
+    return true;
   }
 
   void setMALLinked(bool linked) {

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -5,6 +5,7 @@ import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
 import 'package:anymex/controllers/services/mal/mal_service.dart';
 import 'package:anymex/controllers/services/simkl/simkl_service.dart';
+import 'package:anymex/controllers/settings/settings.dart';
 import 'package:anymex/database/data_keys/keys.dart';
 import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/kv_helper.dart';
@@ -140,6 +141,10 @@ class ProfileManager extends GetxController {
     currentProfileId.value = profile.id;
     KvHelper.profilePrefix = '${profile.id}_';
     _saveCurrentProfileId();
+
+    if (Get.isRegistered<Settings>()) {
+      Get.find<Settings>().reloadForProfile();
+    }
 
     if (autoStart) {
       _writeGlobal(_kAutoStartProfileIdKey, profile.id);

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -153,7 +153,7 @@ class ProfileManager extends GetxController {
     isProfileReady.value = true;
     showProfileSelection.value = false;
 
-    _reauthServices();
+    await _reauthServices();
 
     if (Get.isRegistered<OfflineStorageController>()) {
       Get.find<OfflineStorageController>().migrateOrphanedData();
@@ -162,14 +162,12 @@ class ProfileManager extends GetxController {
     return profile;
   }
 
-  void _reauthServices() {
+  Future<void> _reauthServices() async {
     try {
       final handler = Get.find<ServiceHandler>();
-      handler.autoLogin().then((_) {
-        handler.fetchHomePage();
-      }).then((_) {
-        updateServiceBadges();
-      });
+      await handler.autoLogin();
+      await handler.fetchHomePage();
+      updateServiceBadges();
     } catch (e) {
       Logger.i('Error re-authenticating on profile switch: $e');
     }
@@ -241,6 +239,11 @@ class ProfileManager extends GetxController {
     if (profile == null) return false;
 
     if (profile.isLocked) return null;
+
+    if (profile.failedAttempts >= kMaxLockAttempts) {
+      profile = profile.copyWith(failedAttempts: 0, lockedUntil: null);
+      _updateProfile(profile);
+    }
 
     final bytes = utf8.encode(input);
     final hash = sha256.convert(bytes).toString();

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -31,6 +31,7 @@ class ProfileManager extends GetxController {
   RxString currentProfileId = ''.obs;
   RxBool isProfileReady = false.obs;
   RxString autoStartProfileId = ''.obs;
+  RxBool showProfileSelection = false.obs;
 
   @override
   void onInit() {
@@ -116,6 +117,7 @@ class ProfileManager extends GetxController {
     handler.serviceType.value = ServicesType.values[serviceIndex];
 
     isProfileReady.value = true;
+    showProfileSelection.value = false;
 
     _reauthServices();
 
@@ -287,6 +289,14 @@ class ProfileManager extends GetxController {
   void resetAutoStart() {
     _writeGlobal(_kAutoStartProfileIdKey, '');
     autoStartProfileId.value = '';
+  }
+
+  void requestProfileSelection() {
+    showProfileSelection.value = true;
+  }
+
+  void clearProfileSelectionRequest() {
+    showProfileSelection.value = false;
   }
 
   void _updateProfile(AppProfile updated) {

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:anymex/controllers/cacher/cache_controller.dart';
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
@@ -21,6 +22,26 @@ import 'package:isar_community/isar.dart';
 const int kMaxProfiles = 5;
 const int kMaxLockAttempts = 5;
 const int kLockoutMinutes = 5;
+const int kMaxSecurityQuestions = 3;
+const String kCustomQuestionLabel = '✏️ Write your own question';
+
+const List<String> kSecurityQuestions = [
+  'First anime/manga you ever watched/read?',
+  'Favorite anime/manga character?',
+  'Anime/manga that made you cry?',
+  'Anime/manga you\'ve rewatched/reread the most?',
+  'Favorite anime/manga opening song?',
+  'Favorite anime/manga villain?',
+  'First video game you played?',
+  'Your favorite game of all time?',
+  'Favorite J-pop/K-pop artist?',
+  'A fictional world you\'d want to live in?',
+  'Your anime/manga waifu/husbando?',
+  'Favorite anime/manga studio?',
+  'Anime/manga you\'d recommend to everyone?',
+  'Manga you want to see animated?',
+  'Your go-to comfort anime/manga?',
+];
 
 const String _kProfilesKey = '__app_profiles__';
 const String _kCurrentProfileIdKey = '__current_profile_id__';
@@ -137,6 +158,10 @@ class ProfileManager extends GetxController {
     profile.lastUsedAt = DateTime.now();
     _updateProfile(profile);
 
+    if (Get.isRegistered<CacheController>()) {
+      Get.find<CacheController>().saveToStorage();
+    }
+
     currentProfile.value = profile;
     currentProfileId.value = profile.id;
     KvHelper.profilePrefix = '${profile.id}_';
@@ -160,6 +185,10 @@ class ProfileManager extends GetxController {
 
     await _reauthServices();
 
+    if (Get.isRegistered<CacheController>()) {
+      Get.find<CacheController>().loadFromStorage();
+    }
+
     if (Get.isRegistered<OfflineStorageController>()) {
       Get.find<OfflineStorageController>().migrateOrphanedData();
     }
@@ -178,7 +207,7 @@ class ProfileManager extends GetxController {
     }
   }
 
-  bool setPin(String profileId, String pin) {
+  bool setPin(String profileId, String pin, {List<Map<String, String>>? securityQAs}) {
     if (pin.length < 4 || pin.length > 6) return false;
     if (!RegExp(r'^\d+$').hasMatch(pin)) return false;
 
@@ -188,15 +217,18 @@ class ProfileManager extends GetxController {
     final bytes = utf8.encode(pin);
     final hash = sha256.convert(bytes).toString();
 
+    final qaJson = _encodeSecurityQAs(securityQAs);
+
     _updateProfile(profile.copyWith(
         lockHash: hash,
         lockType: 'pin',
         failedAttempts: 0,
-        lockedUntil: null));
+        lockedUntil: null,
+        securityQuestionsJson: qaJson));
     return true;
   }
 
-  bool setPassword(String profileId, String password) {
+  bool setPassword(String profileId, String password, {List<Map<String, String>>? securityQAs}) {
     if (password.length < 4 || password.length > 32) return false;
 
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
@@ -205,15 +237,18 @@ class ProfileManager extends GetxController {
     final bytes = utf8.encode(password);
     final hash = sha256.convert(bytes).toString();
 
+    final qaJson = _encodeSecurityQAs(securityQAs);
+
     _updateProfile(profile.copyWith(
         lockHash: hash,
         lockType: 'password',
         failedAttempts: 0,
-        lockedUntil: null));
+        lockedUntil: null,
+        securityQuestionsJson: qaJson));
     return true;
   }
 
-  bool setPattern(String profileId, List<int> pattern) {
+  bool setPattern(String profileId, List<int> pattern, {List<Map<String, String>>? securityQAs}) {
     if (pattern.length < 4) return false;
 
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
@@ -223,11 +258,14 @@ class ProfileManager extends GetxController {
     final bytes = utf8.encode(patternStr);
     final hash = sha256.convert(bytes).toString();
 
+    final qaJson = _encodeSecurityQAs(securityQAs);
+
     _updateProfile(profile.copyWith(
         lockHash: hash,
         lockType: 'pattern',
         failedAttempts: 0,
-        lockedUntil: null));
+        lockedUntil: null,
+        securityQuestionsJson: qaJson));
     return true;
   }
 
@@ -235,12 +273,38 @@ class ProfileManager extends GetxController {
     final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return false;
 
-    _updateProfile(profile.copyWith(clearLock: true));
+    _updateProfile(profile.copyWith(clearLock: true, clearSecurityQuestions: true));
+    return true;
+  }
+
+  bool verifySecurityAnswer(String profileId, String answer) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    final qas = profile.securityQAs;
+    if (qas.isEmpty) return false;
+
+    final ansBytes = utf8.encode(answer.trim().toLowerCase());
+    final hash = sha256.convert(ansBytes).toString();
+
+    return qas.any((qa) => qa['a'] == hash);
+  }
+
+  bool bypassLock(String profileId) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    _updateProfile(profile.copyWith(
+      lockHash: null,
+      lockType: 'none',
+      failedAttempts: 0,
+      lockedUntil: null,
+    ));
     return true;
   }
 
   bool? verifyLock(String profileId, String input) {
-    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    var profile = profiles.firstWhereOrNull((p) => p.id == profileId);
     if (profile == null) return false;
 
     if (profile.isLocked) return null;
@@ -426,6 +490,21 @@ class ProfileManager extends GetxController {
       Logger.i('Error reading global KV $key: $e');
       return null;
     }
+  }
+
+  static String? _encodeSecurityQAs(List<Map<String, String>>? qas) {
+    if (qas == null || qas.isEmpty) return null;
+
+    final encoded = qas.map((qa) {
+      final question = qa['q'] ?? '';
+      final answer = qa['a'] ?? '';
+      final isCustom = qa['c'] == 'true';
+      final ansBytes = utf8.encode(answer.trim().toLowerCase());
+      final hash = sha256.convert(ansBytes).toString();
+      return {'q': question, 'a': hash, 'c': isCustom};
+    }).toList();
+
+    return jsonEncode(encoded);
   }
 
   static void _writeGlobal(String key, String value) {

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -1,0 +1,290 @@
+import 'dart:convert';
+
+import 'package:anymex/controllers/service_handler/service_handler.dart';
+import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
+import 'package:anymex/controllers/services/mal/mal_service.dart';
+import 'package:anymex/controllers/services/simkl/simkl_service.dart';
+import 'package:anymex/database/isar_models/key_value.dart';
+import 'package:anymex/database/kv_helper.dart';
+import 'package:anymex/main.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/utils/logger.dart';
+import 'package:crypto/crypto.dart';
+import 'package:get/get.dart';
+import 'package:isar_community/isar.dart';
+
+const int kMaxProfiles = 5;
+const int kMaxPinAttempts = 5;
+const int kLockoutMinutes = 5;
+
+const String _kProfilesKey = '__app_profiles__';
+const String _kCurrentProfileIdKey = '__current_profile_id__';
+const String _kAutoStartProfileIdKey = '__auto_start_profile_id__';
+
+class ProfileManager extends GetxController {
+  RxList<AppProfile> profiles = <AppProfile>[].obs;
+  Rx<AppProfile?> currentProfile = Rx<AppProfile?>(null);
+  RxString currentProfileId = ''.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadProfiles();
+  }
+
+  void _loadProfiles() {
+    final raw = _readGlobal(_kProfilesKey);
+    if (raw != null && raw.isNotEmpty) {
+      profiles.value = AppProfile.fromJsonList(raw);
+    }
+
+    final savedId = _readGlobal(_kCurrentProfileIdKey);
+    if (savedId != null && savedId.isNotEmpty) {
+      final profile = profiles.firstWhereOrNull((p) => p.id == savedId);
+      if (profile != null) {
+        currentProfile.value = profile;
+        currentProfileId.value = profile.id;
+        KvHelper.profilePrefix = 'prof_${profile.id}_';
+      }
+    }
+  }
+
+  void _saveProfiles() {
+    _writeGlobal(_kProfilesKey, AppProfile.toJsonList(profiles.toList()));
+  }
+
+  void _saveCurrentProfileId() {
+    _writeGlobal(_kCurrentProfileIdKey, currentProfileId.value);
+  }
+
+  bool get hasProfiles => profiles.isNotEmpty;
+
+  bool get hasSingleProfile => profiles.length == 1;
+
+  String? get autoStartProfileId {
+    return _readGlobal(_kAutoStartProfileIdKey);
+  }
+
+  AppProfile? createProfile({
+    required String name,
+    String avatarPath = '',
+  }) {
+    if (profiles.length >= kMaxProfiles) return null;
+
+    final profile = AppProfile(
+      id: 'prof_${DateTime.now().millisecondsSinceEpoch}',
+      name: name,
+      avatarPath: avatarPath,
+    );
+
+    profiles.add(profile);
+    _saveProfiles();
+    return profile;
+  }
+
+  Future<AppProfile?> switchToProfile(String profileId,
+      {bool autoStart = false}) async {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return null;
+    if (profile.isLocked) return null;
+
+    profile.lastUsedAt = DateTime.now();
+    _updateProfile(profile);
+
+    currentProfile.value = profile;
+    currentProfileId.value = profile.id;
+    KvHelper.profilePrefix = 'prof_${profile.id}_';
+    _saveCurrentProfileId();
+
+    if (autoStart) {
+      _writeGlobal(_kAutoStartProfileIdKey, profile.id);
+    }
+
+    await _reauthServices();
+
+    return profile;
+  }
+
+  Future<void> _reauthServices() async {
+    try {
+      final handler = Get.find<ServiceHandler>();
+      await handler.autoLogin();
+      await handler.fetchHomePage();
+      updateServiceBadges();
+    } catch (e) {
+      Logger.i('Error re-authenticating on profile switch: $e');
+    }
+  }
+
+  bool setPin(String profileId, String pin) {
+    if (pin.length < 4 || pin.length > 6) return false;
+    if (!RegExp(r'^\d+$').hasMatch(pin)) return false;
+
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    final bytes = utf8.encode(pin);
+    final hash = sha256.convert(bytes).toString();
+
+    _updateProfile(profile.copyWith(
+        pinHash: hash, failedPinAttempts: 0, lockedUntil: null));
+    return true;
+  }
+
+  bool removePin(String profileId) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    _updateProfile(
+        profile.copyWith(pinHash: null, failedPinAttempts: 0, lockedUntil: null));
+    return true;
+  }
+
+  bool? verifyPin(String profileId, String pin) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    if (profile.isLocked) return null;
+
+    final bytes = utf8.encode(pin);
+    final hash = sha256.convert(bytes).toString();
+
+    if (hash == profile.pinHash) {
+      _updateProfile(
+          profile.copyWith(failedPinAttempts: 0, lockedUntil: null));
+      return true;
+    } else {
+      final newAttempts = profile.failedPinAttempts + 1;
+      DateTime? lockedUntil;
+
+      if (newAttempts >= kMaxPinAttempts) {
+        lockedUntil =
+            DateTime.now().add(Duration(minutes: kLockoutMinutes));
+      }
+
+      _updateProfile(profile.copyWith(
+        failedPinAttempts: newAttempts,
+        lockedUntil: lockedUntil,
+      ));
+      return false;
+    }
+  }
+
+  void setAniListLinked(bool linked) {
+    if (currentProfile.value == null) return;
+    _updateProfile(currentProfile.value!.copyWith(anilistLinked: linked));
+  }
+
+  void setMALLinked(bool linked) {
+    if (currentProfile.value == null) return;
+    _updateProfile(currentProfile.value!.copyWith(malLinked: linked));
+  }
+
+  void setSimklLinked(bool linked) {
+    if (currentProfile.value == null) return;
+    _updateProfile(currentProfile.value!.copyWith(simklLinked: linked));
+  }
+
+  void updateServiceBadges() {
+    try {
+      if (!Get.isRegistered<AnilistAuth>()) return;
+      final anilistAuth = Get.find<AnilistAuth>();
+      setAniListLinked(anilistAuth.isLoggedIn.value);
+
+      if (!Get.isRegistered<MalService>()) return;
+      final malService = Get.find<MalService>();
+      setMALLinked(malService.isLoggedIn.value);
+
+      if (!Get.isRegistered<SimklService>()) return;
+      final simklService = Get.find<SimklService>();
+      setSimklLinked(simklService.isLoggedIn.value);
+    } catch (e) {
+      Logger.i('Error updating service badges: $e');
+    }
+  }
+
+  Future<bool> deleteProfile(String profileId, {String? currentId}) async {
+    if (profileId == currentId) return false;
+
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return false;
+
+    final prefix = 'prof_${profile.id}_';
+    try {
+      final col = isar.collection<KeyValue>();
+      final allKeys = col.where().findAllSync();
+      final toDelete =
+          allKeys.where((kv) => kv.key.startsWith(prefix)).toList();
+
+      isar.writeTxnSync(() {
+        for (final kv in toDelete) {
+          col.deleteSync(kv.id);
+        }
+      });
+    } catch (e) {
+      Logger.i('Error deleting profile KV data: $e');
+    }
+
+    profiles.removeWhere((p) => p.id == profileId);
+    _saveProfiles();
+
+    if (autoStartProfileId == profileId) {
+      _writeGlobal(_kAutoStartProfileIdKey, '');
+    }
+
+    return true;
+  }
+
+  void resetAutoStart() {
+    _writeGlobal(_kAutoStartProfileIdKey, '');
+  }
+
+  void _updateProfile(AppProfile updated) {
+    final index = profiles.indexWhere((p) => p.id == updated.id);
+    if (index == -1) return;
+
+    profiles[index] = updated;
+    if (currentProfile.value?.id == updated.id) {
+      currentProfile.value = updated;
+    }
+    _saveProfiles();
+  }
+
+  void updateProfileName(String profileId, String newName) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return;
+    _updateProfile(profile.copyWith(name: newName));
+  }
+
+  void updateProfileAvatar(String profileId, String avatarPath) {
+    final profile = profiles.firstWhereOrNull((p) => p.id == profileId);
+    if (profile == null) return;
+    _updateProfile(profile.copyWith(avatarPath: avatarPath));
+  }
+
+  static String? _readGlobal(String key) {
+    try {
+      final col = isar.collection<KeyValue>();
+      final result = col.filter().keyEqualTo(key).findFirstSync();
+      if (result?.value == null) return null;
+      return jsonDecode(result!.value!)['val'] as String?;
+    } catch (e) {
+      Logger.i('Error reading global KV $key: $e');
+      return null;
+    }
+  }
+
+  static void _writeGlobal(String key, String value) {
+    try {
+      final data = KeyValue()
+        ..key = key
+        ..value = jsonEncode({'val': value});
+
+      isar.writeTxnSync(() {
+        isar.collection<KeyValue>().putSync(data);
+      });
+    } catch (e) {
+      Logger.i('Error writing global KV $key: $e');
+    }
+  }
+}

--- a/lib/controllers/profile/profile_manager.dart
+++ b/lib/controllers/profile/profile_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/anilist/anilist_auth.dart';
 import 'package:anymex/controllers/services/mal/mal_service.dart';
@@ -7,6 +8,8 @@ import 'package:anymex/controllers/services/simkl/simkl_service.dart';
 import 'package:anymex/database/data_keys/keys.dart';
 import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/kv_helper.dart';
+import 'package:anymex/database/isar_models/custom_list.dart';
+import 'package:anymex/database/isar_models/offline_media.dart';
 import 'package:anymex/main.dart';
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/utils/logger.dart';
@@ -115,6 +118,10 @@ class ProfileManager extends GetxController {
     isProfileReady.value = true;
 
     _reauthServices();
+
+    if (Get.isRegistered<OfflineStorageController>()) {
+      Get.find<OfflineStorageController>().migrateOrphanedData();
+    }
 
     return profile;
   }
@@ -239,6 +246,31 @@ class ProfileManager extends GetxController {
       });
     } catch (e) {
       Logger.i('Error deleting profile KV data: $e');
+    }
+
+    final pid = profile.id;
+    try {
+      isar.writeTxnSync(() {
+        final mediaCol = isar.collection<OfflineMedia>();
+        final mediaToDelete = mediaCol
+            .filter()
+            .profileIdEqualTo(pid)
+            .findAllSync();
+        for (final m in mediaToDelete) {
+          mediaCol.deleteSync(m.id);
+        }
+
+        final listCol = isar.collection<CustomList>();
+        final listsToDelete = listCol
+            .filter()
+            .profileIdEqualTo(pid)
+            .findAllSync();
+        for (final l in listsToDelete) {
+          listCol.deleteSync(l.id);
+        }
+      });
+    } catch (e) {
+      Logger.i('Error deleting profile library data: $e');
     }
 
     profiles.removeWhere((p) => p.id == profileId);

--- a/lib/controllers/service_handler/service_handler.dart
+++ b/lib/controllers/service_handler/service_handler.dart
@@ -150,8 +150,6 @@ class ServiceHandler extends GetxController {
   @override
   void onReady() {
     super.onReady();
-    fetchHomePage();
-    autoLogin();
   }
 
   Future<void> fetchHomePage() => service.fetchHomePage();

--- a/lib/controllers/service_handler/service_handler.dart
+++ b/lib/controllers/service_handler/service_handler.dart
@@ -150,6 +150,8 @@ class ServiceHandler extends GetxController {
   @override
   void onReady() {
     super.onReady();
+    autoLogin();
+    fetchHomePage();
   }
 
   Future<void> fetchHomePage() => service.fetchHomePage();

--- a/lib/controllers/services/anilist/anilist_auth.dart
+++ b/lib/controllers/services/anilist/anilist_auth.dart
@@ -3,6 +3,7 @@
 import 'dart:convert';
 
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/service_handler/params.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/database/comments/comments_db.dart';
@@ -109,6 +110,7 @@ class AnilistAuth extends GetxController {
 
   Future<void> tryAutoLogin() async {
     isLoggedIn.value = false;
+    profileData.value = Profile();
     final token = AuthKeys.authToken.get<String?>();
     if (token != null) {
       await fetchUserProfile();
@@ -584,8 +586,13 @@ class AnilistAuth extends GetxController {
         Logger.i(
             'User profile fetched: ${userProfile.name} (ID: ${userProfile.id})');
 
-        // fetchFollowersAndFollowing(userProfile.id ?? '');
         CommentsDatabase().login();
+
+        try {
+          if (Get.isRegistered<ProfileManager>()) {
+            Get.find<ProfileManager>().updateServiceBadges();
+          }
+        } catch (_) {}
       } else if (response.statusCode == 403) {
         _handle403(response);
       } else {
@@ -2245,5 +2252,10 @@ class AnilistAuth extends GetxController {
     AuthKeys.authToken.delete();
     profileData.value = Profile();
     isLoggedIn.value = false;
+    try {
+      if (Get.isRegistered<ProfileManager>()) {
+        Get.find<ProfileManager>().updateServiceBadges();
+      }
+    } catch (_) {}
   }
 }

--- a/lib/controllers/services/backup_restore/backup_restore_service.dart
+++ b/lib/controllers/services/backup_restore/backup_restore_service.dart
@@ -8,6 +8,7 @@ import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/database/isar_models/custom_list.dart';
 import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/isar_models/offline_media.dart';
+import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/library/controller/library_controller.dart';
 import 'package:anymex/utils/logger.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
@@ -95,6 +96,11 @@ class BackupRestoreService extends GetxController {
       return backupSettings && _isCurrentProfileKey(e.key);
     }).map((e) => {'key': e.key, 'value': e.value}).toList();
 
+    AppProfile? profile;
+    if (Get.isRegistered<ProfileManager>()) {
+      profile = Get.find<ProfileManager>().currentProfile.value;
+    }
+
     return {
       'date': DateFormat('dd MM yyyy hh:mm a').format(DateTime.now()),
       'appVersion': '',
@@ -113,24 +119,49 @@ class BackupRestoreService extends GetxController {
       'settings': filteredSettings,
       'profilePrefix': KvHelper.profilePrefix,
       'profileId': _getCurrentPid(),
-      'profileName': Get.isRegistered<ProfileManager>()
-          ? Get.find<ProfileManager>().currentProfile.value?.name ?? ''
-          : '',
+      'profileName': profile?.name ?? '',
+      'profileData': profile?.toJson(),
+      'isMultiProfileEnabled': Get.isRegistered<ProfileManager>() &&
+          Get.find<ProfileManager>().isMultiProfileEnabled.value,
     };
   }
 
-  Future<void> _applyBackupData(Map<String, dynamic> data,
+  Future<String?> _applyBackupData(Map<String, dynamic> data,
       {bool merge = false,
       bool restoreSettings = true,
-      bool restoreAuthTokens = false}) async {
-    final currentPid = _getCurrentPid();
+      bool restoreAuthTokens = false,
+      bool createNewProfile = false}) async {
+    String? newProfileId;
+    String targetPid;
+
+    if (createNewProfile && Get.isRegistered<ProfileManager>()) {
+      final manager = Get.find<ProfileManager>();
+      final profileData = data['profileData'] as Map<String, dynamic>?;
+      final profileName = data['profileName'] as String? ?? 'Restored Profile';
+
+      final newProfile = manager.createProfile(name: profileName);
+      if (newProfile == null) {
+        throw Exception('Cannot create profile (max $kMaxProfiles reached)');
+      }
+      newProfileId = newProfile.id;
+
+      if (profileData != null) {
+        final restoredProfile = AppProfile.fromJson(profileData);
+        manager.restoreProfileFromBackup(newProfileId, restoredProfile);
+      }
+
+      targetPid = newProfileId;
+    } else {
+      targetPid = _getCurrentPid() ?? '';
+    }
+
     final backupPrefix = (data['profilePrefix'] as String?) ?? '';
 
     final animeList = (data['animeLibrary'] as List?)
             ?.map((e) {
               final media = OfflineMedia.fromJson(
                   (e as Map<String, dynamic>)..["mediaTypeIndex"] = 1);
-              media.profileId = currentPid;
+              media.profileId = targetPid;
               return media;
             })
             .toList() ??
@@ -140,7 +171,7 @@ class BackupRestoreService extends GetxController {
             ?.map((e) {
               final media = OfflineMedia.fromJson(
                   (e as Map<String, dynamic>)..["mediaTypeIndex"] = 0);
-              media.profileId = currentPid;
+              media.profileId = targetPid;
               return media;
             })
             .toList() ??
@@ -150,106 +181,110 @@ class BackupRestoreService extends GetxController {
             ?.map((e) {
               final media = OfflineMedia.fromJson(
                   (e as Map<String, dynamic>)..["mediaTypeIndex"] = 2);
-              media.profileId = currentPid;
+              media.profileId = targetPid;
               return media;
             })
             .toList() ??
         [];
 
-    await isar.writeTxn(() async {
+    final animeCustomLists = !merge
+        ? ((data['animeCustomLists'] as List?)
+                ?.map((e) {
+                  final list = CustomList.fromJson(
+                      (e as Map<String, dynamic>)..['mediaTypeIndex'] = 1);
+                  list.profileId = targetPid;
+                  return list;
+                })
+                .toList() ??
+            [])
+        : <CustomList>[];
+
+    final mangaCustomLists = !merge
+        ? ((data['mangaCustomLists'] as List?)
+                ?.map((e) {
+                  final list = CustomList.fromJson(
+                      (e as Map<String, dynamic>)..['mediaTypeIndex'] = 0);
+                  list.profileId = targetPid;
+                  return list;
+                })
+                .toList() ??
+            [])
+        : <CustomList>[];
+
+    final novelCustomLists = !merge
+        ? ((data['novelCustomLists'] as List?)
+                ?.map((e) {
+                  final list = CustomList.fromJson(
+                      (e as Map<String, dynamic>)..['mediaTypeIndex'] = 2);
+                  list.profileId = targetPid;
+                  return list;
+                })
+                .toList() ??
+            [])
+        : <CustomList>[];
+
+    final settingsList = data['settings'] as List? ?? [];
+
+    isar.writeTxnSync(() {
+      final mediaCol = isar.collection<OfflineMedia>();
+      final listCol = isar.collection<CustomList>();
+      final kvCol = isar.collection<KeyValue>();
+
       if (!merge) {
-        final mediaToDelete = isar.offlineMedias
+        final mediaToDelete = mediaCol
             .filter()
-            .profileIdEqualTo(currentPid)
+            .profileIdEqualTo(targetPid)
             .findAllSync();
         for (final m in mediaToDelete) {
-          await isar.offlineMedias.delete(m.id);
+          mediaCol.deleteSync(m.id);
         }
 
-        final listsToDelete = isar.customLists
+        final listsToDelete = listCol
             .filter()
-            .profileIdEqualTo(currentPid)
+            .profileIdEqualTo(targetPid)
             .findAllSync();
         for (final l in listsToDelete) {
-          await isar.customLists.delete(l.id);
+          listCol.deleteSync(l.id);
         }
       }
 
       if (merge) {
-        final existingIds = isar.offlineMedias
+        final existingIds = mediaCol
             .filter()
-            .profileIdEqualTo(currentPid)
+            .profileIdEqualTo(targetPid)
             .mediaIdProperty()
             .findAllSync();
 
         for (var anime in animeList) {
           if (!existingIds.contains(anime.mediaId)) {
-            await isar.offlineMedias.put(anime);
+            mediaCol.putSync(anime);
           }
         }
 
         for (var manga in mangaList) {
           if (!existingIds.contains(manga.mediaId)) {
-            await isar.offlineMedias.put(manga);
+            mediaCol.putSync(manga);
           }
         }
 
         for (var novel in novelList) {
           if (!existingIds.contains(novel.mediaId)) {
-            await isar.offlineMedias.put(novel);
+            mediaCol.putSync(novel);
           }
         }
       } else {
-        await isar.offlineMedias.putAll([
+        mediaCol.putAllSync([
           ...animeList,
           ...mangaList,
           ...novelList,
         ]);
-      }
-    });
-
-    if (!merge) {
-      final animeCustomLists = (data['animeCustomLists'] as List?)
-              ?.map((e) {
-                final list = CustomList.fromJson(
-                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 1);
-                list.profileId = currentPid;
-                return list;
-              })
-              .toList() ??
-          [];
-
-      final mangaCustomLists = (data['mangaCustomLists'] as List?)
-              ?.map((e) {
-                final list = CustomList.fromJson(
-                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 0);
-                list.profileId = currentPid;
-                return list;
-              })
-              .toList() ??
-          [];
-
-      final novelCustomLists = (data['novelCustomLists'] as List?)
-              ?.map((e) {
-                final list = CustomList.fromJson(
-                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 2);
-                list.profileId = currentPid;
-                return list;
-              })
-              .toList() ??
-          [];
-
-      await isar.writeTxn(() async {
-        await isar.customLists.putAll([
+        listCol.putAllSync([
           ...animeCustomLists,
           ...mangaCustomLists,
           ...novelCustomLists,
         ]);
-      });
-    }
+      }
 
-    final settingsList = data['settings'] as List? ?? [];
-    await isar.writeTxn(() async {
       for (var setting in settingsList) {
         final originalKey = setting['key'] as String?;
         if (originalKey == null) continue;
@@ -263,11 +298,17 @@ class BackupRestoreService extends GetxController {
         final kv = KeyValue()
           ..key = remappedKey
           ..value = setting['value'];
-        await isar.collection<KeyValue>().put(kv);
+        kvCol.putSync(kv);
       }
     });
 
     Get.delete<LibraryController>();
+
+    if (createNewProfile && newProfileId != null) {
+      await Get.find<ProfileManager>().switchToProfile(newProfileId);
+    }
+
+    return newProfileId;
   }
 
   String _encryptData(Map<String, dynamic> data, String password) {
@@ -423,7 +464,8 @@ class BackupRestoreService extends GetxController {
       {String? password,
       bool merge = false,
       bool restoreSettings = true,
-      bool restoreAuthTokens = false}) async {
+      bool restoreAuthTokens = false,
+      bool createNewProfile = false}) async {
     try {
       final file = File(filePath);
 
@@ -440,7 +482,8 @@ class BackupRestoreService extends GetxController {
       await _applyBackupData(data,
           merge: merge,
           restoreSettings: restoreSettings,
-          restoreAuthTokens: restoreAuthTokens);
+          restoreAuthTokens: restoreAuthTokens,
+          createNewProfile: createNewProfile);
 
       Logger.i('Backup restored successfully from: $filePath');
     } catch (e) {
@@ -527,6 +570,8 @@ class BackupRestoreService extends GetxController {
       final mangaCount = data['mangaCount'] ?? 0;
       final novelCount = data['novelCount'] ?? 0;
 
+      final profileData = data['profileData'] as Map<String, dynamic>?;
+
       return {
         'date': data['date'],
         'username': data['username'],
@@ -560,6 +605,11 @@ class BackupRestoreService extends GetxController {
         'profilePrefix': data['profilePrefix'] ?? '',
         'profileId': data['profileId'] ?? '',
         'profileName': data['profileName'] ?? '',
+        'profileData': profileData,
+        'hasProfileLock': profileData != null &&
+            (profileData['lockHash'] as String?)?.isNotEmpty == true,
+        'profileLockType': profileData?['lockType'] as String? ?? 'none',
+        'canCreateNewProfile': data['isMultiProfileEnabled'] == true,
       };
     } catch (e) {
       Logger.i('Failed to get backup info: $e');

--- a/lib/controllers/services/backup_restore/backup_restore_service.dart
+++ b/lib/controllers/services/backup_restore/backup_restore_service.dart
@@ -39,39 +39,31 @@ class BackupRestoreService extends GetxController {
     return digest.toString().substring(0, 32);
   }
 
-  /// Returns the current profile's ID derived from KvHelper.profilePrefix.
-  /// Matches the same logic as OfflineStorageController._pid.
   String? _getCurrentPid() {
     final prefix = KvHelper.profilePrefix;
     if (prefix.isEmpty) return null;
     return prefix.replaceAll('_', '');
   }
 
-  /// Checks if a KV key is global (e.g. __app_profiles__) — not scoped to any profile.
   bool _isGlobalKey(String key) {
     return key.startsWith('__') && key.endsWith('__');
   }
 
-  /// Checks if a KV key belongs to the current profile.
   bool _isCurrentProfileKey(String key) {
     if (_isGlobalKey(key)) return false;
     final prefix = KvHelper.profilePrefix;
-    if (prefix.isEmpty) return true; // Legacy non-profile key
+    if (prefix.isEmpty) return true;
     return key.startsWith(prefix);
   }
 
-  /// Remaps a profile-scoped KV key from an old profile prefix to the current one.
-  /// Global keys are returned unchanged. Legacy keys get the current prefix added.
   String _remapKey(String key, String backupPrefix) {
     if (_isGlobalKey(key)) return key;
     final currentPrefix = KvHelper.profilePrefix;
 
     if (backupPrefix.isNotEmpty && key.startsWith(backupPrefix)) {
-      // Strip old profile prefix, apply current profile prefix
       final suffix = key.substring(backupPrefix.length);
       return '$currentPrefix$suffix';
     } else {
-      // Legacy key without any prefix — add current prefix
       return '$currentPrefix$key';
     }
   }
@@ -106,13 +98,10 @@ class BackupRestoreService extends GetxController {
       (sum, list) => sum + (list.mediaIds?.length ?? 0),
     );
 
-    // Only include settings for the current profile + global keys.
-    // Other profiles' settings are excluded from the backup.
     final allSettings = isar.collection<KeyValue>().where().findAllSync();
     final filteredSettings = allSettings.where((e) {
       final isAuth = e.key.startsWith('AuthKeys_');
       if (isAuth) return backupAuthTokens;
-      // Only include current profile's keys and global keys
       return backupSettings && _isCurrentProfileKey(e.key);
     }).map((e) => {'key': e.key, 'value': e.value}).toList();
 
@@ -132,7 +121,6 @@ class BackupRestoreService extends GetxController {
       'mangaCustomLists': mangaCustomLists.map((e) => e.toJson()).toList(),
       'novelCustomLists': novelCustomLists.map((e) => e.toJson()).toList(),
       'settings': filteredSettings,
-      // Store the profile prefix so restore can remap keys correctly
       'profilePrefix': KvHelper.profilePrefix,
       'profileId': _getCurrentPid(),
     };
@@ -146,10 +134,7 @@ class BackupRestoreService extends GetxController {
       await _storageController.clearCache();
     }
 
-    // Get current profile's ID so restored media belongs to THIS profile
     final currentPid = _getCurrentPid();
-
-    // Get the backup's profile prefix for key remapping
     final backupPrefix = (data['profilePrefix'] as String?) ?? '';
 
     final animeList = (data['animeLibrary'] as List?)
@@ -250,19 +235,16 @@ class BackupRestoreService extends GetxController {
       });
     }
 
-    // Restore settings with key remapping for profile isolation
     final settingsList = data['settings'] as List? ?? [];
     await isar.writeTxn(() async {
       for (var setting in settingsList) {
         final originalKey = setting['key'] as String?;
         if (originalKey == null) continue;
 
-        // Skip AuthKeys if not requested
         final isAuth = originalKey.contains('AuthKeys_');
         if (isAuth && !restoreAuthTokens) continue;
         if (!isAuth && !restoreSettings) continue;
 
-        // Remap the key to use the current profile's prefix
         final remappedKey = _remapKey(originalKey, backupPrefix);
 
         final kv = KeyValue()

--- a/lib/controllers/services/backup_restore/backup_restore_service.dart
+++ b/lib/controllers/services/backup_restore/backup_restore_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/database/isar_models/custom_list.dart';
 import 'package:anymex/database/isar_models/key_value.dart';
 import 'package:anymex/database/isar_models/offline_media.dart';
@@ -38,6 +39,43 @@ class BackupRestoreService extends GetxController {
     return digest.toString().substring(0, 32);
   }
 
+  /// Returns the current profile's ID derived from KvHelper.profilePrefix.
+  /// Matches the same logic as OfflineStorageController._pid.
+  String? _getCurrentPid() {
+    final prefix = KvHelper.profilePrefix;
+    if (prefix.isEmpty) return null;
+    return prefix.replaceAll('_', '');
+  }
+
+  /// Checks if a KV key is global (e.g. __app_profiles__) — not scoped to any profile.
+  bool _isGlobalKey(String key) {
+    return key.startsWith('__') && key.endsWith('__');
+  }
+
+  /// Checks if a KV key belongs to the current profile.
+  bool _isCurrentProfileKey(String key) {
+    if (_isGlobalKey(key)) return false;
+    final prefix = KvHelper.profilePrefix;
+    if (prefix.isEmpty) return true; // Legacy non-profile key
+    return key.startsWith(prefix);
+  }
+
+  /// Remaps a profile-scoped KV key from an old profile prefix to the current one.
+  /// Global keys are returned unchanged. Legacy keys get the current prefix added.
+  String _remapKey(String key, String backupPrefix) {
+    if (_isGlobalKey(key)) return key;
+    final currentPrefix = KvHelper.profilePrefix;
+
+    if (backupPrefix.isNotEmpty && key.startsWith(backupPrefix)) {
+      // Strip old profile prefix, apply current profile prefix
+      final suffix = key.substring(backupPrefix.length);
+      return '$currentPrefix$suffix';
+    } else {
+      // Legacy key without any prefix — add current prefix
+      return '$currentPrefix$key';
+    }
+  }
+
   Future<Map<String, dynamic>> _buildBackupData({
     bool backupSettings = true,
     bool backupAuthTokens = false,
@@ -68,6 +106,16 @@ class BackupRestoreService extends GetxController {
       (sum, list) => sum + (list.mediaIds?.length ?? 0),
     );
 
+    // Only include settings for the current profile + global keys.
+    // Other profiles' settings are excluded from the backup.
+    final allSettings = isar.collection<KeyValue>().where().findAllSync();
+    final filteredSettings = allSettings.where((e) {
+      final isAuth = e.key.startsWith('AuthKeys_');
+      if (isAuth) return backupAuthTokens;
+      // Only include current profile's keys and global keys
+      return backupSettings && _isCurrentProfileKey(e.key);
+    }).map((e) => {'key': e.key, 'value': e.value}).toList();
+
     return {
       'date': DateFormat('dd MM yyyy hh:mm a').format(DateTime.now()),
       'appVersion': '',
@@ -83,16 +131,10 @@ class BackupRestoreService extends GetxController {
       'animeCustomLists': animeCustomLists.map((e) => e.toJson()).toList(),
       'mangaCustomLists': mangaCustomLists.map((e) => e.toJson()).toList(),
       'novelCustomLists': novelCustomLists.map((e) => e.toJson()).toList(),
-      'settings': isar.collection<KeyValue>()
-          .where()
-          .findAllSync()
-          .where((e) {
-            final isAuth = e.key?.startsWith('AuthKeys_') ?? false;
-            if (isAuth) return backupAuthTokens;
-            return backupSettings;
-          })
-          .map((e) => {'key': e.key, 'value': e.value})
-          .toList(),
+      'settings': filteredSettings,
+      // Store the profile prefix so restore can remap keys correctly
+      'profilePrefix': KvHelper.profilePrefix,
+      'profileId': _getCurrentPid(),
     };
   }
 
@@ -104,21 +146,39 @@ class BackupRestoreService extends GetxController {
       await _storageController.clearCache();
     }
 
+    // Get current profile's ID so restored media belongs to THIS profile
+    final currentPid = _getCurrentPid();
+
+    // Get the backup's profile prefix for key remapping
+    final backupPrefix = (data['profilePrefix'] as String?) ?? '';
+
     final animeList = (data['animeLibrary'] as List?)
-            ?.map((e) => OfflineMedia.fromJson(
-                (e as Map<String, dynamic>)..["mediaTypeIndex"] = 1))
+            ?.map((e) {
+              final media = OfflineMedia.fromJson(
+                  (e as Map<String, dynamic>)..["mediaTypeIndex"] = 1);
+              media.profileId = currentPid;
+              return media;
+            })
             .toList() ??
         [];
 
     final mangaList = (data['mangaLibrary'] as List?)
-            ?.map((e) => OfflineMedia.fromJson(
-                (e as Map<String, dynamic>)..["mediaTypeIndex"] = 0))
+            ?.map((e) {
+              final media = OfflineMedia.fromJson(
+                  (e as Map<String, dynamic>)..["mediaTypeIndex"] = 0);
+              media.profileId = currentPid;
+              return media;
+            })
             .toList() ??
         [];
 
     final novelList = (data['novelLibrary'] as List?)
-            ?.map((e) => OfflineMedia.fromJson(
-                (e as Map<String, dynamic>)..["mediaTypeIndex"] = 2))
+            ?.map((e) {
+              final media = OfflineMedia.fromJson(
+                  (e as Map<String, dynamic>)..["mediaTypeIndex"] = 2);
+              media.profileId = currentPid;
+              return media;
+            })
             .toList() ??
         [];
 
@@ -152,20 +212,32 @@ class BackupRestoreService extends GetxController {
 
     if (!merge) {
       final animeCustomLists = (data['animeCustomLists'] as List?)
-              ?.map((e) => CustomList.fromJson(
-                  (e as Map<String, dynamic>)..['mediaTypeIndex'] = 1))
+              ?.map((e) {
+                final list = CustomList.fromJson(
+                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 1);
+                list.profileId = currentPid;
+                return list;
+              })
               .toList() ??
           [];
 
       final mangaCustomLists = (data['mangaCustomLists'] as List?)
-              ?.map((e) => CustomList.fromJson(
-                  (e as Map<String, dynamic>)..['mediaTypeIndex'] = 0))
+              ?.map((e) {
+                final list = CustomList.fromJson(
+                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 0);
+                list.profileId = currentPid;
+                return list;
+              })
               .toList() ??
           [];
 
       final novelCustomLists = (data['novelCustomLists'] as List?)
-              ?.map((e) => CustomList.fromJson(
-                  (e as Map<String, dynamic>)..['mediaTypeIndex'] = 2))
+              ?.map((e) {
+                final list = CustomList.fromJson(
+                    (e as Map<String, dynamic>)..['mediaTypeIndex'] = 2);
+                list.profileId = currentPid;
+                return list;
+              })
               .toList() ??
           [];
 
@@ -178,18 +250,23 @@ class BackupRestoreService extends GetxController {
       });
     }
 
+    // Restore settings with key remapping for profile isolation
     final settingsList = data['settings'] as List? ?? [];
     await isar.writeTxn(() async {
       for (var setting in settingsList) {
-        final key = setting['key'] as String?;
-        if (key == null) continue;
+        final originalKey = setting['key'] as String?;
+        if (originalKey == null) continue;
 
-        final isAuth = key.startsWith('AuthKeys_');
+        // Skip AuthKeys if not requested
+        final isAuth = originalKey.contains('AuthKeys_');
         if (isAuth && !restoreAuthTokens) continue;
         if (!isAuth && !restoreSettings) continue;
 
+        // Remap the key to use the current profile's prefix
+        final remappedKey = _remapKey(originalKey, backupPrefix);
+
         final kv = KeyValue()
-          ..key = key
+          ..key = remappedKey
           ..value = setting['value'];
         await isar.collection<KeyValue>().put(kv);
       }
@@ -485,6 +562,8 @@ class BackupRestoreService extends GetxController {
         'hasAuthTokens': (data['settings'] as List?)?.any((e) =>
                 (e['key'] as String? ?? '').startsWith('AuthKeys_')) ??
             false,
+        'profilePrefix': data['profilePrefix'] ?? '',
+        'profileId': data['profileId'] ?? '',
       };
     } catch (e) {
       Logger.i('Failed to get backup info: $e');

--- a/lib/controllers/services/backup_restore/backup_restore_service.dart
+++ b/lib/controllers/services/backup_restore/backup_restore_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/database/isar_models/custom_list.dart';
@@ -42,7 +43,7 @@ class BackupRestoreService extends GetxController {
   String? _getCurrentPid() {
     final prefix = KvHelper.profilePrefix;
     if (prefix.isEmpty) return null;
-    return prefix.replaceAll('_', '');
+    return prefix.substring(0, prefix.length - 1);
   }
 
   bool _isGlobalKey(String key) {
@@ -83,20 +84,9 @@ class BackupRestoreService extends GetxController {
     final mangaLibrary = await _storageController.getMangaLibrary();
     final novelLibrary = await _storageController.getNovelLibrary();
 
-    final animeCount = animeCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
-
-    final mangaCount = mangaCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
-
-    final novelCount = novelCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
+    final animeCount = animeLibrary.length;
+    final mangaCount = mangaLibrary.length;
+    final novelCount = novelLibrary.length;
 
     final allSettings = isar.collection<KeyValue>().where().findAllSync();
     final filteredSettings = allSettings.where((e) {
@@ -123,6 +113,9 @@ class BackupRestoreService extends GetxController {
       'settings': filteredSettings,
       'profilePrefix': KvHelper.profilePrefix,
       'profileId': _getCurrentPid(),
+      'profileName': Get.isRegistered<ProfileManager>()
+          ? Get.find<ProfileManager>().currentProfile.value?.name ?? ''
+          : '',
     };
   }
 
@@ -130,10 +123,6 @@ class BackupRestoreService extends GetxController {
       {bool merge = false,
       bool restoreSettings = true,
       bool restoreAuthTokens = false}) async {
-    if (!merge) {
-      await _storageController.clearCache();
-    }
-
     final currentPid = _getCurrentPid();
     final backupPrefix = (data['profilePrefix'] as String?) ?? '';
 
@@ -168,21 +157,45 @@ class BackupRestoreService extends GetxController {
         [];
 
     await isar.writeTxn(() async {
+      if (!merge) {
+        final mediaToDelete = isar.offlineMedias
+            .filter()
+            .profileIdEqualTo(currentPid)
+            .findAllSync();
+        for (final m in mediaToDelete) {
+          await isar.offlineMedias.delete(m.id);
+        }
+
+        final listsToDelete = isar.customLists
+            .filter()
+            .profileIdEqualTo(currentPid)
+            .findAllSync();
+        for (final l in listsToDelete) {
+          await isar.customLists.delete(l.id);
+        }
+      }
+
       if (merge) {
+        final existingIds = isar.offlineMedias
+            .filter()
+            .profileIdEqualTo(currentPid)
+            .mediaIdProperty()
+            .findAllSync();
+
         for (var anime in animeList) {
-          if (_storageController.getMediaById(anime.mediaId ?? '') == null) {
+          if (!existingIds.contains(anime.mediaId)) {
             await isar.offlineMedias.put(anime);
           }
         }
 
         for (var manga in mangaList) {
-          if (_storageController.getMediaById(manga.mediaId ?? '') == null) {
+          if (!existingIds.contains(manga.mediaId)) {
             await isar.offlineMedias.put(manga);
           }
         }
 
         for (var novel in novelList) {
-          if (_storageController.getMediaById(novel.mediaId ?? '') == null) {
+          if (!existingIds.contains(novel.mediaId)) {
             await isar.offlineMedias.put(novel);
           }
         }
@@ -546,6 +559,7 @@ class BackupRestoreService extends GetxController {
             false,
         'profilePrefix': data['profilePrefix'] ?? '',
         'profileId': data['profileId'] ?? '',
+        'profileName': data['profileName'] ?? '',
       };
     } catch (e) {
       Logger.i('Failed to get backup info: $e');
@@ -570,6 +584,10 @@ class BackupRestoreService extends GetxController {
   }
 
   Future<Map<String, dynamic>> getLibraryStats() async {
+    final animeLibrary = await _storageController.getAnimeLibrary();
+    final mangaLibrary = await _storageController.getMangaLibrary();
+    final novelLibrary = await _storageController.getNovelLibrary();
+
     final animeCustomLists =
         await _storageController.getCustomListsByType(ItemType.anime);
     final mangaCustomLists =
@@ -577,29 +595,10 @@ class BackupRestoreService extends GetxController {
     final novelCustomLists =
         await _storageController.getCustomListsByType(ItemType.novel);
 
-    final animeCount = animeCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
-
-    final mangaCount = mangaCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
-
-    final novelCount = novelCustomLists.fold<int>(
-      0,
-      (sum, list) => sum + (list.mediaIds?.length ?? 0),
-    );
-
-    final animeLibrary = await _storageController.getAnimeLibrary();
-    final mangaLibrary = await _storageController.getMangaLibrary();
-    final novelLibrary = await _storageController.getNovelLibrary();
-
     return {
-      'animeCount': animeCount,
-      'mangaCount': mangaCount,
-      'novelCount': novelCount,
+      'animeCount': animeLibrary.length,
+      'mangaCount': mangaLibrary.length,
+      'novelCount': novelLibrary.length,
       'totalMedia':
           animeLibrary.length + mangaLibrary.length + novelLibrary.length,
       'animeCustomLists': animeCustomLists.length,

--- a/lib/controllers/services/mal/mal_service.dart
+++ b/lib/controllers/services/mal/mal_service.dart
@@ -407,6 +407,8 @@ class MalService extends GetxController implements BaseService, OnlineService {
 
   @override
   Future<void> autoLogin() async {
+    isLoggedIn.value = false;
+    profileData.value = Profile();
     try {
       final token = AuthKeys.malAuthToken.get<String?>();
       final refreshToken = AuthKeys.malRefreshToken.get<String?>();

--- a/lib/controllers/services/mal/mal_service.dart
+++ b/lib/controllers/services/mal/mal_service.dart
@@ -3,6 +3,7 @@ import 'dart:math' show Random;
 
 import 'package:anymex/controllers/cacher/cache_controller.dart';
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/service_handler/params.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/widgets/widgets_builders.dart';
@@ -402,6 +403,11 @@ class MalService extends GetxController implements BaseService, OnlineService {
         auth: true, useAuthHeader: true, token: tokenn);
     profileData.value = Profile.fromKitsu(data);
     isLoggedIn.value = true;
+    try {
+      if (Get.isRegistered<ProfileManager>()) {
+        Get.find<ProfileManager>().updateServiceBadges();
+      }
+    } catch (_) {}
     Future.wait([fetchUserAnimeList(), fetchUserMangaList()]);
   }
 
@@ -816,10 +822,13 @@ class MalService extends GetxController implements BaseService, OnlineService {
     AuthKeys.malSessionId.delete();
     isLoggedIn.value = false;
     profileData.value = Profile();
-    // animeList.value = [];
-    // mangaList.value = [];
     continueWatching.value = [];
     continueReading.value = [];
+    try {
+      if (Get.isRegistered<ProfileManager>()) {
+        Get.find<ProfileManager>().updateServiceBadges();
+      }
+    } catch (_) {}
   }
 
   @override

--- a/lib/controllers/services/simkl/simkl_service.dart
+++ b/lib/controllers/services/simkl/simkl_service.dart
@@ -798,6 +798,8 @@ class SimklService extends GetxController
 
   @override
   Future<void> autoLogin() async {
+    isLoggedIn.value = false;
+    profileData.value = Profile();
     final token = AuthKeys.simklAuthToken.get<String?>();
     if (token != null) {
       await fetchUserInfo();

--- a/lib/controllers/services/simkl/simkl_service.dart
+++ b/lib/controllers/services/simkl/simkl_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:anymex/controllers/cacher/cache_controller.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/service_handler/params.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/community_service.dart';
@@ -739,6 +740,11 @@ class SimklService extends GetxController
               mangaStats: MangaStats(
                   mangaCount:
                       stats['tv']?['completed']?['count']?.toString())));
+      try {
+        if (Get.isRegistered<ProfileManager>()) {
+          Get.find<ProfileManager>().updateServiceBadges();
+        }
+      } catch (_) {}
       fetchUserMovieList();
       fetchUserSeriesList();
     } else {
@@ -794,6 +800,11 @@ class SimklService extends GetxController
     AuthKeys.simklAuthToken.delete();
     isLoggedIn.value = false;
     profileData.value = Profile();
+    try {
+      if (Get.isRegistered<ProfileManager>()) {
+        Get.find<ProfileManager>().updateServiceBadges();
+      }
+    } catch (_) {}
   }
 
   @override

--- a/lib/controllers/services/storage/storage_manager_service.dart
+++ b/lib/controllers/services/storage/storage_manager_service.dart
@@ -2,7 +2,13 @@ import 'dart:io';
 
 import 'package:anymex/controllers/services/storage/anymex_cache_manager.dart';
 import 'package:anymex/database/data_keys/keys.dart';
+import 'package:anymex/database/isar_models/custom_list.dart';
+import 'package:anymex/database/isar_models/key_value.dart';
+import 'package:anymex/database/isar_models/offline_media.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/main.dart';
+import 'package:isar_community/isar.dart';
+import 'package:anymex/utils/logger.dart';
 import 'package:flutter/painting.dart';
 
 class StorageManagerService {
@@ -53,9 +59,46 @@ class StorageManagerService {
   }
 
   Future<void> factoryResetIsar() async {
-    await isar.writeTxn(() async {
-      await isar.clear();
-    });
+    try {
+      final prefix = KvHelper.profilePrefix;
+      final pid = prefix.isNotEmpty
+          ? prefix.substring(0, prefix.length - 1)
+          : null;
+
+      isar.writeTxnSync(() {
+        if (pid != null) {
+          final mediaToDelete = isar.offlineMedias
+              .filter()
+              .profileIdEqualTo(pid)
+              .findAllSync();
+          for (final m in mediaToDelete) {
+            isar.offlineMedias.deleteSync(m.id);
+          }
+
+          final listsToDelete = isar.customLists
+              .filter()
+              .profileIdEqualTo(pid)
+              .findAllSync();
+          for (final l in listsToDelete) {
+            isar.customLists.deleteSync(l.id);
+          }
+
+          final allKeys =
+              isar.collection<KeyValue>().where().findAllSync();
+          final toDelete = allKeys
+              .where((kv) => kv.key.startsWith(prefix))
+              .toList();
+          for (final kv in toDelete) {
+            isar.collection<KeyValue>().deleteSync(kv.id);
+          }
+        } else {
+          isar.clearSync();
+        }
+      });
+    } catch (e) {
+      Logger.i('Error during profile data reset: $e');
+      rethrow;
+    }
   }
 
   String formatBytes(int bytes) {

--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -179,6 +179,34 @@ class Settings extends GetxController {
     DownloadKeys.enableJxlCompression.set(value);
   }
 
+  void reloadForProfile() {
+    playerSettings = Rx<PlayerSettings>(PlayerSettings.fromDB());
+    uiSettings = Rx<UISettings>(UISettings.fromDB());
+    uiSettings.value.normalizeMaps();
+
+    selectedShader = PlayerUiKeys.selectedShaderLegacy.get<String>("");
+    selectedProfile = PlayerUiKeys.selectedProfile.get<String>("MID-END");
+    playerControlThemeRx.value =
+        PlayerUiKeys.playerControlTheme.get<String>('default');
+    mediaIndicatorThemeRx.value =
+        PlayerUiKeys.mediaIndicatorTheme.get<String>('default');
+    readerControlThemeRx.value =
+        ReaderKeys.readerControlTheme.get<String>('default');
+
+    enableBetaUpdates.value = General.enableBetaUpdates.get<bool>(false);
+    writeLogToFile.value = General.writeLogToFile.get<bool>(false);
+    customLogDirectory.value = General.customLogDirectory.get<String>("");
+
+    downloadPath.value = DownloadKeys.downloadPath.get<String>("");
+    concurrentDownloads.value = DownloadKeys.concurrentDownloads.get<int>(3);
+    downloadChunks.value = DownloadKeys.downloadChunks.get<int>(1);
+    hlsParallelSegments.value = DownloadKeys.hlsParallelSegments.get<int>(3);
+    enableJxlCompression.value = DownloadKeys.enableJxlCompression.get<bool>(false);
+
+    Logger.setFileLoggingEnabled(writeLogToFile.value,
+        customPath: customLogDirectory.value);
+  }
+
   void showWelcomeDialog(BuildContext context) {
     if (General.isFirstTime.get<bool>(true)) {
       showWelcomeDialogg(context);

--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -157,7 +157,7 @@ class Settings extends GetxController {
     _updateBridgeDispatcher();
   }
 
-  void saveDownloadPath(String value) {
+  bool saveDownloadPath(String value) {
     if (value.isNotEmpty) {
       try {
         final manager = Get.find<ProfileManager>();
@@ -169,8 +169,7 @@ class Settings extends GetxController {
           final otherPath = DownloadKeys.downloadPath.get<String>('');
           if (otherPath.isNotEmpty && otherPath == value) {
             KvHelper.profilePrefix = savedPrefix;
-            snackBar('Folder already used by "${profile.name}"');
-            return;
+            return false;
           }
         }
         KvHelper.profilePrefix = savedPrefix;
@@ -178,6 +177,7 @@ class Settings extends GetxController {
     }
     downloadPath.value = value;
     DownloadKeys.downloadPath.set(value);
+    return true;
   }
 
   void saveConcurrentDownloads(int value) {

--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/database/data_keys/keys.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/models/player/player_adaptor.dart';
 import 'package:anymex/models/ui/ui_adaptor.dart';
 import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
@@ -11,6 +13,7 @@ import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/logger.dart';
 import 'package:anymex/utils/shaders.dart';
 import 'package:anymex/utils/updater.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
@@ -155,6 +158,24 @@ class Settings extends GetxController {
   }
 
   void saveDownloadPath(String value) {
+    if (value.isNotEmpty) {
+      try {
+        final manager = Get.find<ProfileManager>();
+        final currentId = manager.currentProfileId.value;
+        final savedPrefix = KvHelper.profilePrefix;
+        for (final profile in manager.profiles) {
+          if (profile.id == currentId) continue;
+          KvHelper.profilePrefix = '${profile.id}_';
+          final otherPath = DownloadKeys.downloadPath.get<String>('');
+          if (otherPath.isNotEmpty && otherPath == value) {
+            KvHelper.profilePrefix = savedPrefix;
+            snackBar('Folder already used by "${profile.name}"');
+            return;
+          }
+        }
+        KvHelper.profilePrefix = savedPrefix;
+      } catch (_) {}
+    }
     downloadPath.value = value;
     DownloadKeys.downloadPath.set(value);
   }

--- a/lib/database/isar_models/chapter.g.dart
+++ b/lib/database/isar_models/chapter.g.dart
@@ -38,43 +38,48 @@ const ChapterSchema = Schema(
       name: r'link',
       type: IsarType.string,
     ),
-    r'maxOffset': PropertySchema(
+    r'localPath': PropertySchema(
       id: 5,
+      name: r'localPath',
+      type: IsarType.string,
+    ),
+    r'maxOffset': PropertySchema(
+      id: 6,
       name: r'maxOffset',
       type: IsarType.double,
     ),
     r'number': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'number',
       type: IsarType.double,
     ),
     r'pageNumber': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'pageNumber',
       type: IsarType.long,
     ),
     r'releaseDate': PropertySchema(
-      id: 8,
+      id: 9,
       name: r'releaseDate',
       type: IsarType.string,
     ),
     r'scanlator': PropertySchema(
-      id: 9,
+      id: 10,
       name: r'scanlator',
       type: IsarType.string,
     ),
     r'sourceName': PropertySchema(
-      id: 10,
+      id: 11,
       name: r'sourceName',
       type: IsarType.string,
     ),
     r'title': PropertySchema(
-      id: 11,
+      id: 12,
       name: r'title',
       type: IsarType.string,
     ),
     r'totalPages': PropertySchema(
-      id: 12,
+      id: 13,
       name: r'totalPages',
       type: IsarType.long,
     )
@@ -122,6 +127,12 @@ int _chapterEstimateSize(
     }
   }
   {
+    final value = object.localPath;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.releaseDate;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -159,14 +170,15 @@ void _chapterSerialize(
   writer.writeStringList(offsets[2], object.headerValues);
   writer.writeLong(offsets[3], object.lastReadTime);
   writer.writeString(offsets[4], object.link);
-  writer.writeDouble(offsets[5], object.maxOffset);
-  writer.writeDouble(offsets[6], object.number);
-  writer.writeLong(offsets[7], object.pageNumber);
-  writer.writeString(offsets[8], object.releaseDate);
-  writer.writeString(offsets[9], object.scanlator);
-  writer.writeString(offsets[10], object.sourceName);
-  writer.writeString(offsets[11], object.title);
-  writer.writeLong(offsets[12], object.totalPages);
+  writer.writeString(offsets[5], object.localPath);
+  writer.writeDouble(offsets[6], object.maxOffset);
+  writer.writeDouble(offsets[7], object.number);
+  writer.writeLong(offsets[8], object.pageNumber);
+  writer.writeString(offsets[9], object.releaseDate);
+  writer.writeString(offsets[10], object.scanlator);
+  writer.writeString(offsets[11], object.sourceName);
+  writer.writeString(offsets[12], object.title);
+  writer.writeLong(offsets[13], object.totalPages);
 }
 
 Chapter _chapterDeserialize(
@@ -181,14 +193,15 @@ Chapter _chapterDeserialize(
     headerValues: reader.readStringList(offsets[2]),
     lastReadTime: reader.readLongOrNull(offsets[3]),
     link: reader.readStringOrNull(offsets[4]),
-    maxOffset: reader.readDoubleOrNull(offsets[5]),
-    number: reader.readDoubleOrNull(offsets[6]),
-    pageNumber: reader.readLongOrNull(offsets[7]),
-    releaseDate: reader.readStringOrNull(offsets[8]),
-    scanlator: reader.readStringOrNull(offsets[9]),
-    sourceName: reader.readStringOrNull(offsets[10]),
-    title: reader.readStringOrNull(offsets[11]),
-    totalPages: reader.readLongOrNull(offsets[12]),
+    localPath: reader.readStringOrNull(offsets[5]),
+    maxOffset: reader.readDoubleOrNull(offsets[6]),
+    number: reader.readDoubleOrNull(offsets[7]),
+    pageNumber: reader.readLongOrNull(offsets[8]),
+    releaseDate: reader.readStringOrNull(offsets[9]),
+    scanlator: reader.readStringOrNull(offsets[10]),
+    sourceName: reader.readStringOrNull(offsets[11]),
+    title: reader.readStringOrNull(offsets[12]),
+    totalPages: reader.readLongOrNull(offsets[13]),
   );
   return object;
 }
@@ -211,13 +224,13 @@ P _chapterDeserializeProp<P>(
     case 4:
       return (reader.readStringOrNull(offset)) as P;
     case 5:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 6:
       return (reader.readDoubleOrNull(offset)) as P;
     case 7:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 8:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 9:
       return (reader.readStringOrNull(offset)) as P;
     case 10:
@@ -225,6 +238,8 @@ P _chapterDeserializeProp<P>(
     case 11:
       return (reader.readStringOrNull(offset)) as P;
     case 12:
+      return (reader.readStringOrNull(offset)) as P;
+    case 13:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -1003,6 +1018,152 @@ extension ChapterQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'link',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'localPath',
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'localPath',
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'localPath',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'localPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'localPath',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localPath',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> localPathIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'localPath',
         value: '',
       ));
     });

--- a/lib/database/isar_models/custom_list.dart
+++ b/lib/database/isar_models/custom_list.dart
@@ -7,6 +7,9 @@ class CustomList {
   Id id = Isar.autoIncrement;
 
   @Index()
+  String? profileId;
+
+  @Index()
   String? listName;
 
   List<String>? mediaIds;
@@ -14,6 +17,7 @@ class CustomList {
   int mediaTypeIndex;
 
   CustomList({
+    this.profileId,
     this.listName = "Default",
     this.mediaIds,
     this.mediaTypeIndex = 0,
@@ -21,6 +25,7 @@ class CustomList {
 
   Map<String, dynamic> toJson() {
     return {
+      'profileId': profileId,
       'listName': listName,
       'mediaIds': mediaIds,
       'mediaTypeIndex': mediaTypeIndex,
@@ -29,6 +34,7 @@ class CustomList {
 
   factory CustomList.fromJson(Map<String, dynamic> json) {
     return CustomList(
+      profileId: json['profileId'] as String?,
       listName: json['listName'] as String? ?? "Default",
       mediaIds: (json['mediaIds'] as List<dynamic>?)?.cast<String>(),
       mediaTypeIndex: json['mediaTypeIndex'] as int? ?? 0,

--- a/lib/database/isar_models/custom_list.g.dart
+++ b/lib/database/isar_models/custom_list.g.dart
@@ -31,6 +31,11 @@ const CustomListSchema = CollectionSchema(
       id: 2,
       name: r'mediaTypeIndex',
       type: IsarType.long,
+    ),
+    r'profileId': PropertySchema(
+      id: 3,
+      name: r'profileId',
+      type: IsarType.string,
     )
   },
   estimateSize: _customListEstimateSize,
@@ -39,6 +44,19 @@ const CustomListSchema = CollectionSchema(
   deserializeProp: _customListDeserializeProp,
   idName: r'id',
   indexes: {
+    r'profileId': IndexSchema(
+      id: 6052971939042612300,
+      name: r'profileId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'profileId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    ),
     r'listName': IndexSchema(
       id: -9160894145738258075,
       name: r'listName',
@@ -85,6 +103,12 @@ int _customListEstimateSize(
       }
     }
   }
+  {
+    final value = object.profileId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
   return bytesCount;
 }
 
@@ -97,6 +121,7 @@ void _customListSerialize(
   writer.writeString(offsets[0], object.listName);
   writer.writeStringList(offsets[1], object.mediaIds);
   writer.writeLong(offsets[2], object.mediaTypeIndex);
+  writer.writeString(offsets[3], object.profileId);
 }
 
 CustomList _customListDeserialize(
@@ -109,6 +134,7 @@ CustomList _customListDeserialize(
     listName: reader.readStringOrNull(offsets[0]),
     mediaIds: reader.readStringList(offsets[1]),
     mediaTypeIndex: reader.readLongOrNull(offsets[2]) ?? 0,
+    profileId: reader.readStringOrNull(offsets[3]),
   );
   object.id = id;
   return object;
@@ -127,6 +153,8 @@ P _customListDeserializeProp<P>(
       return (reader.readStringList(offset)) as P;
     case 2:
       return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 3:
+      return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
@@ -217,6 +245,71 @@ extension CustomListQueryWhere
         upper: upperId,
         includeUpper: includeUpper,
       ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterWhereClause> profileIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'profileId',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterWhereClause> profileIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'profileId',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterWhereClause> profileIdEqualTo(
+      String? profileId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'profileId',
+        value: [profileId],
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterWhereClause> profileIdNotEqualTo(
+      String? profileId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [],
+              upper: [profileId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [profileId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [profileId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [],
+              upper: [profileId],
+              includeUpper: false,
+            ));
+      }
     });
   }
 
@@ -789,6 +882,158 @@ extension CustomListQueryFilter
       ));
     });
   }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'profileId',
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'profileId',
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'profileId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition> profileIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'profileId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'profileId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterFilterCondition>
+      profileIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'profileId',
+        value: '',
+      ));
+    });
+  }
 }
 
 extension CustomListQueryObject
@@ -821,6 +1066,18 @@ extension CustomListQuerySortBy
       sortByMediaTypeIndexDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'mediaTypeIndex', Sort.desc);
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterSortBy> sortByProfileId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterSortBy> sortByProfileIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.desc);
     });
   }
 }
@@ -863,6 +1120,18 @@ extension CustomListQuerySortThenBy
       return query.addSortBy(r'mediaTypeIndex', Sort.desc);
     });
   }
+
+  QueryBuilder<CustomList, CustomList, QAfterSortBy> thenByProfileId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QAfterSortBy> thenByProfileIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.desc);
+    });
+  }
 }
 
 extension CustomListQueryWhereDistinct
@@ -883,6 +1152,13 @@ extension CustomListQueryWhereDistinct
   QueryBuilder<CustomList, CustomList, QDistinct> distinctByMediaTypeIndex() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'mediaTypeIndex');
+    });
+  }
+
+  QueryBuilder<CustomList, CustomList, QDistinct> distinctByProfileId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'profileId', caseSensitive: caseSensitive);
     });
   }
 }
@@ -910,6 +1186,12 @@ extension CustomListQueryProperty
   QueryBuilder<CustomList, int, QQueryOperations> mediaTypeIndexProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'mediaTypeIndex');
+    });
+  }
+
+  QueryBuilder<CustomList, String?, QQueryOperations> profileIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'profileId');
     });
   }
 }

--- a/lib/database/isar_models/episode.g.dart
+++ b/lib/database/isar_models/episode.g.dart
@@ -49,28 +49,38 @@ const EpisodeSchema = Schema(
       name: r'number',
       type: IsarType.string,
     ),
-    r'source': PropertySchema(
+    r'sortKeys': PropertySchema(
       id: 7,
+      name: r'sortKeys',
+      type: IsarType.stringList,
+    ),
+    r'sortVals': PropertySchema(
+      id: 8,
+      name: r'sortVals',
+      type: IsarType.stringList,
+    ),
+    r'source': PropertySchema(
+      id: 9,
       name: r'source',
       type: IsarType.string,
     ),
     r'thumbnail': PropertySchema(
-      id: 8,
+      id: 10,
       name: r'thumbnail',
       type: IsarType.string,
     ),
     r'timeStampInMilliseconds': PropertySchema(
-      id: 9,
+      id: 11,
       name: r'timeStampInMilliseconds',
       type: IsarType.long,
     ),
     r'title': PropertySchema(
-      id: 10,
+      id: 12,
       name: r'title',
       type: IsarType.string,
     ),
     r'videoTracks': PropertySchema(
-      id: 11,
+      id: 13,
       name: r'videoTracks',
       type: IsarType.objectList,
       target: r'Video',
@@ -108,6 +118,30 @@ int _episodeEstimateSize(
     }
   }
   bytesCount += 3 + object.number.length * 3;
+  {
+    final list = object.sortKeys;
+    if (list != null) {
+      bytesCount += 3 + list.length * 3;
+      {
+        for (var i = 0; i < list.length; i++) {
+          final value = list[i];
+          bytesCount += value.length * 3;
+        }
+      }
+    }
+  }
+  {
+    final list = object.sortVals;
+    if (list != null) {
+      bytesCount += 3 + list.length * 3;
+      {
+        for (var i = 0; i < list.length; i++) {
+          final value = list[i];
+          bytesCount += value.length * 3;
+        }
+      }
+    }
+  }
   {
     final value = object.source;
     if (value != null) {
@@ -160,12 +194,14 @@ void _episodeSerialize(
   writer.writeLong(offsets[4], object.lastWatchedTime);
   writer.writeString(offsets[5], object.link);
   writer.writeString(offsets[6], object.number);
-  writer.writeString(offsets[7], object.source);
-  writer.writeString(offsets[8], object.thumbnail);
-  writer.writeLong(offsets[9], object.timeStampInMilliseconds);
-  writer.writeString(offsets[10], object.title);
+  writer.writeStringList(offsets[7], object.sortKeys);
+  writer.writeStringList(offsets[8], object.sortVals);
+  writer.writeString(offsets[9], object.source);
+  writer.writeString(offsets[10], object.thumbnail);
+  writer.writeLong(offsets[11], object.timeStampInMilliseconds);
+  writer.writeString(offsets[12], object.title);
   writer.writeObjectList<Video>(
-    offsets[11],
+    offsets[13],
     allOffsets,
     VideoSchema.serialize,
     object.videoTracks,
@@ -190,12 +226,14 @@ Episode _episodeDeserialize(
     lastWatchedTime: reader.readLongOrNull(offsets[4]),
     link: reader.readStringOrNull(offsets[5]),
     number: reader.readStringOrNull(offsets[6]) ?? "1",
-    source: reader.readStringOrNull(offsets[7]),
-    thumbnail: reader.readStringOrNull(offsets[8]),
-    timeStampInMilliseconds: reader.readLongOrNull(offsets[9]),
-    title: reader.readStringOrNull(offsets[10]),
+    sortKeys: reader.readStringList(offsets[7]),
+    sortVals: reader.readStringList(offsets[8]),
+    source: reader.readStringOrNull(offsets[9]),
+    thumbnail: reader.readStringOrNull(offsets[10]),
+    timeStampInMilliseconds: reader.readLongOrNull(offsets[11]),
+    title: reader.readStringOrNull(offsets[12]),
     videoTracks: reader.readObjectList<Video>(
-      offsets[11],
+      offsets[13],
       VideoSchema.deserialize,
       allOffsets,
       Video(),
@@ -230,14 +268,18 @@ P _episodeDeserializeProp<P>(
     case 6:
       return (reader.readStringOrNull(offset) ?? "1") as P;
     case 7:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readStringList(offset)) as P;
     case 8:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readStringList(offset)) as P;
     case 9:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 10:
       return (reader.readStringOrNull(offset)) as P;
     case 11:
+      return (reader.readLongOrNull(offset)) as P;
+    case 12:
+      return (reader.readStringOrNull(offset)) as P;
+    case 13:
       return (reader.readObjectList<Video>(
         offset,
         VideoSchema.deserialize,
@@ -859,6 +901,476 @@ extension EpisodeQueryFilter
         property: r'number',
         value: '',
       ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'sortKeys',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'sortKeys',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortKeysElementGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'sortKeys',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortKeysElementStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'sortKeys',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysElementMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'sortKeys',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortKeysElementIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortKeys',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortKeysElementIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'sortKeys',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortKeysLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortKeysLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortKeys',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'sortVals',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'sortVals',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortValsElementGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'sortVals',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortValsElementStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'sortVals',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsElementMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'sortVals',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortValsElementIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'sortVals',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortValsElementIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'sortVals',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition>
+      sortValsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Episode, Episode, QAfterFilterCondition> sortValsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'sortVals',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
     });
   }
 

--- a/lib/database/isar_models/offline_media.dart
+++ b/lib/database/isar_models/offline_media.dart
@@ -12,6 +12,9 @@ class OfflineMedia {
   Id id = Isar.autoIncrement;
 
   @Index()
+  String? profileId;
+
+  @Index()
   String? mediaId;
 
   String? jname;
@@ -49,6 +52,7 @@ class OfflineMedia {
   int? mediaTypeIndex;
 
   OfflineMedia({
+    this.profileId,
     this.mediaId,
     this.jname,
     this.name,
@@ -82,6 +86,7 @@ class OfflineMedia {
 
   Map<String, dynamic> toJson() {
     return {
+      'profileId': profileId,
       'id': mediaId,
       'jname': jname,
       'name': name,
@@ -116,6 +121,7 @@ class OfflineMedia {
 
   factory OfflineMedia.fromJson(Map<String, dynamic> json) {
     return OfflineMedia(
+      profileId: json['profileId'] as String?,
       mediaId: json['id'] as String?,
       jname: json['jname'] as String?,
       name: json['name'] as String?,

--- a/lib/database/isar_models/offline_media.g.dart
+++ b/lib/database/isar_models/offline_media.g.dart
@@ -116,54 +116,59 @@ const OfflineMediaSchema = CollectionSchema(
       name: r'premiered',
       type: IsarType.string,
     ),
-    r'rating': PropertySchema(
+    r'profileId': PropertySchema(
       id: 19,
+      name: r'profileId',
+      type: IsarType.string,
+    ),
+    r'rating': PropertySchema(
+      id: 20,
       name: r'rating',
       type: IsarType.string,
     ),
     r'readChapters': PropertySchema(
-      id: 20,
+      id: 21,
       name: r'readChapters',
       type: IsarType.objectList,
       target: r'Chapter',
     ),
     r'season': PropertySchema(
-      id: 21,
+      id: 22,
       name: r'season',
       type: IsarType.string,
     ),
     r'serviceIndex': PropertySchema(
-      id: 22,
+      id: 23,
       name: r'serviceIndex',
       type: IsarType.long,
     ),
     r'status': PropertySchema(
-      id: 23,
+      id: 24,
       name: r'status',
       type: IsarType.string,
     ),
     r'studios': PropertySchema(
-      id: 24,
+      id: 25,
       name: r'studios',
       type: IsarType.stringList,
     ),
     r'totalChapters': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'totalChapters',
       type: IsarType.string,
     ),
     r'totalEpisodes': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'totalEpisodes',
       type: IsarType.string,
     ),
     r'type': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'type',
       type: IsarType.string,
     ),
     r'watchedEpisodes': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'watchedEpisodes',
       type: IsarType.objectList,
       target: r'Episode',
@@ -175,6 +180,19 @@ const OfflineMediaSchema = CollectionSchema(
   deserializeProp: _offlineMediaDeserializeProp,
   idName: r'id',
   indexes: {
+    r'profileId': IndexSchema(
+      id: 6052971939042612300,
+      name: r'profileId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'profileId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    ),
     r'mediaId': IndexSchema(
       id: -8001372983137409759,
       name: r'mediaId',
@@ -339,6 +357,12 @@ int _offlineMediaEstimateSize(
     }
   }
   {
+    final value = object.profileId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.rating;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -460,22 +484,23 @@ void _offlineMediaSerialize(
   writer.writeString(offsets[16], object.popularity);
   writer.writeString(offsets[17], object.poster);
   writer.writeString(offsets[18], object.premiered);
-  writer.writeString(offsets[19], object.rating);
+  writer.writeString(offsets[19], object.profileId);
+  writer.writeString(offsets[20], object.rating);
   writer.writeObjectList<Chapter>(
-    offsets[20],
+    offsets[21],
     allOffsets,
     ChapterSchema.serialize,
     object.readChapters,
   );
-  writer.writeString(offsets[21], object.season);
-  writer.writeLong(offsets[22], object.serviceIndex);
-  writer.writeString(offsets[23], object.status);
-  writer.writeStringList(offsets[24], object.studios);
-  writer.writeString(offsets[25], object.totalChapters);
-  writer.writeString(offsets[26], object.totalEpisodes);
-  writer.writeString(offsets[27], object.type);
+  writer.writeString(offsets[22], object.season);
+  writer.writeLong(offsets[23], object.serviceIndex);
+  writer.writeString(offsets[24], object.status);
+  writer.writeStringList(offsets[25], object.studios);
+  writer.writeString(offsets[26], object.totalChapters);
+  writer.writeString(offsets[27], object.totalEpisodes);
+  writer.writeString(offsets[28], object.type);
   writer.writeObjectList<Episode>(
-    offsets[28],
+    offsets[29],
     allOffsets,
     EpisodeSchema.serialize,
     object.watchedEpisodes,
@@ -526,22 +551,23 @@ OfflineMedia _offlineMediaDeserialize(
     popularity: reader.readStringOrNull(offsets[16]),
     poster: reader.readStringOrNull(offsets[17]),
     premiered: reader.readStringOrNull(offsets[18]),
-    rating: reader.readStringOrNull(offsets[19]),
+    profileId: reader.readStringOrNull(offsets[19]),
+    rating: reader.readStringOrNull(offsets[20]),
     readChapters: reader.readObjectList<Chapter>(
-      offsets[20],
+      offsets[21],
       ChapterSchema.deserialize,
       allOffsets,
       Chapter(),
     ),
-    season: reader.readStringOrNull(offsets[21]),
-    serviceIndex: reader.readLongOrNull(offsets[22]),
-    status: reader.readStringOrNull(offsets[23]),
-    studios: reader.readStringList(offsets[24]),
-    totalChapters: reader.readStringOrNull(offsets[25]),
-    totalEpisodes: reader.readStringOrNull(offsets[26]),
-    type: reader.readStringOrNull(offsets[27]),
+    season: reader.readStringOrNull(offsets[22]),
+    serviceIndex: reader.readLongOrNull(offsets[23]),
+    status: reader.readStringOrNull(offsets[24]),
+    studios: reader.readStringList(offsets[25]),
+    totalChapters: reader.readStringOrNull(offsets[26]),
+    totalEpisodes: reader.readStringOrNull(offsets[27]),
+    type: reader.readStringOrNull(offsets[28]),
     watchedEpisodes: reader.readObjectList<Episode>(
-      offsets[28],
+      offsets[29],
       EpisodeSchema.deserialize,
       allOffsets,
       Episode(),
@@ -617,27 +643,29 @@ P _offlineMediaDeserializeProp<P>(
     case 19:
       return (reader.readStringOrNull(offset)) as P;
     case 20:
+      return (reader.readStringOrNull(offset)) as P;
+    case 21:
       return (reader.readObjectList<Chapter>(
         offset,
         ChapterSchema.deserialize,
         allOffsets,
         Chapter(),
       )) as P;
-    case 21:
-      return (reader.readStringOrNull(offset)) as P;
     case 22:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 23:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 24:
-      return (reader.readStringList(offset)) as P;
-    case 25:
       return (reader.readStringOrNull(offset)) as P;
+    case 25:
+      return (reader.readStringList(offset)) as P;
     case 26:
       return (reader.readStringOrNull(offset)) as P;
     case 27:
       return (reader.readStringOrNull(offset)) as P;
     case 28:
+      return (reader.readStringOrNull(offset)) as P;
+    case 29:
       return (reader.readObjectList<Episode>(
         offset,
         EpisodeSchema.deserialize,
@@ -737,6 +765,73 @@ extension OfflineMediaQueryWhere
         upper: upperId,
         includeUpper: includeUpper,
       ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterWhereClause>
+      profileIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'profileId',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterWhereClause>
+      profileIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'profileId',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterWhereClause> profileIdEqualTo(
+      String? profileId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'profileId',
+        value: [profileId],
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterWhereClause>
+      profileIdNotEqualTo(String? profileId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [],
+              upper: [profileId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [profileId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [profileId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'profileId',
+              lower: [],
+              upper: [profileId],
+              includeUpper: false,
+            ));
+      }
     });
   }
 
@@ -3421,6 +3516,160 @@ extension OfflineMediaQueryFilter
   }
 
   QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'profileId',
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'profileId',
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'profileId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'profileId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'profileId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'profileId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
+      profileIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'profileId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterFilterCondition>
       ratingIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -5092,6 +5341,18 @@ extension OfflineMediaQuerySortBy
     });
   }
 
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> sortByProfileId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> sortByProfileIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.desc);
+    });
+  }
+
   QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> sortByRating() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'rating', Sort.asc);
@@ -5366,6 +5627,18 @@ extension OfflineMediaQuerySortThenBy
     });
   }
 
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> thenByProfileId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> thenByProfileIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'profileId', Sort.desc);
+    });
+  }
+
   QueryBuilder<OfflineMedia, OfflineMedia, QAfterSortBy> thenByRating() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'rating', Sort.asc);
@@ -5560,6 +5833,13 @@ extension OfflineMediaQueryWhereDistinct
     });
   }
 
+  QueryBuilder<OfflineMedia, OfflineMedia, QDistinct> distinctByProfileId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'profileId', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<OfflineMedia, OfflineMedia, QDistinct> distinctByRating(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -5740,6 +6020,12 @@ extension OfflineMediaQueryProperty
   QueryBuilder<OfflineMedia, String?, QQueryOperations> premieredProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'premiered');
+    });
+  }
+
+  QueryBuilder<OfflineMedia, String?, QQueryOperations> profileIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'profileId');
     });
   }
 

--- a/lib/database/kv_helper.dart
+++ b/lib/database/kv_helper.dart
@@ -15,13 +15,22 @@ extension KvExtensions on Enum {
 }
 
 class KvHelper {
+  static String profilePrefix = '';
+
+  static String _prefixKey(String key) {
+    if (profilePrefix.isEmpty) return key;
+    if (key.startsWith('__') && key.endsWith('__')) return key;
+    return '$profilePrefix$key';
+  }
+
   static T get<T>(String key, {T? defaultVal}) {
+    final qualifiedKey = _prefixKey(key);
     final col = isar.collection<KeyValue>();
-    final result = col.filter().keyEqualTo(key).findFirstSync();
+    final result = col.filter().keyEqualTo(qualifiedKey).findFirstSync();
 
     if (result?.value == null) {
       if (defaultVal != null) return defaultVal;
-      Logger.e('Key $key not found');
+      Logger.e('Key $qualifiedKey not found');
       return null as T;
     }
 
@@ -46,7 +55,7 @@ class KvHelper {
 
     if (val is! T) {
       print(
-        'Key $key expected type $T but got ${val.runtimeType}',
+        'Key $qualifiedKey expected type $T but got ${val.runtimeType}',
       );
       if (defaultVal != null) return defaultVal;
       return null as T;
@@ -56,8 +65,9 @@ class KvHelper {
   }
 
   static void set<T>(String key, T value) {
+    final qualifiedKey = _prefixKey(key);
     final data = KeyValue()
-      ..key = key
+      ..key = qualifiedKey
       ..value = jsonEncode({'val': value});
 
     isar.writeTxnSync(() {
@@ -66,8 +76,9 @@ class KvHelper {
   }
 
   static void remove(String key) {
+    final qualifiedKey = _prefixKey(key);
     final col = isar.collection<KeyValue>();
-    final data = col.filter().keyEqualTo(key).findFirstSync();
+    final data = col.filter().keyEqualTo(qualifiedKey).findFirstSync();
 
     if (data == null) return;
 

--- a/lib/database/kv_helper.dart
+++ b/lib/database/kv_helper.dart
@@ -17,9 +17,14 @@ extension KvExtensions on Enum {
 class KvHelper {
   static String profilePrefix = '';
 
+  static const _globalKeys = {
+    'isFirstTime',
+  };
+
   static String _prefixKey(String key) {
     if (profilePrefix.isEmpty) return key;
     if (key.startsWith('__') && key.endsWith('__')) return key;
+    if (_globalKeys.contains(key)) return key;
     return '$profilePrefix$key';
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,9 @@ import 'package:anymex/utils/external_font_loader.dart';
 import 'package:anymex/utils/logger.dart';
 import 'package:anymex/utils/deeplink.dart';
 import 'package:anymex/utils/register_protocol/register_protocol.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/adaptive_wrapper.dart';
 import 'package:anymex/widgets/animation/more_page_transitions.dart';
 import 'package:anymex/widgets/common/glow.dart';
@@ -405,6 +408,12 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
     }
   }
 
+  void _goToProfileSelection() {
+    final manager = Get.find<ProfileManager>();
+    manager.isProfileReady.value = true;
+    manager.resetAutoStart();
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -418,8 +427,36 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
     if (_needsPin) {
       return Scaffold(
         backgroundColor: colorScheme.surface,
-        body: Center(
-          child: _PinAutoStartDialog(onSubmit: _submitPin),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    onPressed: _goToProfileSelection,
+                    icon: Icon(Icons.arrow_back,
+                        color: colorScheme.onSurface.withOpacity(0.7)),
+                    label: Text('Switch Profile',
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontSize: 14,
+                          color: colorScheme.onSurface.withOpacity(0.7),
+                        )),
+                  ),
+                ),
+                Expanded(
+                  child: _PinAutoStartWidget(
+                    profile: manager.profiles.firstWhere(
+                        (p) => p.id == widget.profileId),
+                    onSubmit: _submitPin,
+                    onSwitchProfile: _goToProfileSelection,
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       );
     }
@@ -435,17 +472,24 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
   }
 }
 
-class _PinAutoStartDialog extends StatefulWidget {
+class _PinAutoStartWidget extends StatefulWidget {
+  final AppProfile profile;
   final Future<void> Function(String pin) onSubmit;
-  const _PinAutoStartDialog({required this.onSubmit});
+  final VoidCallback onSwitchProfile;
+  const _PinAutoStartWidget({
+    required this.profile,
+    required this.onSubmit,
+    required this.onSwitchProfile,
+  });
 
   @override
-  State<_PinAutoStartDialog> createState() => _PinAutoStartDialogState();
+  State<_PinAutoStartWidget> createState() => _PinAutoStartWidgetState();
 }
 
-class _PinAutoStartDialogState extends State<_PinAutoStartDialog> {
+class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
   final _controller = TextEditingController();
   bool _error = false;
+  String _errorMessage = '';
 
   @override
   void dispose() {
@@ -453,86 +497,213 @@ class _PinAutoStartDialogState extends State<_PinAutoStartDialog> {
     super.dispose();
   }
 
+  void _submit() {
+    final pin = _controller.text.trim();
+    if (pin.length < 4) return;
+    widget.onSubmit(pin);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final profile = widget.profile;
+    final onSurface = context.colors.onSurface;
 
-    return Container(
-      margin: const EdgeInsets.all(32),
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainer,
-        borderRadius: BorderRadius.circular(24),
-      ),
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ProfileAvatar(profile: profile, radius: 48, showLocked: true),
+            const SizedBox(height: 16),
+            Text(profile.name,
+                style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    fontSize: 22,
+                    color: onSurface)),
+            const SizedBox(height: 24),
+            Text('Too many failed attempts.',
+                style: TextStyle(
+                    color: onSurface.withOpacity(0.7), fontSize: 14)),
+            const SizedBox(height: 8),
+            Text('Try again in $remaining minute${remaining != 1 ? 's' : ''}',
+                style: const TextStyle(
+                    color: Colors.red,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'Poppins')),
+            const SizedBox(height: 24),
+            TextButton(
+              onPressed: widget.onSwitchProfile,
+              child: Text('Switch to another profile',
+                  style: TextStyle(
+                      color: colorScheme.primary,
+                      fontFamily: 'Poppins',
+                      fontWeight: FontWeight.w600)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.lock_rounded, size: 48,
-              color: colorScheme.primary),
+          const SizedBox(height: 40),
+          ProfileAvatar(profile: profile, radius: 52),
           const SizedBox(height: 16),
-          Text('Enter PIN',
+          Text(profile.name,
               style: TextStyle(
-                fontFamily: 'Poppins',
-                fontWeight: FontWeight.bold,
-                fontSize: 20,
-                color: colorScheme.onSurface,
-              )),
-          const SizedBox(height: 20),
-          TextField(
-            controller: _controller,
-            keyboardType: TextInputType.number,
-            obscureText: true,
-            maxLength: 6,
-            autofocus: true,
-            style: TextStyle(
-              color: colorScheme.onSurface,
-              fontFamily: 'Poppins',
-              fontSize: 24,
-              letterSpacing: 8,
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.bold,
+                  fontSize: 24,
+                  color: onSurface)),
+          const SizedBox(height: 6),
+          if (profile.anilistLinked ||
+              profile.malLinked ||
+              profile.simklLinked)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (profile.anilistLinked)
+                  _serviceDot('AL', Colors.blue),
+                if (profile.malLinked)
+                  _serviceDot('MAL', Colors.blueAccent),
+                if (profile.simklLinked)
+                  _serviceDot('Simkl', Colors.green),
+              ],
             ),
-            textAlign: TextAlign.center,
-            decoration: InputDecoration(
-              filled: true,
-              fillColor: colorScheme.surface,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: _error
-                    ? const BorderSide(color: Colors.red, width: 2)
-                    : BorderSide.none,
-              ),
-              counterText: '',
+          const SizedBox(height: 40),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainer,
+              borderRadius: BorderRadius.circular(20),
             ),
-            onChanged: (_) => setState(() => _error = false),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.lock_outline_rounded,
+                        size: 20,
+                        color: colorScheme.primary.withOpacity(0.8)),
+                    const SizedBox(width: 8),
+                    Text('Enter PIN to unlock',
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15,
+                          color: onSurface.withOpacity(0.8),
+                        )),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                TextField(
+                  controller: _controller,
+                  keyboardType: TextInputType.number,
+                  obscureText: true,
+                  maxLength: 6,
+                  autofocus: true,
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontFamily: 'Poppins',
+                    fontSize: 28,
+                    letterSpacing: 10,
+                  ),
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    filled: true,
+                    fillColor: colorScheme.surface,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(14),
+                      borderSide: _error
+                          ? const BorderSide(color: Colors.red, width: 2)
+                          : BorderSide.none,
+                    ),
+                    counterText: '',
+                  ),
+                  onChanged: (_) => setState(() {
+                    _error = false;
+                    _errorMessage = '';
+                  }),
+                  onSubmitted: (_) => _submit(),
+                ),
+                if (_error) ...[
+                  const SizedBox(height: 8),
+                  Text(_errorMessage,
+                      style: const TextStyle(
+                          color: Colors.red, fontSize: 13)),
+                ],
+                const SizedBox(height: 4),
+                Obx(() {
+                  final manager = Get.find<ProfileManager>();
+                  final attempts = manager.profiles
+                          .firstWhereOrNull((p) => p.id == profile.id)
+                          ?.failedPinAttempts ??
+                      0;
+                  if (attempts > 0) {
+                    return Text(
+                      '$attempts / $kMaxPinAttempts attempts',
+                      style: TextStyle(
+                          color: onSurface.withOpacity(0.4), fontSize: 12),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                }),
+              ],
+            ),
           ),
-          if (_error) ...[
-            const SizedBox(height: 8),
-            const Text('Wrong PIN',
-                style: TextStyle(color: Colors.red)),
-          ],
           const SizedBox(height: 20),
           SizedBox(
             width: double.infinity,
-            height: 48,
+            height: 52,
             child: ElevatedButton(
-              onPressed: () {
-                final pin = _controller.text.trim();
-                if (pin.length >= 4) widget.onSubmit(pin);
-              },
+              onPressed: _submit,
               style: ElevatedButton.styleFrom(
                 backgroundColor: colorScheme.primary,
                 foregroundColor: colorScheme.onPrimary,
                 shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
+                    borderRadius: BorderRadius.circular(14)),
               ),
               child: const Text('Unlock',
                   style: TextStyle(
                     fontFamily: 'Poppins',
                     fontWeight: FontWeight.bold,
+                    fontSize: 16,
                   )),
             ),
           ),
+          const SizedBox(height: 16),
+          TextButton(
+            onPressed: widget.onSwitchProfile,
+            child: Text('Not your profile? Switch to another',
+                style: TextStyle(
+                    color: colorScheme.primary.withOpacity(0.8),
+                    fontFamily: 'Poppins',
+                    fontSize: 13)),
+          ),
         ],
       ),
+    );
+  }
+
+  Widget _serviceDot(String text, Color color) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 3),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(text,
+          style: TextStyle(
+              fontSize: 11, fontWeight: FontWeight.w600, color: color)),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -331,6 +331,10 @@ class _ProfileGateState extends State<ProfileGate> {
     final manager = Get.find<ProfileManager>();
 
     return Obx(() {
+      if (manager.showProfileSelection.value) {
+        return const ProfileSelectionPage();
+      }
+
       if (manager.isProfileReady.value) {
         return const FilterScreen();
       }
@@ -410,8 +414,8 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
 
   void _goToProfileSelection() {
     final manager = Get.find<ProfileManager>();
-    manager.isProfileReady.value = true;
     manager.resetAutoStart();
+    manager.requestProfileSelection();
   }
 
   @override
@@ -419,8 +423,11 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
     final colorScheme = Theme.of(context).colorScheme;
     final manager = Get.find<ProfileManager>();
 
-    if (manager.isProfileReady.value || !manager.profiles
-        .any((p) => p.id == widget.profileId)) {
+    if (!manager.profiles.any((p) => p.id == widget.profileId)) {
+      return const ProfileSelectionPage();
+    }
+
+    if (manager.isProfileReady.value) {
       return const FilterScreen();
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:anymex/utils/logger.dart';
 import 'package:anymex/utils/deeplink.dart';
 import 'package:anymex/utils/register_protocol/register_protocol.dart';
 import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/adaptive_wrapper.dart';
@@ -343,6 +344,11 @@ class _ProfileGateState extends State<ProfileGate> {
         return const ProfileCreationPage();
       }
 
+      if (!manager.isMultiProfileEnabled.value && manager.hasSingleProfile) {
+        return _AutoStartHandler(
+            profileId: manager.profiles.first.id);
+      }
+
       if (manager.hasAutoStart) {
         return _AutoStartHandler(profileId: manager.autoStartProfileId.value);
       }
@@ -389,23 +395,25 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
       return;
     }
 
-    if (profile.hasPin) {
+    if (profile.hasLock) {
       setState(() => _needsPin = true);
     } else {
       await manager.switchToProfile(profile.id);
     }
   }
 
-  Future<void> _submitPin(String pin) async {
+  Future<void> _submitLock(String input) async {
     final manager = Get.find<ProfileManager>();
-    final result = manager.verifyPin(widget.profileId, pin);
+    final result = manager.verifyLock(widget.profileId, input);
 
     if (result == true) {
       await manager.switchToProfile(widget.profileId);
     } else {
+      final profile = manager.profiles.firstWhereOrNull((p) => p.id == widget.profileId);
+      final label = profile?.lockLabel ?? 'lock';
       snackBar(result == null
           ? 'Profile is temporarily locked'
-          : 'Wrong PIN');
+          : 'Wrong $label');
       if (result == null && mounted) {
         setState(() => _needsPin = false);
       }
@@ -454,10 +462,10 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
                   ),
                 ),
                 Expanded(
-                  child: _PinAutoStartWidget(
+                  child: _LockAutoStartWidget(
                     profile: manager.profiles.firstWhere(
                         (p) => p.id == widget.profileId),
-                    onSubmit: _submitPin,
+                    onSubmit: _submitLock,
                     onSwitchProfile: _goToProfileSelection,
                   ),
                 ),
@@ -479,21 +487,21 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
   }
 }
 
-class _PinAutoStartWidget extends StatefulWidget {
+class _LockAutoStartWidget extends StatefulWidget {
   final AppProfile profile;
-  final Future<void> Function(String pin) onSubmit;
+  final Future<void> Function(String input) onSubmit;
   final VoidCallback onSwitchProfile;
-  const _PinAutoStartWidget({
+  const _LockAutoStartWidget({
     required this.profile,
     required this.onSubmit,
     required this.onSwitchProfile,
   });
 
   @override
-  State<_PinAutoStartWidget> createState() => _PinAutoStartWidgetState();
+  State<_LockAutoStartWidget> createState() => _LockAutoStartWidgetState();
 }
 
-class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
+class _LockAutoStartWidgetState extends State<_LockAutoStartWidget> {
   final _controller = TextEditingController();
   bool _error = false;
   String _errorMessage = '';
@@ -505,9 +513,13 @@ class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
   }
 
   void _submit() {
-    final pin = _controller.text.trim();
-    if (pin.length < 4) return;
-    widget.onSubmit(pin);
+    final profile = widget.profile;
+    if (profile.isPatternLocked) return;
+    final input = profile.isPinLocked
+        ? _controller.text.trim()
+        : _controller.text;
+    if (input.length < 4) return;
+    widget.onSubmit(input);
   }
 
   @override
@@ -597,11 +609,16 @@ class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(Icons.lock_outline_rounded,
+                    Icon(
+                        profile.isPinLocked
+                            ? Icons.dialpad_rounded
+                            : profile.isPasswordLocked
+                                ? Icons.password_rounded
+                                : Icons.grid_3x3_rounded,
                         size: 20,
                         color: colorScheme.primary.withOpacity(0.8)),
                     const SizedBox(width: 8),
-                    Text('Enter PIN to unlock',
+                    Text('Enter ${profile.lockLabel} to unlock',
                         style: TextStyle(
                           fontFamily: 'Poppins',
                           fontWeight: FontWeight.w600,
@@ -611,11 +628,24 @@ class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
                   ],
                 ),
                 const SizedBox(height: 20),
-                TextField(
+                if (profile.isPatternLocked)
+                  SizedBox(
+                    width: 220,
+                    height: 220,
+                    child: PatternLock(
+                      onPatternComplete: (pattern) {
+                        widget.onSubmit(pattern.join(','));
+                      },
+                    ),
+                  )
+                else
+                  TextField(
                   controller: _controller,
-                  keyboardType: TextInputType.number,
+                  keyboardType: profile.isPinLocked
+                      ? TextInputType.number
+                      : TextInputType.text,
                   obscureText: true,
-                  maxLength: 6,
+                  maxLength: profile.isPinLocked ? 6 : 32,
                   autofocus: true,
                   style: TextStyle(
                     color: colorScheme.onSurface,
@@ -652,11 +682,11 @@ class _PinAutoStartWidgetState extends State<_PinAutoStartWidget> {
                   final manager = Get.find<ProfileManager>();
                   final attempts = manager.profiles
                           .firstWhereOrNull((p) => p.id == profile.id)
-                          ?.failedPinAttempts ??
+                          ?.failedAttempts ??
                       0;
                   if (attempts > 0) {
                     return Text(
-                      '$attempts / $kMaxPinAttempts attempts',
+                      '$attempts / $kMaxLockAttempts attempts',
                       style: TextStyle(
                           color: onSurface.withOpacity(0.4), fontSize: 12),
                     );
@@ -811,32 +841,36 @@ class _FilterScreenState extends State<FilterScreen> {
                             return SettingsSheet.show(context);
                           },
                           label: 'Profile',
-                          altIcon: GestureDetector(
-                            onLongPress: () =>
-                                showProfileSwitcher(context),
-                            child: CircleAvatar(
-                                radius: 24,
-                                backgroundColor: Theme.of(context)
-                                    .colorScheme
-                                    .surfaceContainer
-                                    .withValues(alpha: 0.3),
-                                child: authService.isLoggedIn.value
-                                    ? ClipRRect(
-                                        borderRadius:
-                                            BorderRadius.circular(59),
-                                        child: AnymeXImage(
-                                            width: 40,
-                                            height: 40,
-                                            fit: BoxFit.cover,
-                                            radius: 0,
-                                            imageUrl: authService
-                                                    .profileData
-                                                    .value
-                                                    .avatar ??
-                                                ''),
-                                      )
-                                    : const Icon((IconlyBold.profile))),
-                          )),
+                          altIcon: Obx(() {
+                            final multiProfile = Get.find<ProfileManager>().isMultiProfileEnabled.value;
+                            return GestureDetector(
+                              onLongPress: multiProfile
+                                  ? () => showProfileSwitcher(context)
+                                  : null,
+                              child: CircleAvatar(
+                                  radius: 24,
+                                  backgroundColor: Theme.of(context)
+                                      .colorScheme
+                                      .surfaceContainer
+                                      .withValues(alpha: 0.3),
+                                  child: authService.isLoggedIn.value
+                                      ? ClipRRect(
+                                          borderRadius:
+                                              BorderRadius.circular(59),
+                                          child: AnymeXImage(
+                                              width: 40,
+                                              height: 40,
+                                              fit: BoxFit.cover,
+                                              radius: 0,
+                                              imageUrl: authService
+                                                      .profileData
+                                                      .value
+                                                      .avatar ??
+                                                  ''),
+                                        )
+                                      : const Icon((IconlyBold.profile))),
+                            );
+                          })),
                       NavItem(
                         unselectedIcon: IconlyLight.home,
                         selectedIcon: IconlyBold.home,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -341,7 +341,7 @@ class _ProfileGateState extends State<ProfileGate> {
       }
 
       if (!manager.hasProfiles) {
-        return const ProfileCreationPage();
+        return const ProfileCreationPage(isFirstLaunch: true);
       }
 
       if (!manager.isMultiProfileEnabled.value && manager.hasSingleProfile) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -328,15 +328,16 @@ class _ProfileGateState extends State<ProfileGate> {
     final manager = Get.find<ProfileManager>();
 
     return Obx(() {
+      if (manager.isProfileReady.value) {
+        return const FilterScreen();
+      }
+
       if (!manager.hasProfiles) {
         return const ProfileCreationPage();
       }
 
-      final autoStartId = manager.autoStartProfileId;
-      if (autoStartId != null &&
-          autoStartId.isNotEmpty &&
-          manager.profiles.any((p) => p.id == autoStartId)) {
-        return _AutoStartHandler(profileId: autoStartId);
+      if (manager.hasAutoStart) {
+        return _AutoStartHandler(profileId: manager.autoStartProfileId.value);
       }
 
       if (manager.hasSingleProfile) {
@@ -358,7 +359,6 @@ class _AutoStartHandler extends StatefulWidget {
 }
 
 class _AutoStartHandlerState extends State<_AutoStartHandler> {
-  bool _resolved = false;
   bool _needsPin = false;
 
   @override
@@ -369,11 +369,16 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
 
   Future<void> _checkAndStart() async {
     final manager = Get.find<ProfileManager>();
+
+    if (manager.isProfileReady.value) {
+      return;
+    }
+
     final profile = manager.profiles
         .firstWhereOrNull((p) => p.id == widget.profileId);
 
     if (profile == null) {
-      setState(() => _resolved = true);
+      manager.isProfileReady.value = true;
       return;
     }
 
@@ -381,7 +386,6 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
       setState(() => _needsPin = true);
     } else {
       await manager.switchToProfile(profile.id);
-      if (mounted) setState(() => _resolved = true);
     }
   }
 
@@ -391,7 +395,6 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
 
     if (result == true) {
       await manager.switchToProfile(widget.profileId);
-      if (mounted) setState(() => _resolved = true);
     } else {
       snackBar(result == null
           ? 'Profile is temporarily locked'
@@ -405,8 +408,10 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final manager = Get.find<ProfileManager>();
 
-    if (_resolved) {
+    if (manager.isProfileReady.value || !manager.profiles
+        .any((p) => p.id == widget.profileId)) {
       return const FilterScreen();
     }
 
@@ -419,8 +424,14 @@ class _AutoStartHandlerState extends State<_AutoStartHandler> {
       );
     }
 
-    // Fallback: show profile selection
-    return const ProfileSelectionPage();
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: Center(
+        child: CircularProgressIndicator(
+          color: colorScheme.primary,
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:anymex/controllers/cacher/cache_controller.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/screens/downloads/controller/download_controller.dart';
 import 'package:anymex/controllers/discord/discord_rpc.dart';
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
@@ -36,6 +37,9 @@ import 'package:anymex/widgets/animation/more_page_transitions.dart';
 import 'package:anymex/widgets/common/glow.dart';
 import 'package:anymex/widgets/common/navbar.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_image.dart';
+import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/profile_selection_page.dart';
+import 'package:anymex/screens/profile/widgets/profile_switcher_overlay.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_splash_screen.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_titlebar.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
@@ -169,6 +173,7 @@ void main(List<String> args) async {
 }
 
 void _initializeGetxController() async {
+  Get.put(ProfileManager(), permanent: true);
   Get.put(Settings());
   Get.put(OfflineStorageController());
   Get.put(AnilistAuth());
@@ -276,7 +281,7 @@ class _MainAppState extends State<MainApp> {
             : theme.isLightMode
                 ? ThemeMode.light
                 : ThemeMode.dark,
-        home: _showMainApp ? const FilterScreen() : const AnymeXSplashScreen(),
+        home: _showMainApp ? const ProfileGate() : const AnymeXSplashScreen(),
         builder: (context, child) {
           if (PlatformDispatcher.instance.views.length > 1) {
             return child!;
@@ -305,6 +310,217 @@ class _MainAppState extends State<MainApp> {
         logWriterCallback: (text, {isError = false}) async {
           Logger.d(text);
         },
+      ),
+    );
+  }
+}
+
+class ProfileGate extends StatefulWidget {
+  const ProfileGate({super.key});
+
+  @override
+  State<ProfileGate> createState() => _ProfileGateState();
+}
+
+class _ProfileGateState extends State<ProfileGate> {
+  @override
+  Widget build(BuildContext context) {
+    final manager = Get.find<ProfileManager>();
+
+    return Obx(() {
+      if (!manager.hasProfiles) {
+        return const ProfileCreationPage();
+      }
+
+      final autoStartId = manager.autoStartProfileId;
+      if (autoStartId != null &&
+          autoStartId.isNotEmpty &&
+          manager.profiles.any((p) => p.id == autoStartId)) {
+        return _AutoStartHandler(profileId: autoStartId);
+      }
+
+      if (manager.hasSingleProfile) {
+        return _AutoStartHandler(
+            profileId: manager.profiles.first.id);
+      }
+
+      return const ProfileSelectionPage();
+    });
+  }
+}
+
+class _AutoStartHandler extends StatefulWidget {
+  final String profileId;
+  const _AutoStartHandler({required this.profileId});
+
+  @override
+  State<_AutoStartHandler> createState() => _AutoStartHandlerState();
+}
+
+class _AutoStartHandlerState extends State<_AutoStartHandler> {
+  bool _resolved = false;
+  bool _needsPin = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkAndStart();
+  }
+
+  Future<void> _checkAndStart() async {
+    final manager = Get.find<ProfileManager>();
+    final profile = manager.profiles
+        .firstWhereOrNull((p) => p.id == widget.profileId);
+
+    if (profile == null) {
+      setState(() => _resolved = true);
+      return;
+    }
+
+    if (profile.hasPin) {
+      setState(() => _needsPin = true);
+    } else {
+      await manager.switchToProfile(profile.id);
+      if (mounted) setState(() => _resolved = true);
+    }
+  }
+
+  Future<void> _submitPin(String pin) async {
+    final manager = Get.find<ProfileManager>();
+    final result = manager.verifyPin(widget.profileId, pin);
+
+    if (result == true) {
+      await manager.switchToProfile(widget.profileId);
+      if (mounted) setState(() => _resolved = true);
+    } else {
+      snackBar(result == null
+          ? 'Profile is temporarily locked'
+          : 'Wrong PIN');
+      if (result == null && mounted) {
+        setState(() => _needsPin = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (_resolved) {
+      return const FilterScreen();
+    }
+
+    if (_needsPin) {
+      return Scaffold(
+        backgroundColor: colorScheme.surface,
+        body: Center(
+          child: _PinAutoStartDialog(onSubmit: _submitPin),
+        ),
+      );
+    }
+
+    // Fallback: show profile selection
+    return const ProfileSelectionPage();
+  }
+}
+
+class _PinAutoStartDialog extends StatefulWidget {
+  final Future<void> Function(String pin) onSubmit;
+  const _PinAutoStartDialog({required this.onSubmit});
+
+  @override
+  State<_PinAutoStartDialog> createState() => _PinAutoStartDialogState();
+}
+
+class _PinAutoStartDialogState extends State<_PinAutoStartDialog> {
+  final _controller = TextEditingController();
+  bool _error = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      margin: const EdgeInsets.all(32),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.lock_rounded, size: 48,
+              color: colorScheme.primary),
+          const SizedBox(height: 16),
+          Text('Enter PIN',
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+                color: colorScheme.onSurface,
+              )),
+          const SizedBox(height: 20),
+          TextField(
+            controller: _controller,
+            keyboardType: TextInputType.number,
+            obscureText: true,
+            maxLength: 6,
+            autofocus: true,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontFamily: 'Poppins',
+              fontSize: 24,
+              letterSpacing: 8,
+            ),
+            textAlign: TextAlign.center,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _error
+                    ? const BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+              counterText: '',
+            ),
+            onChanged: (_) => setState(() => _error = false),
+          ),
+          if (_error) ...[
+            const SizedBox(height: 8),
+            const Text('Wrong PIN',
+                style: TextStyle(color: Colors.red)),
+          ],
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: ElevatedButton(
+              onPressed: () {
+                final pin = _controller.text.trim();
+                if (pin.length >= 4) widget.onSubmit(pin);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: colorScheme.primary,
+                foregroundColor: colorScheme.onPrimary,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
+              child: const Text('Unlock',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                  )),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -406,25 +622,32 @@ class _FilterScreenState extends State<FilterScreen> {
                             return SettingsSheet.show(context);
                           },
                           label: 'Profile',
-                          altIcon: CircleAvatar(
-                              radius: 24,
-                              backgroundColor: Theme.of(context)
-                                  .colorScheme
-                                  .surfaceContainer
-                                  .withValues(alpha: 0.3),
-                              child: authService.isLoggedIn.value
-                                  ? ClipRRect(
-                                      borderRadius: BorderRadius.circular(59),
-                                      child: AnymeXImage(
-                                          width: 40,
-                                          height: 40,
-                                          fit: BoxFit.cover,
-                                          radius: 0,
-                                          imageUrl: authService
-                                                  .profileData.value.avatar ??
-                                              ''),
-                                    )
-                                  : const Icon((IconlyBold.profile)))),
+                          altIcon: GestureDetector(
+                            onLongPress: () =>
+                                showProfileSwitcher(context),
+                            child: CircleAvatar(
+                                radius: 24,
+                                backgroundColor: Theme.of(context)
+                                    .colorScheme
+                                    .surfaceContainer
+                                    .withValues(alpha: 0.3),
+                                child: authService.isLoggedIn.value
+                                    ? ClipRRect(
+                                        borderRadius:
+                                            BorderRadius.circular(59),
+                                        child: AnymeXImage(
+                                            width: 40,
+                                            height: 40,
+                                            fit: BoxFit.cover,
+                                            radius: 0,
+                                            imageUrl: authService
+                                                    .profileData
+                                                    .value
+                                                    .avatar ??
+                                                ''),
+                                      )
+                                    : const Icon((IconlyBold.profile))),
+                          )),
                       NavItem(
                         unselectedIcon: IconlyLight.home,
                         selectedIcon: IconlyBold.home,

--- a/lib/models/Service/app_profile.dart
+++ b/lib/models/Service/app_profile.dart
@@ -46,6 +46,9 @@ class AppProfile {
     return name[0].toUpperCase();
   }
 
+  @override
+  String toString() => name;
+
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,

--- a/lib/models/Service/app_profile.dart
+++ b/lib/models/Service/app_profile.dart
@@ -33,6 +33,7 @@ class AppProfile {
   String lockType;
   int failedAttempts;
   DateTime? lockedUntil;
+  String? securityQuestionsJson;
 
   AppProfile({
     required this.id,
@@ -44,6 +45,7 @@ class AppProfile {
     this.lockType = 'none',
     this.failedAttempts = 0,
     this.lockedUntil,
+    this.securityQuestionsJson,
   })  : createdAt = createdAt ?? DateTime.now(),
         lastUsedAt = lastUsedAt ?? DateTime.now();
 
@@ -58,6 +60,24 @@ class AppProfile {
   bool get isLocked {
     if (lockedUntil == null) return false;
     return DateTime.now().isBefore(lockedUntil!);
+  }
+
+  List<Map<String, dynamic>> get securityQAs {
+    if (securityQuestionsJson == null || securityQuestionsJson!.isEmpty) {
+      return [];
+    }
+    try {
+      final list = jsonDecode(securityQuestionsJson!) as List<dynamic>;
+      return list.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  bool get hasSecurityQuestions => securityQAs.isNotEmpty;
+
+  List<String> get securityQuestionTexts {
+    return securityQAs.map((e) => e['q'] as String).toList();
   }
 
   bool get hasLock => lockHash != null && lockHash!.isNotEmpty;
@@ -106,6 +126,7 @@ class AppProfile {
         'anilistLinked': anilistLinked,
         'malLinked': malLinked,
         'simklLinked': simklLinked,
+        'securityQuestionsJson': securityQuestionsJson,
       };
 
   factory AppProfile.fromJson(Map<String, dynamic> json) {
@@ -135,10 +156,23 @@ class AppProfile {
       lockedUntil: json['lockedUntil'] != null
           ? DateTime.parse(json['lockedUntil'] as String)
           : null,
+      securityQuestionsJson: json['securityQuestionsJson'] as String? ??
+          _migrateOldSecurityFields(json),
     )
       ..anilistLinked = json['anilistLinked'] as bool? ?? false
       ..malLinked = json['malLinked'] as bool? ?? false
       ..simklLinked = json['simklLinked'] as bool? ?? false;
+  }
+
+  static String? _migrateOldSecurityFields(Map<String, dynamic> json) {
+    final oldQ = json['securityQuestion'] as String?;
+    final oldA = json['securityAnswerHash'] as String?;
+    if (oldQ != null && oldA != null) {
+      return jsonEncode([
+        {'q': oldQ, 'a': oldA, 'c': false}
+      ]);
+    }
+    return null;
   }
 
   static List<AppProfile> fromJsonList(String jsonStr) {
@@ -168,6 +202,8 @@ class AppProfile {
     bool? simklLinked,
     DateTime? lastUsedAt,
     bool clearLock = false,
+    String? securityQuestionsJson,
+    bool clearSecurityQuestions = false,
   }) {
     return AppProfile(
       id: id,
@@ -183,6 +219,9 @@ class AppProfile {
       lockedUntil: clearLock
           ? null
           : (lockedUntil ?? this.lockedUntil),
+      securityQuestionsJson: clearSecurityQuestions
+          ? null
+          : (securityQuestionsJson ?? this.securityQuestionsJson),
     )
       ..anilistLinked = anilistLinked ?? this.anilistLinked
       ..malLinked = malLinked ?? this.malLinked

--- a/lib/models/Service/app_profile.dart
+++ b/lib/models/Service/app_profile.dart
@@ -1,13 +1,37 @@
 import 'dart:convert';
 
+enum ProfileLockType {
+  none('none'),
+  pin('pin'),
+  password('password'),
+  pattern('pattern');
+
+  const ProfileLockType(this.value);
+  final String value;
+
+  static ProfileLockType fromString(String? value) {
+    switch (value) {
+      case 'pin':
+        return ProfileLockType.pin;
+      case 'password':
+        return ProfileLockType.password;
+      case 'pattern':
+        return ProfileLockType.pattern;
+      default:
+        return ProfileLockType.none;
+    }
+  }
+}
+
 class AppProfile {
   final String id;
   String name;
   String avatarPath;
   final DateTime createdAt;
   DateTime lastUsedAt;
-  String? pinHash;
-  int failedPinAttempts;
+  String? lockHash;
+  String lockType;
+  int failedAttempts;
   DateTime? lockedUntil;
 
   AppProfile({
@@ -16,8 +40,9 @@ class AppProfile {
     this.avatarPath = '',
     DateTime? createdAt,
     DateTime? lastUsedAt,
-    this.pinHash,
-    this.failedPinAttempts = 0,
+    this.lockHash,
+    this.lockType = 'none',
+    this.failedAttempts = 0,
     this.lockedUntil,
   })  : createdAt = createdAt ?? DateTime.now(),
         lastUsedAt = lastUsedAt ?? DateTime.now();
@@ -35,7 +60,26 @@ class AppProfile {
     return DateTime.now().isBefore(lockedUntil!);
   }
 
-  bool get hasPin => pinHash != null && pinHash!.isNotEmpty;
+  bool get hasLock => lockHash != null && lockHash!.isNotEmpty;
+
+  bool get isPinLocked => hasLock && lockType == 'pin';
+  bool get isPasswordLocked => hasLock && lockType == 'password';
+  bool get isPatternLocked => hasLock && lockType == 'pattern';
+
+  ProfileLockType get profileLockType => ProfileLockType.fromString(lockType);
+
+  String get lockLabel {
+    switch (profileLockType) {
+      case ProfileLockType.none:
+        return 'None';
+      case ProfileLockType.pin:
+        return 'PIN';
+      case ProfileLockType.password:
+        return 'Password';
+      case ProfileLockType.pattern:
+        return 'Pattern';
+    }
+  }
 
   String get initials {
     if (name.isEmpty) return '?';
@@ -55,8 +99,9 @@ class AppProfile {
         'avatarPath': avatarPath,
         'createdAt': createdAt.toIso8601String(),
         'lastUsedAt': lastUsedAt.toIso8601String(),
-        'pinHash': pinHash,
-        'failedPinAttempts': failedPinAttempts,
+        'lockHash': lockHash,
+        'lockType': lockType,
+        'failedAttempts': failedAttempts,
         'lockedUntil': lockedUntil?.toIso8601String(),
         'anilistLinked': anilistLinked,
         'malLinked': malLinked,
@@ -64,6 +109,13 @@ class AppProfile {
       };
 
   factory AppProfile.fromJson(Map<String, dynamic> json) {
+    final pinHash = json['pinHash'] as String?;
+    final lockHash = json['lockHash'] as String? ?? pinHash;
+    final lockType = json['lockType'] as String?;
+    final effectiveLockType = (lockType != null && lockType != 'none')
+        ? lockType
+        : (pinHash != null && pinHash.isNotEmpty ? 'pin' : 'none');
+
     return AppProfile(
       id: json['id'] as String,
       name: json['name'] as String? ?? 'Profile',
@@ -75,8 +127,11 @@ class AppProfile {
       lastUsedAt: json['lastUsedAt'] != null
           ? DateTime.parse(json['lastUsedAt'] as String)
           : DateTime.now(),
-      pinHash: json['pinHash'] as String?,
-      failedPinAttempts: json['failedPinAttempts'] as int? ?? 0,
+      lockHash: lockHash,
+      lockType: effectiveLockType,
+      failedAttempts: json['failedAttempts'] as int? ??
+          json['failedPinAttempts'] as int? ??
+          0,
       lockedUntil: json['lockedUntil'] != null
           ? DateTime.parse(json['lockedUntil'] as String)
           : null,
@@ -89,7 +144,9 @@ class AppProfile {
   static List<AppProfile> fromJsonList(String jsonStr) {
     try {
       final list = jsonDecode(jsonStr) as List<dynamic>;
-      return list.map((e) => AppProfile.fromJson(e as Map<String, dynamic>)).toList();
+      return list
+          .map((e) => AppProfile.fromJson(e as Map<String, dynamic>))
+          .toList();
     } catch (_) {
       return [];
     }
@@ -102,13 +159,15 @@ class AppProfile {
   AppProfile copyWith({
     String? name,
     String? avatarPath,
-    String? pinHash,
-    int? failedPinAttempts,
+    String? lockHash,
+    String? lockType,
+    int? failedAttempts,
     DateTime? lockedUntil,
     bool? anilistLinked,
     bool? malLinked,
     bool? simklLinked,
     DateTime? lastUsedAt,
+    bool clearLock = false,
   }) {
     return AppProfile(
       id: id,
@@ -116,9 +175,14 @@ class AppProfile {
       avatarPath: avatarPath ?? this.avatarPath,
       createdAt: createdAt,
       lastUsedAt: lastUsedAt ?? this.lastUsedAt,
-      pinHash: pinHash ?? this.pinHash,
-      failedPinAttempts: failedPinAttempts ?? this.failedPinAttempts,
-      lockedUntil: lockedUntil ?? this.lockedUntil,
+      lockHash: clearLock ? null : (lockHash ?? this.lockHash),
+      lockType: clearLock ? 'none' : (lockType ?? this.lockType),
+      failedAttempts: clearLock
+          ? 0
+          : (failedAttempts ?? this.failedAttempts),
+      lockedUntil: clearLock
+          ? null
+          : (lockedUntil ?? this.lockedUntil),
     )
       ..anilistLinked = anilistLinked ?? this.anilistLinked
       ..malLinked = malLinked ?? this.malLinked

--- a/lib/models/Service/app_profile.dart
+++ b/lib/models/Service/app_profile.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+
+class AppProfile {
+  final String id;
+  String name;
+  String avatarPath;
+  final DateTime createdAt;
+  DateTime lastUsedAt;
+  String? pinHash;
+  int failedPinAttempts;
+  DateTime? lockedUntil;
+
+  AppProfile({
+    required this.id,
+    required this.name,
+    this.avatarPath = '',
+    DateTime? createdAt,
+    DateTime? lastUsedAt,
+    this.pinHash,
+    this.failedPinAttempts = 0,
+    this.lockedUntil,
+  })  : createdAt = createdAt ?? DateTime.now(),
+        lastUsedAt = lastUsedAt ?? DateTime.now();
+
+  bool get hasAniList => anilistLinked;
+  bool get hasMAL => malLinked;
+  bool get hasSimkl => simklLinked;
+
+  bool anilistLinked = false;
+  bool malLinked = false;
+  bool simklLinked = false;
+
+  bool get isLocked {
+    if (lockedUntil == null) return false;
+    return DateTime.now().isBefore(lockedUntil!);
+  }
+
+  bool get hasPin => pinHash != null && pinHash!.isNotEmpty;
+
+  String get initials {
+    if (name.isEmpty) return '?';
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length >= 2) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return name[0].toUpperCase();
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'avatarPath': avatarPath,
+        'createdAt': createdAt.toIso8601String(),
+        'lastUsedAt': lastUsedAt.toIso8601String(),
+        'pinHash': pinHash,
+        'failedPinAttempts': failedPinAttempts,
+        'lockedUntil': lockedUntil?.toIso8601String(),
+        'anilistLinked': anilistLinked,
+        'malLinked': malLinked,
+        'simklLinked': simklLinked,
+      };
+
+  factory AppProfile.fromJson(Map<String, dynamic> json) {
+    return AppProfile(
+      id: json['id'] as String,
+      name: json['name'] as String? ?? 'Profile',
+      avatarPath: json['avatarPath'] as String? ??
+          (json['avatarEmoji'] as String? ?? ''),
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse(json['createdAt'] as String)
+          : DateTime.now(),
+      lastUsedAt: json['lastUsedAt'] != null
+          ? DateTime.parse(json['lastUsedAt'] as String)
+          : DateTime.now(),
+      pinHash: json['pinHash'] as String?,
+      failedPinAttempts: json['failedPinAttempts'] as int? ?? 0,
+      lockedUntil: json['lockedUntil'] != null
+          ? DateTime.parse(json['lockedUntil'] as String)
+          : null,
+    )
+      ..anilistLinked = json['anilistLinked'] as bool? ?? false
+      ..malLinked = json['malLinked'] as bool? ?? false
+      ..simklLinked = json['simklLinked'] as bool? ?? false;
+  }
+
+  static List<AppProfile> fromJsonList(String jsonStr) {
+    try {
+      final list = jsonDecode(jsonStr) as List<dynamic>;
+      return list.map((e) => AppProfile.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  static String toJsonList(List<AppProfile> profiles) {
+    return jsonEncode(profiles.map((e) => e.toJson()).toList());
+  }
+
+  AppProfile copyWith({
+    String? name,
+    String? avatarPath,
+    String? pinHash,
+    int? failedPinAttempts,
+    DateTime? lockedUntil,
+    bool? anilistLinked,
+    bool? malLinked,
+    bool? simklLinked,
+    DateTime? lastUsedAt,
+  }) {
+    return AppProfile(
+      id: id,
+      name: name ?? this.name,
+      avatarPath: avatarPath ?? this.avatarPath,
+      createdAt: createdAt,
+      lastUsedAt: lastUsedAt ?? this.lastUsedAt,
+      pinHash: pinHash ?? this.pinHash,
+      failedPinAttempts: failedPinAttempts ?? this.failedPinAttempts,
+      lockedUntil: lockedUntil ?? this.lockedUntil,
+    )
+      ..anilistLinked = anilistLinked ?? this.anilistLinked
+      ..malLinked = malLinked ?? this.malLinked
+      ..simklLinked = simklLinked ?? this.simklLinked;
+  }
+}

--- a/lib/screens/anime/widgets/custom_list_dialog.dart
+++ b/lib/screens/anime/widgets/custom_list_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
+import 'package:anymex/database/kv_helper.dart';
 import 'package:anymex/main.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/utils/theme_extensions.dart';
@@ -43,10 +44,19 @@ class _CustomListDialogState extends State<CustomListDialog> {
   }
 
   void _init() {
-    final raw = isar.customLists
+    final pid = KvHelper.profilePrefix.isNotEmpty
+        ? KvHelper.profilePrefix.substring(0, KvHelper.profilePrefix.length - 1)
+        : null;
+
+    var query = isar.customLists
         .filter()
-        .mediaTypeIndexEqualTo(widget.original.mediaType.index)
-        .findAllSync();
+        .mediaTypeIndexEqualTo(widget.original.mediaType.index);
+
+    if (pid != null) {
+      query = query.profileIdEqualTo(pid);
+    }
+
+    final raw = query.findAllSync();
 
     customList = raw
         .map((l) => CustomList(

--- a/lib/screens/downloads/download_screen.dart
+++ b/lib/screens/downloads/download_screen.dart
@@ -223,8 +223,12 @@ class _DownloadScreenState extends State<DownloadScreen> {
   Future<void> _pickDownloadDirectory() async {
     final result = await FilePicker.platform.getDirectoryPath();
     if (result != null && mounted) {
-      _settings.saveDownloadPath(result);
-      setState(() => _hasDownloadDir = true);
+      final accepted = _settings.saveDownloadPath(result);
+      if (accepted) {
+        setState(() => _hasDownloadDir = true);
+      } else {
+        snackBar('This folder is already used by another profile. Please choose a different folder.');
+      }
     }
   }
 

--- a/lib/screens/profile/profile_creation_page.dart
+++ b/lib/screens/profile/profile_creation_page.dart
@@ -632,7 +632,6 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
               ),
             ),
 
-            // Bottom buttons
             SafeArea(
               top: false,
               child: Padding(

--- a/lib/screens/profile/profile_creation_page.dart
+++ b/lib/screens/profile/profile_creation_page.dart
@@ -16,12 +16,17 @@ class ProfileCreationPage extends StatefulWidget {
 
 class _ProfileCreationPageState extends State<ProfileCreationPage> {
   final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _pinController = TextEditingController();
+  final TextEditingController _confirmPinController = TextEditingController();
   String _avatarPath = '';
   bool _isCreating = false;
+  bool _enablePin = false;
 
   @override
   void dispose() {
     _nameController.dispose();
+    _pinController.dispose();
+    _confirmPinController.dispose();
     super.dispose();
   }
 
@@ -41,6 +46,32 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
       return;
     }
 
+    if (_enablePin) {
+      final pin = _pinController.text.trim();
+      final confirmPin = _confirmPinController.text.trim();
+
+      if (pin.length < 4 || pin.length > 6) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('PIN must be 4-6 digits')),
+        );
+        return;
+      }
+
+      if (!RegExp(r'^\d+$').hasMatch(pin)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('PIN must contain only numbers')),
+        );
+        return;
+      }
+
+      if (pin != confirmPin) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('PINs do not match')),
+        );
+        return;
+      }
+    }
+
     setState(() => _isCreating = true);
 
     final manager = Get.find<ProfileManager>();
@@ -57,6 +88,10 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
         );
       }
       return;
+    }
+
+    if (_enablePin) {
+      manager.setPin(profile.id, _pinController.text.trim());
     }
 
     await manager.switchToProfile(profile.id);
@@ -191,7 +226,238 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
                 ),
               ),
             ),
-            const SizedBox(height: 40),
+            const SizedBox(height: 20),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainer,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.lock_outline_rounded,
+                            size: 20,
+                            color: _enablePin
+                                ? colorScheme.primary
+                                : theme.onSurface.withOpacity(0.5),
+                          ),
+                          const SizedBox(width: 12),
+                          Text(
+                            'Protect with PIN',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: theme.onSurface,
+                            ),
+                          ),
+                        ],
+                      ),
+                      Switch(
+                        value: _enablePin,
+                        onChanged: (val) {
+                          setState(() {
+                            _enablePin = val;
+                            if (!val) {
+                              _pinController.clear();
+                              _confirmPinController.clear();
+                            }
+                          });
+                        },
+                        activeColor: colorScheme.primary,
+                      ),
+                    ],
+                  ),
+                  if (!_enablePin)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Profile will be unprotected. Anyone who opens the app can access it.',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: theme.onSurface.withOpacity(0.4),
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (_enablePin) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      'Set a 4-6 digit PIN. You\'ll need to enter it every time you open this profile.',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: theme.onSurface.withOpacity(0.6),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    TextField(
+                      controller: _pinController,
+                      keyboardType: TextInputType.number,
+                      obscureText: true,
+                      maxLength: 6,
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontFamily: 'Poppins',
+                        fontSize: 22,
+                        letterSpacing: 8,
+                      ),
+                      textAlign: TextAlign.center,
+                      decoration: InputDecoration(
+                        labelText: 'Create PIN',
+                        labelStyle: TextStyle(
+                          color: theme.onSurface.withOpacity(0.6),
+                          fontFamily: 'Poppins',
+                          fontSize: 13,
+                        ),
+                        filled: true,
+                        fillColor: colorScheme.surface,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(
+                            color: colorScheme.primary,
+                            width: 2,
+                          ),
+                        ),
+                        counterText: '',
+                        prefixIcon: Icon(
+                          Icons.password_rounded,
+                          color: colorScheme.primary.withOpacity(0.6),
+                          size: 20,
+                        ),
+                        prefixIconConstraints: const BoxConstraints(
+                          minWidth: 40,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    if (_pinController.text.isNotEmpty)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 10),
+                        decoration: BoxDecoration(
+                          color: colorScheme.primary.withOpacity(0.08),
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'Preview: ',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontFamily: 'Poppins',
+                                color: theme.onSurface.withOpacity(0.5),
+                              ),
+                            ),
+                            Row(
+                              children: List.generate(
+                                _pinController.text.length,
+                                (index) => Container(
+                                  margin: const EdgeInsets.symmetric(
+                                      horizontal: 3),
+                                  width: 12,
+                                  height: 12,
+                                  decoration: BoxDecoration(
+                                    color: colorScheme.primary,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: _confirmPinController,
+                      keyboardType: TextInputType.number,
+                      obscureText: true,
+                      maxLength: 6,
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontFamily: 'Poppins',
+                        fontSize: 22,
+                        letterSpacing: 8,
+                      ),
+                      textAlign: TextAlign.center,
+                      decoration: InputDecoration(
+                        labelText: 'Confirm PIN',
+                        labelStyle: TextStyle(
+                          color: theme.onSurface.withOpacity(0.6),
+                          fontFamily: 'Poppins',
+                          fontSize: 13,
+                        ),
+                        filled: true,
+                        fillColor: colorScheme.surface,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(
+                            color: colorScheme.primary,
+                            width: 2,
+                          ),
+                        ),
+                        counterText: '',
+                        prefixIcon: Icon(
+                          Icons.password_rounded,
+                          color: colorScheme.primary.withOpacity(0.6),
+                          size: 20,
+                        ),
+                        prefixIconConstraints: const BoxConstraints(
+                          minWidth: 40,
+                        ),
+                      ),
+                    ),
+                    if (_confirmPinController.text.isNotEmpty &&
+                        _confirmPinController.text != _pinController.text)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline_rounded,
+                                color: Colors.red, size: 14),
+                            const SizedBox(width: 4),
+                            const Text('PINs do not match',
+                                style:
+                                    TextStyle(color: Colors.red, fontSize: 12)),
+                          ],
+                        ),
+                      ),
+                    if (_confirmPinController.text.isNotEmpty &&
+                        _confirmPinController.text == _pinController.text)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Row(
+                          children: [
+                            Icon(Icons.check_circle_outline_rounded,
+                                color: Colors.green.shade400, size: 14),
+                            const SizedBox(width: 4),
+                            Text('PINs match',
+                                style: TextStyle(
+                                    color: Colors.green.shade400, fontSize: 12)),
+                          ],
+                        ),
+                      ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: 32),
             Obx(() {
               final count = Get.find<ProfileManager>().profiles.length;
               return Text(
@@ -227,7 +493,7 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
                         ),
                       )
                     : Text(
-                        'Create Profile',
+                        _enablePin ? 'Create Protected Profile' : 'Create Profile',
                         style: TextStyle(
                           fontFamily: 'Poppins',
                           fontWeight: FontWeight.bold,

--- a/lib/screens/profile/profile_creation_page.dart
+++ b/lib/screens/profile/profile_creation_page.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
@@ -14,20 +16,56 @@ class ProfileCreationPage extends StatefulWidget {
   State<ProfileCreationPage> createState() => _ProfileCreationPageState();
 }
 
-class _ProfileCreationPageState extends State<ProfileCreationPage> {
+class _ProfileCreationPageState extends State<ProfileCreationPage>
+    with SingleTickerProviderStateMixin {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _pinController = TextEditingController();
   final TextEditingController _confirmPinController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController = TextEditingController();
   String _avatarPath = '';
   bool _isCreating = false;
-  bool _enablePin = false;
+  bool _showSetupForm = false;
+  ProfileLockType _lockType = ProfileLockType.none;
+  List<int> _pattern = [];
+  bool _patternConfirmed = false;
+  List<int> _firstPattern = [];
+
+  late final AnimationController _animController;
+  late final Animation<double> _expandAnimation;
+  late final Animation<double> _fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    );
+    _expandAnimation = CurvedAnimation(
+      parent: _animController,
+      curve: Curves.easeInOutCubic,
+    );
+    _fadeAnimation = CurvedAnimation(
+      parent: _animController,
+      curve: Curves.easeIn,
+    );
+  }
 
   @override
   void dispose() {
     _nameController.dispose();
     _pinController.dispose();
     _confirmPinController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    _animController.dispose();
     super.dispose();
+  }
+
+  void _toggleSetupForm() {
+    setState(() => _showSetupForm = true);
+    _animController.forward();
   }
 
   Future<void> _pickImage() async {
@@ -35,6 +73,69 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
     if (path != null) {
       setState(() => _avatarPath = path);
     }
+  }
+
+  bool _validateLock() {
+    switch (_lockType) {
+      case ProfileLockType.none:
+        return true;
+      case ProfileLockType.pin:
+        final pin = _pinController.text.trim();
+        final confirmPin = _confirmPinController.text.trim();
+        if (pin.length < 4 || pin.length > 6) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('PIN must be 4-6 digits')),
+          );
+          return false;
+        }
+        if (!RegExp(r'^\d+$').hasMatch(pin)) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('PIN must contain only numbers')),
+          );
+          return false;
+        }
+        if (pin != confirmPin) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('PINs do not match')),
+          );
+          return false;
+        }
+        return true;
+      case ProfileLockType.password:
+        final password = _passwordController.text;
+        final confirmPassword = _confirmPasswordController.text;
+        if (password.length < 4 || password.length > 32) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Password must be 4-32 characters')),
+          );
+          return false;
+        }
+        if (password != confirmPassword) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Passwords do not match')),
+          );
+          return false;
+        }
+        return true;
+      case ProfileLockType.pattern:
+        if (!_patternConfirmed || _pattern.length < 4) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Please draw and confirm a pattern with at least 4 dots')),
+          );
+          return false;
+        }
+        return true;
+    }
+  }
+
+  void _resetLockInputs() {
+    _pinController.clear();
+    _confirmPinController.clear();
+    _passwordController.clear();
+    _confirmPasswordController.clear();
+    _pattern.clear();
+    _firstPattern.clear();
+    _patternConfirmed = false;
   }
 
   Future<void> _createProfile() async {
@@ -46,31 +147,7 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
       return;
     }
 
-    if (_enablePin) {
-      final pin = _pinController.text.trim();
-      final confirmPin = _confirmPinController.text.trim();
-
-      if (pin.length < 4 || pin.length > 6) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('PIN must be 4-6 digits')),
-        );
-        return;
-      }
-
-      if (!RegExp(r'^\d+$').hasMatch(pin)) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('PIN must contain only numbers')),
-        );
-        return;
-      }
-
-      if (pin != confirmPin) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('PINs do not match')),
-        );
-        return;
-      }
-    }
+    if (!_validateLock()) return;
 
     setState(() => _isCreating = true);
 
@@ -90,14 +167,55 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
       return;
     }
 
-    if (_enablePin) {
-      manager.setPin(profile.id, _pinController.text.trim());
+    switch (_lockType) {
+      case ProfileLockType.none:
+        break;
+      case ProfileLockType.pin:
+        manager.setPin(profile.id, _pinController.text.trim());
+        break;
+      case ProfileLockType.password:
+        manager.setPassword(profile.id, _passwordController.text);
+        break;
+      case ProfileLockType.pattern:
+        manager.setPattern(profile.id, _pattern);
+        break;
     }
 
     await manager.switchToProfile(profile.id);
 
     if (mounted) {
       Navigator.of(context).pop(profile);
+    }
+  }
+
+  Future<void> _skipAndCreateDefault() async {
+    final manager = Get.find<ProfileManager>();
+    await manager.skipMultiProfileSetup();
+  }
+
+  IconData _getLockIcon(ProfileLockType type) {
+    switch (type) {
+      case ProfileLockType.none:
+        return Icons.lock_open_rounded;
+      case ProfileLockType.pin:
+        return Icons.dialpad_rounded;
+      case ProfileLockType.password:
+        return Icons.password_rounded;
+      case ProfileLockType.pattern:
+        return Icons.grid_3x3_rounded;
+    }
+  }
+
+  String _getLockLabel(ProfileLockType type) {
+    switch (type) {
+      case ProfileLockType.none:
+        return 'None';
+      case ProfileLockType.pin:
+        return 'PIN';
+      case ProfileLockType.password:
+        return 'Password';
+      case ProfileLockType.pattern:
+        return 'Pattern';
     }
   }
 
@@ -108,404 +226,838 @@ class _ProfileCreationPageState extends State<ProfileCreationPage> {
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        title: Text(
-          'Create Profile',
-          style: TextStyle(
-            fontFamily: 'Poppins',
-            fontWeight: FontWeight.bold,
-            color: theme.onSurface,
-          ),
-        ),
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: theme.onSurface),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
+      body: SafeArea(
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            const SizedBox(height: 20),
-            GestureDetector(
-              onTap: _pickImage,
-              child: Container(
-                width: 100,
-                height: 100,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: colorScheme.primaryContainer,
-                  border: Border.all(
-                    color: colorScheme.primary,
-                    width: 3,
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: colorScheme.primary.withOpacity(0.3),
-                      blurRadius: 20,
-                      spreadRadius: 2,
-                    ),
-                  ],
-                ),
-                child: _avatarPath.isNotEmpty
-                    ? ClipOval(
-                        child: Image.file(
-                          File(_avatarPath),
-                          width: 100,
-                          height: 100,
-                          fit: BoxFit.cover,
-                        ),
-                      )
-                    : Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.add_a_photo_rounded,
-                            size: 32,
-                            color: colorScheme.primary.withOpacity(0.7),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            'Add Photo',
-                            style: TextStyle(
-                              fontSize: 11,
-                              color:
-                                  colorScheme.onSurface.withOpacity(0.5),
-                            ),
-                          ),
-                        ],
-                      ),
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              _avatarPath.isNotEmpty ? 'Tap to change photo' : 'Tap to add avatar',
-              style: TextStyle(
-                color: theme.onSurface.withOpacity(0.5),
-                fontSize: 13,
-              ),
-            ),
-            const SizedBox(height: 32),
-            TextField(
-              controller: _nameController,
-              autofocus: true,
-              textCapitalization: TextCapitalization.words,
-              maxLength: 20,
-              style: TextStyle(color: theme.onSurface, fontFamily: 'Poppins'),
-              decoration: InputDecoration(
-                labelText: 'Profile Name',
-                labelStyle: TextStyle(
-                  color: theme.onSurface.withOpacity(0.7),
-                  fontFamily: 'Poppins',
-                ),
-                hintText: 'Enter a name...',
-                hintStyle: TextStyle(
-                  color: theme.onSurface.withOpacity(0.3),
-                ),
-                filled: true,
-                fillColor: colorScheme.surfaceContainer,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide.none,
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide(
-                    color: colorScheme.primary,
-                    width: 2,
-                  ),
-                ),
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 16,
-                ),
-                counterStyle: TextStyle(
-                  color: theme.onSurface.withOpacity(0.5),
-                ),
-              ),
-            ),
-            const SizedBox(height: 20),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              decoration: BoxDecoration(
-                color: colorScheme.surfaceContainer,
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Column(
+            // App bar - only show back button when in form mode
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 8, 16, 0),
+              child: Row(
                 children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.lock_outline_rounded,
-                            size: 20,
-                            color: _enablePin
-                                ? colorScheme.primary
-                                : theme.onSurface.withOpacity(0.5),
-                          ),
-                          const SizedBox(width: 12),
-                          Text(
-                            'Protect with PIN',
-                            style: TextStyle(
-                              fontFamily: 'Poppins',
-                              fontWeight: FontWeight.w600,
-                              fontSize: 14,
-                              color: theme.onSurface,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Switch(
-                        value: _enablePin,
-                        onChanged: (val) {
-                          setState(() {
-                            _enablePin = val;
-                            if (!val) {
-                              _pinController.clear();
-                              _confirmPinController.clear();
-                            }
-                          });
-                        },
-                        activeColor: colorScheme.primary,
-                      ),
-                    ],
-                  ),
-                  if (!_enablePin)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          'Profile will be unprotected. Anyone who opens the app can access it.',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: theme.onSurface.withOpacity(0.4),
-                          ),
-                        ),
-                      ),
-                    ),
-                  if (_enablePin) ...[
-                    const SizedBox(height: 16),
-                    Text(
-                      'Set a 4-6 digit PIN. You\'ll need to enter it every time you open this profile.',
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: theme.onSurface.withOpacity(0.6),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: _pinController,
-                      keyboardType: TextInputType.number,
-                      obscureText: true,
-                      maxLength: 6,
-                      style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontFamily: 'Poppins',
-                        fontSize: 22,
-                        letterSpacing: 8,
-                      ),
-                      textAlign: TextAlign.center,
-                      decoration: InputDecoration(
-                        labelText: 'Create PIN',
-                        labelStyle: TextStyle(
-                          color: theme.onSurface.withOpacity(0.6),
-                          fontFamily: 'Poppins',
-                          fontSize: 13,
-                        ),
-                        filled: true,
-                        fillColor: colorScheme.surface,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide.none,
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: colorScheme.primary,
-                            width: 2,
-                          ),
-                        ),
-                        counterText: '',
-                        prefixIcon: Icon(
-                          Icons.password_rounded,
-                          color: colorScheme.primary.withOpacity(0.6),
-                          size: 20,
-                        ),
-                        prefixIconConstraints: const BoxConstraints(
-                          minWidth: 40,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    if (_pinController.text.isNotEmpty)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 10),
-                        decoration: BoxDecoration(
-                          color: colorScheme.primary.withOpacity(0.08),
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              'Preview: ',
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontFamily: 'Poppins',
-                                color: theme.onSurface.withOpacity(0.5),
-                              ),
-                            ),
-                            Row(
-                              children: List.generate(
-                                _pinController.text.length,
-                                (index) => Container(
-                                  margin: const EdgeInsets.symmetric(
-                                      horizontal: 3),
-                                  width: 12,
-                                  height: 12,
-                                  decoration: BoxDecoration(
-                                    color: colorScheme.primary,
-                                    shape: BoxShape.circle,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    const SizedBox(height: 12),
-                    TextField(
-                      controller: _confirmPinController,
-                      keyboardType: TextInputType.number,
-                      obscureText: true,
-                      maxLength: 6,
-                      style: TextStyle(
-                        color: colorScheme.onSurface,
-                        fontFamily: 'Poppins',
-                        fontSize: 22,
-                        letterSpacing: 8,
-                      ),
-                      textAlign: TextAlign.center,
-                      decoration: InputDecoration(
-                        labelText: 'Confirm PIN',
-                        labelStyle: TextStyle(
-                          color: theme.onSurface.withOpacity(0.6),
-                          fontFamily: 'Poppins',
-                          fontSize: 13,
-                        ),
-                        filled: true,
-                        fillColor: colorScheme.surface,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide.none,
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: colorScheme.primary,
-                            width: 2,
-                          ),
-                        ),
-                        counterText: '',
-                        prefixIcon: Icon(
-                          Icons.password_rounded,
-                          color: colorScheme.primary.withOpacity(0.6),
-                          size: 20,
-                        ),
-                        prefixIconConstraints: const BoxConstraints(
-                          minWidth: 40,
-                        ),
-                      ),
-                    ),
-                    if (_confirmPinController.text.isNotEmpty &&
-                        _confirmPinController.text != _pinController.text)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 6),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.error_outline_rounded,
-                                color: Colors.red, size: 14),
-                            const SizedBox(width: 4),
-                            const Text('PINs do not match',
-                                style:
-                                    TextStyle(color: Colors.red, fontSize: 12)),
-                          ],
-                        ),
-                      ),
-                    if (_confirmPinController.text.isNotEmpty &&
-                        _confirmPinController.text == _pinController.text)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 6),
-                        child: Row(
-                          children: [
-                            Icon(Icons.check_circle_outline_rounded,
-                                color: Colors.green.shade400, size: 14),
-                            const SizedBox(width: 4),
-                            Text('PINs match',
-                                style: TextStyle(
-                                    color: Colors.green.shade400, fontSize: 12)),
-                          ],
-                        ),
-                      ),
-                  ],
+                  if (_showSetupForm)
+                    IconButton(
+                      icon: Icon(Icons.arrow_back, color: theme.onSurface),
+                      onPressed: () {
+                        setState(() => _showSetupForm = false);
+                        _animController.reverse();
+                      },
+                    )
+                  else
+                    const SizedBox(width: 48),
                 ],
               ),
             ),
-            const SizedBox(height: 32),
-            Obx(() {
-              final count = Get.find<ProfileManager>().profiles.length;
-              return Text(
-                '$count / $kMaxProfiles profiles',
-                style: TextStyle(
-                  color: count >= kMaxProfiles
-                      ? Colors.red
-                      : theme.onSurface.withOpacity(0.5),
-                  fontSize: 13,
-                ),
-              );
-            }),
-            const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              height: 56,
-              child: ElevatedButton(
-                onPressed: _isCreating ? null : _createProfile,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: colorScheme.primary,
-                  foregroundColor: colorScheme.onPrimary,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  elevation: 0,
-                ),
-                child: _isCreating
-                    ? const SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: AnymexProgressIndicator(
-                          strokeWidth: 2.5,
+
+            // Scrollable content
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Column(
+                  children: [
+                    // Welcome icon
+                    Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: colorScheme.primaryContainer,
+                        border: Border.all(
+                          color: colorScheme.primary,
+                          width: 2.5,
                         ),
-                      )
-                    : Text(
-                        _enablePin ? 'Create Protected Profile' : 'Create Profile',
-                        style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          color: colorScheme.onPrimary,
+                        boxShadow: [
+                          BoxShadow(
+                            color: colorScheme.primary.withOpacity(0.25),
+                            blurRadius: 24,
+                            spreadRadius: 2,
+                          ),
+                        ],
+                      ),
+                      child: Icon(
+                        Icons.person_rounded,
+                        size: 36,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(height: 28),
+                    Text(
+                      'Welcome to AnymeX',
+                      style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontWeight: FontWeight.bold,
+                        fontSize: 26,
+                        color: theme.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Text(
+                      _showSetupForm
+                          ? 'Set up your first profile to get started.'
+                          : 'Set up separate profiles to keep your watch history, accounts, and settings organized — or skip and start using the app right away.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontSize: 14,
+                        color: theme.onSurface.withOpacity(0.55),
+                        height: 1.5,
+                      ),
+                    ),
+
+                    // Expandable creation form
+                    SizeTransition(
+                      sizeFactor: _expandAnimation,
+                      axisAlignment: -1.0,
+                      child: FadeTransition(
+                        opacity: _fadeAnimation,
+                        child: Column(
+                          children: [
+                            const SizedBox(height: 24),
+                            GestureDetector(
+                              onTap: _pickImage,
+                              child: Container(
+                                width: 100,
+                                height: 100,
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: colorScheme.primaryContainer,
+                                  border: Border.all(
+                                    color: colorScheme.primary,
+                                    width: 3,
+                                  ),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color:
+                                          colorScheme.primary.withOpacity(0.3),
+                                      blurRadius: 20,
+                                      spreadRadius: 2,
+                                    ),
+                                  ],
+                                ),
+                                child: _avatarPath.isNotEmpty
+                                    ? ClipOval(
+                                        child: Image.file(
+                                          File(_avatarPath),
+                                          width: 100,
+                                          height: 100,
+                                          fit: BoxFit.cover,
+                                        ),
+                                      )
+                                    : Column(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.center,
+                                        children: [
+                                          Icon(
+                                            Icons.add_a_photo_rounded,
+                                            size: 32,
+                                            color: colorScheme.primary
+                                                .withOpacity(0.7),
+                                          ),
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            'Add Photo',
+                                            style: TextStyle(
+                                              fontSize: 11,
+                                              color: colorScheme.onSurface
+                                                  .withOpacity(0.5),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              _avatarPath.isNotEmpty
+                                  ? 'Tap to change photo'
+                                  : 'Tap to add avatar',
+                              style: TextStyle(
+                                color: theme.onSurface.withOpacity(0.5),
+                                fontSize: 13,
+                              ),
+                            ),
+                            const SizedBox(height: 24),
+                            TextField(
+                              controller: _nameController,
+                              autofocus: true,
+                              textCapitalization: TextCapitalization.words,
+                              maxLength: 20,
+                              style: TextStyle(
+                                  color: theme.onSurface,
+                                  fontFamily: 'Poppins'),
+                              decoration: InputDecoration(
+                                labelText: 'Profile Name',
+                                labelStyle: TextStyle(
+                                  color: theme.onSurface.withOpacity(0.7),
+                                  fontFamily: 'Poppins',
+                                ),
+                                hintText: 'Enter a name...',
+                                hintStyle: TextStyle(
+                                  color: theme.onSurface.withOpacity(0.3),
+                                ),
+                                filled: true,
+                                fillColor: colorScheme.surfaceContainer,
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                  borderSide: BorderSide.none,
+                                ),
+                                focusedBorder: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                  borderSide: BorderSide(
+                                    color: colorScheme.primary,
+                                    width: 2,
+                                  ),
+                                ),
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 16,
+                                ),
+                                counterStyle: TextStyle(
+                                  color: theme.onSurface.withOpacity(0.5),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 20),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 14),
+                              decoration: BoxDecoration(
+                                color: colorScheme.surfaceContainer,
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Icon(
+                                        Icons.lock_outline_rounded,
+                                        size: 20,
+                                        color: _lockType != ProfileLockType.none
+                                            ? colorScheme.primary
+                                            : theme.onSurface.withOpacity(0.5),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Text(
+                                          'Protection',
+                                          style: TextStyle(
+                                            fontFamily: 'Poppins',
+                                            fontWeight: FontWeight.w600,
+                                            fontSize: 14,
+                                            color: theme.onSurface,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Wrap(
+                                    spacing: 8,
+                                    runSpacing: 8,
+                                    children:
+                                        ProfileLockType.values.map((type) {
+                                      final isSelected = _lockType == type;
+                                      return ChoiceChip(
+                                        avatar: Icon(
+                                          _getLockIcon(type),
+                                          size: 16,
+                                          color: isSelected
+                                              ? colorScheme.onPrimary
+                                              : theme.onSurface
+                                                  .withOpacity(0.6),
+                                        ),
+                                        label: Text(
+                                          _getLockLabel(type),
+                                          style: TextStyle(
+                                            fontFamily: 'Poppins',
+                                            fontSize: 13,
+                                            fontWeight: isSelected
+                                                ? FontWeight.w600
+                                                : FontWeight.w400,
+                                          ),
+                                        ),
+                                        selected: isSelected,
+                                        selectedColor: colorScheme.primary,
+                                        onSelected: (val) {
+                                          setState(() {
+                                            _lockType = type;
+                                            _resetLockInputs();
+                                          });
+                                        },
+                                        labelStyle: TextStyle(
+                                          color: isSelected
+                                              ? colorScheme.onPrimary
+                                              : theme.onSurface,
+                                        ),
+                                        side: BorderSide(
+                                          color: isSelected
+                                              ? colorScheme.primary
+                                              : colorScheme.outline
+                                                  .withOpacity(0.3),
+                                        ),
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(10),
+                                        ),
+                                      );
+                                    }).toList(),
+                                  ),
+                                  if (_lockType == ProfileLockType.none)
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 8),
+                                      child: Text(
+                                        'Profile will be unprotected. Anyone who opens the app can access it.',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color:
+                                              theme.onSurface.withOpacity(0.4),
+                                        ),
+                                      ),
+                                    ),
+                                  if (_lockType == ProfileLockType.pin) ...[
+                                    const SizedBox(height: 16),
+                                    _buildPinSetup(colorScheme, theme),
+                                  ],
+                                  if (_lockType ==
+                                      ProfileLockType.password) ...[
+                                    const SizedBox(height: 16),
+                                    _buildPasswordSetup(colorScheme, theme),
+                                  ],
+                                  if (_lockType == ProfileLockType.pattern) ...[
+                                    const SizedBox(height: 16),
+                                    _buildPatternSetup(colorScheme, theme),
+                                  ],
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 24),
+                            SizedBox(
+                              width: double.infinity,
+                              height: 56,
+                              child: ElevatedButton(
+                                onPressed:
+                                    _isCreating ? null : _createProfile,
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: colorScheme.primary,
+                                  foregroundColor: colorScheme.onPrimary,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
+                                  elevation: 0,
+                                ),
+                                child: _isCreating
+                                    ? const SizedBox(
+                                        width: 24,
+                                        height: 24,
+                                        child: AnymexProgressIndicator(
+                                          strokeWidth: 2.5,
+                                        ),
+                                      )
+                                    : Text(
+                                        _lockType == ProfileLockType.none
+                                            ? 'Create Profile'
+                                            : 'Create Protected Profile',
+                                        style: TextStyle(
+                                          fontFamily: 'Poppins',
+                                          fontWeight: FontWeight.bold,
+                                          fontSize: 16,
+                                          color: colorScheme.onPrimary,
+                                        ),
+                                      ),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Bottom buttons
+            SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 16, 32, 12),
+                child: Column(
+                  children: [
+                    if (!_showSetupForm) ...[
+                      SizedBox(
+                        width: double.infinity,
+                        height: 54,
+                        child: ElevatedButton(
+                          onPressed: _toggleSetupForm,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: colorScheme.primary,
+                            foregroundColor: colorScheme.onPrimary,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            elevation: 0,
+                          ),
+                          child: Text(
+                            'Set Up Profiles',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                              color: colorScheme.onPrimary,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 54,
+                        child: OutlinedButton(
+                          onPressed: _skipAndCreateDefault,
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor:
+                                theme.onSurface.withOpacity(0.7),
+                            side: BorderSide(
+                              color: colorScheme.outline.withOpacity(0.3),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                          child: Text(
+                            'Skip for Now',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 16,
+                              color: theme.onSurface.withOpacity(0.7),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'You can always enable profiles later in Settings.',
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontSize: 12,
+                          color: theme.onSurface.withOpacity(0.35),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildPinSetup(ColorScheme colorScheme, dynamic theme) {
+    return Column(
+      children: [
+        Text(
+          'Set a 4-6 digit PIN. You\'ll need to enter it every time you open this profile.',
+          style: TextStyle(
+            fontSize: 12,
+            color: theme.onSurface.withOpacity(0.6),
+          ),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _pinController,
+          keyboardType: TextInputType.number,
+          obscureText: true,
+          maxLength: 6,
+          style: TextStyle(
+            color: colorScheme.onSurface,
+            fontFamily: 'Poppins',
+            fontSize: 22,
+            letterSpacing: 8,
+          ),
+          textAlign: TextAlign.center,
+          decoration: InputDecoration(
+            labelText: 'Create PIN',
+            labelStyle: TextStyle(
+              color: theme.onSurface.withOpacity(0.6),
+              fontFamily: 'Poppins',
+              fontSize: 13,
+            ),
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: colorScheme.primary,
+                width: 2,
+              ),
+            ),
+            counterText: '',
+            prefixIcon: Icon(
+              Icons.password_rounded,
+              color: colorScheme.primary.withOpacity(0.6),
+              size: 20,
+            ),
+            prefixIconConstraints: const BoxConstraints(
+              minWidth: 40,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (_pinController.text.isNotEmpty)
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            decoration: BoxDecoration(
+              color: colorScheme.primary.withOpacity(0.08),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Preview: ',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontFamily: 'Poppins',
+                    color: theme.onSurface.withOpacity(0.5),
+                  ),
+                ),
+                Row(
+                  children: List.generate(
+                    _pinController.text.length,
+                    (index) => Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 3),
+                      width: 12,
+                      height: 12,
+                      decoration: BoxDecoration(
+                        color: colorScheme.primary,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _confirmPinController,
+          keyboardType: TextInputType.number,
+          obscureText: true,
+          maxLength: 6,
+          style: TextStyle(
+            color: colorScheme.onSurface,
+            fontFamily: 'Poppins',
+            fontSize: 22,
+            letterSpacing: 8,
+          ),
+          textAlign: TextAlign.center,
+          decoration: InputDecoration(
+            labelText: 'Confirm PIN',
+            labelStyle: TextStyle(
+              color: theme.onSurface.withOpacity(0.6),
+              fontFamily: 'Poppins',
+              fontSize: 13,
+            ),
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: colorScheme.primary,
+                width: 2,
+              ),
+            ),
+            counterText: '',
+            prefixIcon: Icon(
+              Icons.password_rounded,
+              color: colorScheme.primary.withOpacity(0.6),
+              size: 20,
+            ),
+            prefixIconConstraints: const BoxConstraints(
+              minWidth: 40,
+            ),
+          ),
+        ),
+        if (_confirmPinController.text.isNotEmpty &&
+            _confirmPinController.text != _pinController.text)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.error_outline_rounded,
+                    color: Colors.red, size: 14),
+                const SizedBox(width: 4),
+                const Text('PINs do not match',
+                    style:
+                        TextStyle(color: Colors.red, fontSize: 12)),
+              ],
+            ),
+          ),
+        if (_confirmPinController.text.isNotEmpty &&
+            _confirmPinController.text == _pinController.text)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Row(
+              children: [
+                Icon(Icons.check_circle_outline_rounded,
+                    color: Colors.green.shade400, size: 14),
+                const SizedBox(width: 4),
+                Text('PINs match',
+                    style: TextStyle(
+                        color: Colors.green.shade400, fontSize: 12)),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildPasswordSetup(ColorScheme colorScheme, dynamic theme) {
+    return Column(
+      children: [
+        Text(
+          'Set a password (4-32 characters) for this profile.',
+          style: TextStyle(
+            fontSize: 12,
+            color: theme.onSurface.withOpacity(0.6),
+          ),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _passwordController,
+          obscureText: true,
+          maxLength: 32,
+          style: TextStyle(
+            color: colorScheme.onSurface,
+            fontFamily: 'Poppins',
+            fontSize: 16,
+          ),
+          decoration: InputDecoration(
+            labelText: 'Create Password',
+            labelStyle: TextStyle(
+              color: theme.onSurface.withOpacity(0.6),
+              fontFamily: 'Poppins',
+              fontSize: 13,
+            ),
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: colorScheme.primary,
+                width: 2,
+              ),
+            ),
+            counterText: '',
+            prefixIcon: Icon(
+              Icons.lock_rounded,
+              color: colorScheme.primary.withOpacity(0.6),
+              size: 20,
+            ),
+            prefixIconConstraints: const BoxConstraints(
+              minWidth: 40,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _confirmPasswordController,
+          obscureText: true,
+          maxLength: 32,
+          style: TextStyle(
+            color: colorScheme.onSurface,
+            fontFamily: 'Poppins',
+            fontSize: 16,
+          ),
+          decoration: InputDecoration(
+            labelText: 'Confirm Password',
+            labelStyle: TextStyle(
+              color: theme.onSurface.withOpacity(0.6),
+              fontFamily: 'Poppins',
+              fontSize: 13,
+            ),
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: colorScheme.primary,
+                width: 2,
+              ),
+            ),
+            counterText: '',
+            prefixIcon: Icon(
+              Icons.lock_rounded,
+              color: colorScheme.primary.withOpacity(0.6),
+              size: 20,
+            ),
+            prefixIconConstraints: const BoxConstraints(
+              minWidth: 40,
+            ),
+          ),
+        ),
+        if (_confirmPasswordController.text.isNotEmpty &&
+            _confirmPasswordController.text != _passwordController.text)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.error_outline_rounded,
+                    color: Colors.red, size: 14),
+                const SizedBox(width: 4),
+                const Text('Passwords do not match',
+                    style:
+                        TextStyle(color: Colors.red, fontSize: 12)),
+              ],
+            ),
+          ),
+        if (_confirmPasswordController.text.isNotEmpty &&
+            _confirmPasswordController.text == _passwordController.text)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Row(
+              children: [
+                Icon(Icons.check_circle_outline_rounded,
+                    color: Colors.green.shade400, size: 14),
+                const SizedBox(width: 4),
+                Text('Passwords match',
+                    style: TextStyle(
+                        color: Colors.green.shade400, fontSize: 12)),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildPatternSetup(ColorScheme colorScheme, dynamic theme) {
+    return Column(
+      children: [
+        Text(
+          _firstPattern.isEmpty
+              ? 'Draw a pattern by connecting at least 4 dots.'
+              : 'Draw the pattern again to confirm.',
+          style: TextStyle(
+            fontSize: 12,
+            color: theme.onSurface.withOpacity(0.6),
+          ),
+        ),
+        if (_patternConfirmed)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.check_circle_outline_rounded,
+                    color: Colors.green.shade400, size: 14),
+                const SizedBox(width: 4),
+                Text('Pattern confirmed',
+                    style: TextStyle(
+                        color: Colors.green.shade400, fontSize: 12)),
+              ],
+            ),
+          ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: 240,
+          height: 240,
+          child: PatternLock(
+            onPatternComplete: (pattern) {
+              if (_firstPattern.isEmpty) {
+                setState(() {
+                  _firstPattern = pattern;
+                });
+              } else {
+                if (pattern.length >= 4) {
+                  final matches =
+                      pattern.length == _firstPattern.length;
+                  bool samePattern = false;
+                  if (matches) {
+                    samePattern = true;
+                    for (int i = 0; i < pattern.length; i++) {
+                      if (pattern[i] != _firstPattern[i]) {
+                        samePattern = false;
+                        break;
+                      }
+                    }
+                  }
+                  if (samePattern) {
+                    setState(() {
+                      _pattern = pattern;
+                      _patternConfirmed = true;
+                    });
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content:
+                            Text('Patterns do not match. Try again.'),
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
+                    setState(() {
+                      _firstPattern.clear();
+                    });
+                  }
+                }
+              }
+            },
+          ),
+        ),
+        if (_firstPattern.isNotEmpty && !_patternConfirmed)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: TextButton.icon(
+              onPressed: () {
+                setState(() {
+                  _firstPattern.clear();
+                  _pattern.clear();
+                });
+              },
+              icon: const Icon(Icons.refresh, size: 14),
+              label: const Text('Reset pattern'),
+              style: TextButton.styleFrom(
+                foregroundColor: colorScheme.primary,
+              ),
+            ),
+          ),
+        if (_patternConfirmed)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: TextButton.icon(
+              onPressed: () {
+                setState(() {
+                  _firstPattern.clear();
+                  _pattern.clear();
+                  _patternConfirmed = false;
+                });
+              },
+              icon: const Icon(Icons.refresh, size: 14),
+              label: const Text('Redraw pattern'),
+              style: TextButton.styleFrom(
+                foregroundColor: colorScheme.primary,
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/screens/profile/profile_creation_page.dart
+++ b/lib/screens/profile/profile_creation_page.dart
@@ -1,0 +1,245 @@
+import 'dart:io';
+
+import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class ProfileCreationPage extends StatefulWidget {
+  const ProfileCreationPage({super.key});
+
+  @override
+  State<ProfileCreationPage> createState() => _ProfileCreationPageState();
+}
+
+class _ProfileCreationPageState extends State<ProfileCreationPage> {
+  final TextEditingController _nameController = TextEditingController();
+  String _avatarPath = '';
+  bool _isCreating = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final path = await pickAndSaveProfileImage();
+    if (path != null) {
+      setState(() => _avatarPath = path);
+    }
+  }
+
+  Future<void> _createProfile() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a profile name')),
+      );
+      return;
+    }
+
+    setState(() => _isCreating = true);
+
+    final manager = Get.find<ProfileManager>();
+    final profile = manager.createProfile(
+      name: name,
+      avatarPath: _avatarPath,
+    );
+
+    if (profile == null) {
+      setState(() => _isCreating = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Maximum of 5 profiles reached')),
+        );
+      }
+      return;
+    }
+
+    await manager.switchToProfile(profile.id);
+
+    if (mounted) {
+      Navigator.of(context).pop(profile);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.colors;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: Text(
+          'Create Profile',
+          style: TextStyle(
+            fontFamily: 'Poppins',
+            fontWeight: FontWeight.bold,
+            color: theme.onSurface,
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: theme.onSurface),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const SizedBox(height: 20),
+            GestureDetector(
+              onTap: _pickImage,
+              child: Container(
+                width: 100,
+                height: 100,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colorScheme.primaryContainer,
+                  border: Border.all(
+                    color: colorScheme.primary,
+                    width: 3,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.3),
+                      blurRadius: 20,
+                      spreadRadius: 2,
+                    ),
+                  ],
+                ),
+                child: _avatarPath.isNotEmpty
+                    ? ClipOval(
+                        child: Image.file(
+                          File(_avatarPath),
+                          width: 100,
+                          height: 100,
+                          fit: BoxFit.cover,
+                        ),
+                      )
+                    : Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.add_a_photo_rounded,
+                            size: 32,
+                            color: colorScheme.primary.withOpacity(0.7),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Add Photo',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color:
+                                  colorScheme.onSurface.withOpacity(0.5),
+                            ),
+                          ),
+                        ],
+                      ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _avatarPath.isNotEmpty ? 'Tap to change photo' : 'Tap to add avatar',
+              style: TextStyle(
+                color: theme.onSurface.withOpacity(0.5),
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(height: 32),
+            TextField(
+              controller: _nameController,
+              autofocus: true,
+              textCapitalization: TextCapitalization.words,
+              maxLength: 20,
+              style: TextStyle(color: theme.onSurface, fontFamily: 'Poppins'),
+              decoration: InputDecoration(
+                labelText: 'Profile Name',
+                labelStyle: TextStyle(
+                  color: theme.onSurface.withOpacity(0.7),
+                  fontFamily: 'Poppins',
+                ),
+                hintText: 'Enter a name...',
+                hintStyle: TextStyle(
+                  color: theme.onSurface.withOpacity(0.3),
+                ),
+                filled: true,
+                fillColor: colorScheme.surfaceContainer,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(16),
+                  borderSide: BorderSide.none,
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(16),
+                  borderSide: BorderSide(
+                    color: colorScheme.primary,
+                    width: 2,
+                  ),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 16,
+                ),
+                counterStyle: TextStyle(
+                  color: theme.onSurface.withOpacity(0.5),
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+            Obx(() {
+              final count = Get.find<ProfileManager>().profiles.length;
+              return Text(
+                '$count / $kMaxProfiles profiles',
+                style: TextStyle(
+                  color: count >= kMaxProfiles
+                      ? Colors.red
+                      : theme.onSurface.withOpacity(0.5),
+                  fontSize: 13,
+                ),
+              );
+            }),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              height: 56,
+              child: ElevatedButton(
+                onPressed: _isCreating ? null : _createProfile,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colorScheme.primary,
+                  foregroundColor: colorScheme.onPrimary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  elevation: 0,
+                ),
+                child: _isCreating
+                    ? const SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: AnymexProgressIndicator(
+                          strokeWidth: 2.5,
+                        ),
+                      )
+                    : Text(
+                        'Create Profile',
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                          color: colorScheme.onPrimary,
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/profile/profile_creation_page.dart
+++ b/lib/screens/profile/profile_creation_page.dart
@@ -1,16 +1,22 @@
 import 'dart:io';
 
 import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/controllers/services/backup_restore/backup_restore_service.dart';
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart';
 import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/custom_widgets/anymex_animated_logo.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ProfileCreationPage extends StatefulWidget {
-  const ProfileCreationPage({super.key});
+  final bool isFirstLaunch;
+
+  const ProfileCreationPage({super.key, this.isFirstLaunch = false});
 
   @override
   State<ProfileCreationPage> createState() => _ProfileCreationPageState();
@@ -25,7 +31,9 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
   final TextEditingController _confirmPasswordController = TextEditingController();
   String _avatarPath = '';
   bool _isCreating = false;
+  bool _isRestoring = false;
   bool _showSetupForm = false;
+  bool get _showWelcome => widget.isFirstLaunch && !_showSetupForm;
   ProfileLockType _lockType = ProfileLockType.none;
   List<int> _pattern = [];
   bool _patternConfirmed = false;
@@ -50,6 +58,12 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
       parent: _animController,
       curve: Curves.easeIn,
     );
+    if (!widget.isFirstLaunch) {
+      _showSetupForm = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _animController.value = 1.0;
+      });
+    }
   }
 
   @override
@@ -193,6 +207,75 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
     await manager.skipMultiProfileSetup();
   }
 
+  Future<void> _restoreFromBackup() async {
+    setState(() => _isRestoring = true);
+    try {
+      final controller = Get.put(BackupRestoreService());
+      final path = await controller.pickBackupFile();
+      if (path == null || path.isEmpty) {
+        setState(() => _isRestoring = false);
+        return;
+      }
+
+      final isEncrypted = await controller.isBackupEncrypted(path);
+      String? password;
+
+      if (isEncrypted) {
+        if (!mounted) return;
+        final pwController = TextEditingController();
+        password = await showDialog<String>(
+          context: context,
+          builder: (context) => PasswordInputDialog(controller: pwController),
+        );
+        pwController.dispose();
+        if (password == null) {
+          setState(() => _isRestoring = false);
+          return;
+        }
+      }
+
+      final info = await controller.getBackupInfo(path, password: password);
+      if (info == null) {
+        if (mounted) snackBar('Invalid backup file or incorrect password');
+        setState(() => _isRestoring = false);
+        return;
+      }
+
+      if (!mounted) return;
+      await showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        builder: (context) => RestorePreviewSheet(
+          info: info,
+          isEncrypted: isEncrypted,
+          onConfirm: (restoreSettings, restoreAuthTokens, createNew) async {
+            Navigator.pop(context);
+            try {
+              await controller.restoreBackup(
+                path,
+                password: password,
+                merge: false,
+                restoreSettings: restoreSettings,
+                restoreAuthTokens: restoreAuthTokens,
+                createNewProfile: createNew,
+              );
+              if (mounted) {
+                snackBar('Profile restored successfully!');
+              }
+            } catch (e) {
+              if (mounted) snackBar('Restore failed: $e');
+            }
+          },
+        ),
+      );
+      Get.delete<BackupRestoreService>();
+    } catch (e) {
+      if (mounted) snackBar('Error: $e');
+    }
+    setState(() => _isRestoring = false);
+  }
+
   IconData _getLockIcon(ProfileLockType type) {
     switch (type) {
       case ProfileLockType.none:
@@ -229,81 +312,55 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
       body: SafeArea(
         child: Column(
           children: [
-            // App bar - only show back button when in form mode
             Padding(
               padding: const EdgeInsets.fromLTRB(8, 8, 16, 0),
               child: Row(
                 children: [
-                  if (_showSetupForm)
+                  if (_showWelcome)
+                    const SizedBox(width: 48)
+                  else
                     IconButton(
                       icon: Icon(Icons.arrow_back, color: theme.onSurface),
-                      onPressed: () {
-                        setState(() => _showSetupForm = false);
-                        _animController.reverse();
-                      },
-                    )
-                  else
-                    const SizedBox(width: 48),
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
                 ],
               ),
             ),
 
-            // Scrollable content
             Expanded(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.symmetric(horizontal: 32),
                 child: Column(
                   children: [
-                    // Welcome icon
-                    Container(
-                      width: 80,
-                      height: 80,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: colorScheme.primaryContainer,
-                        border: Border.all(
-                          color: colorScheme.primary,
-                          width: 2.5,
+                    if (_showWelcome) ...[
+                      const SizedBox(height: 40),
+                      AnymeXAnimatedLogo(
+                        size: 120,
+                        autoPlay: true,
+                      ),
+                      const SizedBox(height: 28),
+                      Text(
+                        'Welcome to AnymeX',
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontWeight: FontWeight.bold,
+                          fontSize: 26,
+                          color: theme.onSurface,
                         ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: colorScheme.primary.withOpacity(0.25),
-                            blurRadius: 24,
-                            spreadRadius: 2,
-                          ),
-                        ],
                       ),
-                      child: Icon(
-                        Icons.person_rounded,
-                        size: 36,
-                        color: colorScheme.primary,
+                      const SizedBox(height: 10),
+                      Text(
+                        'Set up separate profiles to keep your watch history, accounts, and settings organized — or skip and start using the app right away.',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontSize: 14,
+                          color: theme.onSurface.withOpacity(0.55),
+                          height: 1.5,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 28),
-                    Text(
-                      'Welcome to AnymeX',
-                      style: TextStyle(
-                        fontFamily: 'Poppins',
-                        fontWeight: FontWeight.bold,
-                        fontSize: 26,
-                        color: theme.onSurface,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Text(
-                      _showSetupForm
-                          ? 'Set up your first profile to get started.'
-                          : 'Set up separate profiles to keep your watch history, accounts, and settings organized — or skip and start using the app right away.',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontFamily: 'Poppins',
-                        fontSize: 14,
-                        color: theme.onSurface.withOpacity(0.55),
-                        height: 1.5,
-                      ),
-                    ),
+                    ],
 
-                    // Expandable creation form
                     SizeTransition(
                       sizeFactor: _expandAnimation,
                       axisAlignment: -1.0,
@@ -378,7 +435,7 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
                             const SizedBox(height: 24),
                             TextField(
                               controller: _nameController,
-                              autofocus: true,
+                              autofocus: false,
                               textCapitalization: TextCapitalization.words,
                               maxLength: 20,
                               style: TextStyle(
@@ -582,7 +639,7 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
                 padding: const EdgeInsets.fromLTRB(32, 16, 32, 12),
                 child: Column(
                   children: [
-                    if (!_showSetupForm) ...[
+                    if (_showWelcome) ...[
                       SizedBox(
                         width: double.infinity,
                         height: 54,
@@ -607,7 +664,47 @@ class _ProfileCreationPageState extends State<ProfileCreationPage>
                           ),
                         ),
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: 10),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 48,
+                        child: OutlinedButton.icon(
+                          onPressed: _isRestoring ? null : _restoreFromBackup,
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor:
+                                theme.onSurface.withOpacity(0.7),
+                            side: BorderSide(
+                              color: colorScheme.outline.withOpacity(0.3),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                          icon: _isRestoring
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: AnymexProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : Icon(
+                                  Icons.restore_rounded,
+                                  size: 18,
+                                  color: theme.onSurface.withOpacity(0.7),
+                                ),
+                          label: Text(
+                            'Restore from Backup',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: theme.onSurface.withOpacity(0.7),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
                       SizedBox(
                         width: double.infinity,
                         height: 54,

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -47,11 +47,12 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         return ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            if (autoStartId != null && autoStartId.isNotEmpty) ...[
+            if (autoStartId.isNotEmpty) ...[
               _buildTile(
                 icon: Icons.auto_awesome_rounded,
                 title: 'Auto-start Profile',
-                subtitle: 'Profile "${profiles.firstWhereOrNull((p) => p.id == autoStartId)?.name ?? "Unknown"}" opens automatically',
+                subtitle:
+                    'Profile "${profiles.firstWhereOrNull((p) => p.id == autoStartId)?.name ?? "Unknown"}" opens automatically',
                 trailing: TextButton(
                   onPressed: () {
                     manager.resetAutoStart();
@@ -66,9 +67,10 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
               const SizedBox(height: 8),
             ],
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
               child: Text(
-                '${profiles.length} / ${kMaxProfiles} Profiles',
+                '$profiles.length / $kMaxProfiles Profiles',
                 style: TextStyle(
                   fontFamily: 'Poppins',
                   fontWeight: FontWeight.w600,
@@ -99,6 +101,9 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     ColorScheme colorScheme,
     dynamic theme,
   ) {
+    final needsPin =
+        !isCurrent && profile.hasPin;
+
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(16),
@@ -142,7 +147,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 6, vertical: 2),
                             decoration: BoxDecoration(
-                              color: colorScheme.primary.withOpacity(0.1),
+                              color:
+                                  colorScheme.primary.withOpacity(0.1),
                               borderRadius: BorderRadius.circular(6),
                             ),
                             child: Text(
@@ -178,10 +184,22 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                           Text('No services',
                               style: TextStyle(
                                   fontSize: 11,
-                                  color:
-                                      theme.onSurface.withOpacity(0.4))),
+                                  color: theme.onSurface
+                                      .withOpacity(0.4))),
                       ],
                     ),
+                    if (needsPin)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Text(
+                          'PIN required to make changes',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: colorScheme.primary.withOpacity(0.7),
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
               ),
@@ -194,24 +212,115 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                 onSelected: (value) =>
                     _handleAction(value, profile, isCurrent),
                 itemBuilder: (context) => [
-                  const PopupMenuItem(
-                      value: 'change_avatar',
-                      child: Text('Change Avatar')),
-                  const PopupMenuItem(
-                      value: 'pin', child: Text('Set / Change PIN')),
-                  if (profile.hasPin)
+                  if (isCurrent) ...[
                     const PopupMenuItem(
-                        value: 'remove_pin', child: Text('Remove PIN')),
-                  const PopupMenuItem(
-                      value: 'export', child: Text('Export Data')),
-                  if (!isCurrent) ...[
+                        value: 'change_avatar',
+                        child: Row(
+                          children: [
+                            Icon(Icons.photo_camera, size: 18),
+                            SizedBox(width: 10),
+                            Text('Change Avatar'),
+                          ],
+                        )),
+                    const PopupMenuItem(
+                        value: 'pin',
+                        child: Row(
+                          children: [
+                            Icon(Icons.lock_outline, size: 18),
+                            SizedBox(width: 10),
+                            Text('Set / Change PIN'),
+                          ],
+                        )),
+                    if (profile.hasPin)
+                      const PopupMenuItem(
+                          value: 'remove_pin',
+                          child: Row(
+                            children: [
+                              Icon(Icons.lock_open, size: 18),
+                              SizedBox(width: 10),
+                              Text('Remove PIN'),
+                            ],
+                          )),
+                    const PopupMenuItem(
+                        value: 'export',
+                        child: Row(
+                          children: [
+                            Icon(Icons.download, size: 18),
+                            SizedBox(width: 10),
+                            Text('Export Data'),
+                          ],
+                        )),
+                  ] else ...[
+                    if (needsPin)
+                      const PopupMenuItem(
+                          value: 'verify',
+                          child: Row(
+                            children: [
+                              Icon(Icons.lock_person, size: 18),
+                              SizedBox(width: 10),
+                              Text('Enter PIN to Manage'),
+                            ],
+                          ))
+                    else ...[
+                      const PopupMenuItem(
+                          value: 'change_avatar',
+                          child: Row(
+                            children: [
+                              Icon(Icons.photo_camera, size: 18),
+                              SizedBox(width: 10),
+                              Text('Change Avatar'),
+                            ],
+                          )),
+                      const PopupMenuItem(
+                          value: 'pin',
+                          child: Row(
+                            children: [
+                              Icon(Icons.lock_outline, size: 18),
+                              SizedBox(width: 10),
+                              Text('Set / Change PIN'),
+                            ],
+                          )),
+                      if (profile.hasPin)
+                        const PopupMenuItem(
+                            value: 'remove_pin',
+                            child: Row(
+                              children: [
+                                Icon(Icons.lock_open, size: 18),
+                                SizedBox(width: 10),
+                                Text('Remove PIN'),
+                              ],
+                            )),
+                      const PopupMenuItem(
+                          value: 'export',
+                          child: Row(
+                            children: [
+                              Icon(Icons.download, size: 18),
+                              SizedBox(width: 10),
+                              Text('Export Data'),
+                            ],
+                          )),
+                    ],
+                    const PopupMenuDivider(),
                     const PopupMenuItem(
                         value: 'switch',
-                        child: Text('Switch to Profile')),
+                        child: Row(
+                          children: [
+                            Icon(Icons.swap_horiz, size: 18),
+                            SizedBox(width: 10),
+                            Text('Switch to Profile'),
+                          ],
+                        )),
                     const PopupMenuItem(
                         value: 'delete',
-                        child: Text('Delete Profile',
-                            style: TextStyle(color: Colors.red))),
+                        child: Row(
+                          children: [
+                            Icon(Icons.delete_outline,
+                                size: 18, color: Colors.red),
+                            SizedBox(width: 10),
+                            Text('Delete Profile',
+                                style: TextStyle(color: Colors.red)),
+                          ],
+                        )),
                   ],
                 ],
               ),
@@ -226,8 +335,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     return GestureDetector(
       onTap: () {
         Navigator.of(context).push(
-          MaterialPageRoute(
-              builder: (_) => const ProfileCreationPage()),
+          MaterialPageRoute(builder: (_) => const ProfileCreationPage()),
         );
       },
       child: Container(
@@ -311,24 +419,39 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(text,
-          style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: color)),
+          style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w600,
+              color: color)),
     );
   }
 
   Future<void> _handleAction(
       String action, AppProfile profile, bool isCurrent) async {
-    final manager = Get.find<ProfileManager>();
+    if (!isCurrent && profile.hasPin) {
+      if (action == 'verify') {
+        final verified = await _showPinVerification(profile);
+        if (verified != true) return;
+        _showUnlockedMenu(profile);
+        return;
+      }
+      final verified = await _showPinVerification(profile);
+      if (verified != true) return;
+    }
 
     switch (action) {
       case 'change_avatar':
         _changeAvatar(profile);
         break;
       case 'pin':
-        _showPinSetupDialog(profile);
+        if (!isCurrent && profile.hasPin) {
+          _showChangePinAfterVerify(profile);
+        } else {
+          _showPinSetupDialog(profile);
+        }
         break;
       case 'remove_pin':
-        manager.removePin(profile.id);
-        snackBar('PIN removed');
+        _confirmRemovePin(profile);
         break;
       case 'export':
         _exportProfile(profile);
@@ -346,6 +469,161 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     }
   }
 
+  void _showUnlockedMenu(AppProfile profile) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: colorScheme.surfaceContainer,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(
+                  color: colorScheme.onSurface.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.photo_camera),
+                title: const Text('Change Avatar'),
+                onTap: () {
+                  Navigator.pop(ctx);
+                  _changeAvatar(profile);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.lock_outline),
+                title: const Text('Change PIN'),
+                onTap: () {
+                  Navigator.pop(ctx);
+                  _showChangePinAfterVerify(profile);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.lock_open),
+                title: const Text('Remove PIN'),
+                onTap: () {
+                  Navigator.pop(ctx);
+                  _confirmRemovePin(profile);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.download),
+                title: const Text('Export Data'),
+                onTap: () {
+                  Navigator.pop(ctx);
+                  _exportProfile(profile);
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<bool?> _showPinVerification(AppProfile profile) async {
+    final manager = Get.find<ProfileManager>();
+
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      snackBar(
+          'Profile is locked. Try again in $remaining minute${remaining != 1 ? 's' : ''}');
+      return null;
+    }
+
+    final pinController = TextEditingController();
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final verified = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
+        title: Row(
+          children: [
+            ProfileAvatar(profile: profile, radius: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Verify ${profile.name}',
+                    style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurface),
+                  ),
+                  Text(
+                    'Enter this profile\'s PIN to continue',
+                    style: TextStyle(
+                        fontSize: 12,
+                        color: colorScheme.onSurface.withOpacity(0.6)),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        content: _PinVerifyContent(
+          controller: pinController,
+          profile: profile,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text('Cancel',
+                style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7))),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final pin = pinController.text.trim();
+              if (pin.length < 4) {
+                snackBar('PIN must be at least 4 digits');
+                return;
+              }
+              final result = manager.verifyPin(profile.id, pin);
+              if (result == true) {
+                Navigator.pop(ctx, true);
+              } else {
+                snackBar(result == null
+                    ? 'Profile is temporarily locked'
+                    : 'Wrong PIN');
+                if (result == null) Navigator.pop(ctx, false);
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('Verify',
+                style: TextStyle(
+                    fontFamily: 'Poppins', fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+    pinController.dispose();
+    return verified;
+  }
+
   Future<void> _changeAvatar(AppProfile profile) async {
     final path = await pickAndSaveProfileImage();
     if (path != null) {
@@ -357,82 +635,15 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
 
   Future<void> _switchToProfile(AppProfile profile) async {
     if (profile.hasPin) {
-      final pinController = TextEditingController();
-      final colorScheme = Theme.of(context).colorScheme;
-      final success = await showDialog<bool>(
-        context: context,
-        barrierDismissible: false,
-        builder: (ctx) => AlertDialog(
-          backgroundColor: colorScheme.surfaceContainer,
-          shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20)),
-          title: Text(
-            'Enter PIN for "${profile.name}"',
-            style: TextStyle(
-                fontFamily: 'Poppins',
-                fontWeight: FontWeight.bold,
-                color: colorScheme.onSurface),
-          ),
-          content: TextField(
-            controller: pinController,
-            keyboardType: TextInputType.number,
-            obscureText: true,
-            maxLength: 6,
-            autofocus: true,
-            style: TextStyle(
-                color: colorScheme.onSurface,
-                fontFamily: 'Poppins',
-                fontSize: 22,
-                letterSpacing: 8),
-            textAlign: TextAlign.center,
-            decoration: InputDecoration(
-              filled: true,
-              fillColor: colorScheme.surface,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              counterText: '',
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: Text('Cancel',
-                  style: TextStyle(
-                      color: colorScheme.onSurface.withOpacity(0.7))),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                final pin = pinController.text.trim();
-                if (pin.length < 4) {
-                  snackBar('PIN must be at least 4 digits');
-                  return;
-                }
-                final manager = Get.find<ProfileManager>();
-                final result = manager.verifyPin(profile.id, pin);
-                if (result == true) {
-                  Navigator.pop(ctx, true);
-                } else {
-                  snackBar(result == null
-                      ? 'Profile is temporarily locked'
-                      : 'Wrong PIN');
-                  if (result == null) Navigator.pop(ctx, false);
-                }
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.primary,
-                foregroundColor: colorScheme.onPrimary,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
-              ),
-              child: const Text('Unlock'),
-            ),
-          ],
-        ),
-      );
-      pinController.dispose();
-      if (success != true) return;
+      if (profile.isLocked) {
+        final remaining =
+            profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+        snackBar(
+            'Profile is locked. Try again in $remaining minute${remaining != 1 ? 's' : ''}');
+        return;
+      }
+      final verified = await _showPinVerification(profile);
+      if (verified != true) return;
     }
 
     final manager = Get.find<ProfileManager>();
@@ -453,8 +664,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: colorScheme.surfaceContainer,
-        shape:
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
         title: Text(
           isNew ? 'Set PIN' : 'Change PIN',
           style: TextStyle(
@@ -533,6 +744,142 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     );
   }
 
+  void _showChangePinAfterVerify(AppProfile profile) {
+    final controller = TextEditingController();
+    final colorScheme = Theme.of(context).colorScheme;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
+        title: Text(
+          'Change PIN for "${profile.name}"',
+          style: TextStyle(
+              fontFamily: 'Poppins',
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Enter new PIN (4-6 digits)',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller,
+              keyboardType: TextInputType.number,
+              obscureText: true,
+              maxLength: 6,
+              autofocus: true,
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontFamily: 'Poppins',
+                  fontSize: 22,
+                  letterSpacing: 8),
+              textAlign: TextAlign.center,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: colorScheme.surface,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+                counterText: '',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text('Cancel',
+                style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7))),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final pin = controller.text.trim();
+              if (pin.length < 4 || pin.length > 6) {
+                snackBar('PIN must be 4-6 digits');
+                return;
+              }
+              if (!RegExp(r'^\d+$').hasMatch(pin)) {
+                snackBar('PIN must contain only numbers');
+                return;
+              }
+              final manager = Get.find<ProfileManager>();
+              manager.setPin(profile.id, pin);
+              Navigator.pop(ctx);
+              snackBar('PIN updated successfully');
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('Update PIN',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmRemovePin(AppProfile profile) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
+        title: Text(
+          'Remove PIN from "${profile.name}"?',
+          style: TextStyle(
+              fontFamily: 'Poppins',
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface),
+        ),
+        content: Text(
+          'This profile will no longer be protected. Anyone can access it.',
+          style: TextStyle(
+              color: colorScheme.onSurface.withOpacity(0.7)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text('Cancel',
+                style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7))),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+              final manager = Get.find<ProfileManager>();
+              manager.removePin(profile.id);
+              snackBar('PIN removed from "${profile.name}"');
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('Remove PIN',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _exportProfile(AppProfile profile) async {
     try {
       final backupService = Get.find<BackupRestoreService>();
@@ -562,8 +909,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: colorScheme.surfaceContainer,
-        shape:
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
         title: Text(
           'Delete "${profile.name}"?',
           style: const TextStyle(
@@ -589,14 +936,15 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
               decoration: BoxDecoration(
                 color: Colors.orange.withOpacity(0.1),
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: Colors.orange.withOpacity(0.3)),
+                border:
+                    Border.all(color: Colors.orange.withOpacity(0.3)),
               ),
-              child: Row(
+              child: const Row(
                 children: [
-                  const Icon(Icons.download_rounded,
+                  Icon(Icons.download_rounded,
                       color: Colors.orange, size: 20),
-                  const SizedBox(width: 10),
-                  const Expanded(
+                  SizedBox(width: 10),
+                  Expanded(
                     child: Text(
                       'Would you like to export this profile\'s data before deleting?',
                       style: TextStyle(fontSize: 13),
@@ -613,9 +961,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
             child: const Text('Cancel'),
           ),
           TextButton(
-            onPressed: () async {
-              Navigator.pop(ctx, true);
-            },
+            onPressed: () => Navigator.pop(ctx, true),
             child: const Text('Export & Delete',
                 style: TextStyle(color: Colors.orange)),
           ),
@@ -643,5 +989,92 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     await manager.deleteProfile(profile.id,
         currentId: manager.currentProfileId.value);
     snackBar('Profile "${profile.name}" deleted');
+  }
+}
+
+class _PinVerifyContent extends StatefulWidget {
+  final TextEditingController controller;
+  final AppProfile profile;
+  const _PinVerifyContent(
+      {required this.controller, required this.profile});
+
+  @override
+  State<_PinVerifyContent> createState() => _PinVerifyContentState();
+}
+
+class _PinVerifyContentState extends State<_PinVerifyContent> {
+  bool _isError = false;
+  String _errorMessage = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: widget.controller,
+          keyboardType: TextInputType.number,
+          obscureText: true,
+          maxLength: 6,
+          autofocus: true,
+          style: TextStyle(
+              color: colorScheme.onSurface,
+              fontFamily: 'Poppins',
+              fontSize: 24,
+              letterSpacing: 8),
+          textAlign: TextAlign.center,
+          decoration: InputDecoration(
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: _isError
+                  ? const BorderSide(color: Colors.red, width: 2)
+                  : BorderSide.none,
+            ),
+            hintText: '• • • •',
+            hintStyle: TextStyle(
+              color: colorScheme.onSurface.withOpacity(0.2),
+              letterSpacing: 4,
+            ),
+            counterText: '',
+          ),
+          onChanged: (_) => setState(() {
+            _isError = false;
+            _errorMessage = '';
+          }),
+          onSubmitted: (_) {
+            final pin = widget.controller.text.trim();
+            if (pin.length >= 4) {
+              Navigator.pop(context, true);
+            }
+          },
+        ),
+        if (_isError) ...[
+          const SizedBox(height: 8),
+          Text(_errorMessage,
+              style: const TextStyle(color: Colors.red, fontSize: 13)),
+        ],
+        const SizedBox(height: 4),
+        Obx(() {
+          final manager = Get.find<ProfileManager>();
+          final attempts = manager.profiles
+                  .firstWhereOrNull((p) => p.id == widget.profile.id)
+                  ?.failedPinAttempts ??
+              0;
+          if (attempts > 0) {
+            return Text(
+              '$attempts / $kMaxPinAttempts attempts',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  fontSize: 12),
+            );
+          }
+          return const SizedBox.shrink();
+        }),
+      ],
+    );
   }
 }

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -1,0 +1,551 @@
+import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/controllers/services/backup_restore/backup_restore_service.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class ProfileManagementPage extends StatefulWidget {
+  const ProfileManagementPage({super.key});
+
+  @override
+  State<ProfileManagementPage> createState() => _ProfileManagementPageState();
+}
+
+class _ProfileManagementPageState extends State<ProfileManagementPage> {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final theme = context.colors;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: Text(
+          'Profile Management',
+          style: TextStyle(
+            fontFamily: 'Poppins',
+            fontWeight: FontWeight.bold,
+            color: theme.onSurface,
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: theme.onSurface),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: Obx(() {
+        final manager = Get.find<ProfileManager>();
+        final profiles = manager.profiles;
+        final currentId = manager.currentProfileId.value;
+        final autoStartId = manager.autoStartProfileId;
+
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (autoStartId != null && autoStartId.isNotEmpty) ...[
+              _buildTile(
+                icon: Icons.auto_awesome_rounded,
+                title: 'Auto-start Profile',
+                subtitle: 'Profile "${profiles.firstWhereOrNull((p) => p.id == autoStartId)?.name ?? "Unknown"}" opens automatically',
+                trailing: TextButton(
+                  onPressed: () {
+                    manager.resetAutoStart();
+                    snackBar('Auto-start disabled');
+                  },
+                  child: Text('Reset',
+                      style: TextStyle(color: colorScheme.primary)),
+                ),
+                colorScheme: colorScheme,
+                theme: theme,
+              ),
+              const SizedBox(height: 8),
+            ],
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+              child: Text(
+                '${profiles.length} / ${kMaxProfiles} Profiles',
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: theme.onSurface.withOpacity(0.6),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ...profiles.map((profile) => _buildProfileCard(
+                  profile,
+                  profile.id == currentId,
+                  colorScheme,
+                  theme,
+                )),
+            const SizedBox(height: 16),
+            if (profiles.length < kMaxProfiles)
+              _buildAddButton(colorScheme, theme),
+          ],
+        );
+      }),
+    );
+  }
+
+  Widget _buildProfileCard(
+    AppProfile profile,
+    bool isCurrent,
+    ColorScheme colorScheme,
+    dynamic theme,
+  ) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isCurrent
+              ? colorScheme.primary.withOpacity(0.5)
+              : colorScheme.onSurface.withOpacity(0.08),
+          width: isCurrent ? 1.5 : 1,
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              ProfileAvatar(
+                profile: profile,
+                radius: 24,
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          profile.name,
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontWeight: FontWeight.bold,
+                            fontSize: 15,
+                            color: theme.onSurface,
+                          ),
+                        ),
+                        if (isCurrent) ...[
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: colorScheme.primary.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              'Active',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                        ],
+                        if (profile.hasPin) ...[
+                          const SizedBox(width: 6),
+                          Icon(Icons.lock_outline,
+                              size: 14,
+                              color: theme.onSurface.withOpacity(0.5)),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        if (profile.anilistLinked)
+                          _miniBadge('AniList', Colors.blue),
+                        if (profile.malLinked)
+                          _miniBadge('MAL', Colors.blueAccent),
+                        if (profile.simklLinked)
+                          _miniBadge('Simkl', Colors.green),
+                        if (!profile.anilistLinked &&
+                            !profile.malLinked &&
+                            !profile.simklLinked)
+                          Text('No services',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  color:
+                                      theme.onSurface.withOpacity(0.4))),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              PopupMenuButton<String>(
+                icon: Icon(Icons.more_vert,
+                    color: theme.onSurface.withOpacity(0.6)),
+                color: colorScheme.surfaceContainer,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+                onSelected: (value) =>
+                    _handleAction(value, profile, isCurrent),
+                itemBuilder: (context) => [
+                  const PopupMenuItem(
+                      value: 'change_avatar',
+                      child: Text('Change Avatar')),
+                  const PopupMenuItem(
+                      value: 'pin', child: Text('Set / Change PIN')),
+                  if (profile.hasPin)
+                    const PopupMenuItem(
+                        value: 'remove_pin', child: Text('Remove PIN')),
+                  const PopupMenuItem(
+                      value: 'export', child: Text('Export Data')),
+                  if (!isCurrent)
+                    const PopupMenuItem(
+                        value: 'delete',
+                        child: Text('Delete Profile',
+                            style: TextStyle(color: Colors.red))),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAddButton(ColorScheme colorScheme, dynamic theme) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+              builder: (_) => const ProfileCreationPage()),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: colorScheme.primary.withOpacity(0.3),
+            style: BorderStyle.solid,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.add_rounded, color: colorScheme.primary),
+            const SizedBox(width: 8),
+            Text(
+              'Add Profile',
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.w600,
+                color: colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required Widget trailing,
+    required ColorScheme colorScheme,
+    required dynamic theme,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: colorScheme.primary, size: 22),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title,
+                    style: TextStyle(
+                      fontFamily: 'Poppins',
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                      color: theme.onSurface,
+                    )),
+                const SizedBox(height: 2),
+                Text(subtitle,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: theme.onSurface.withOpacity(0.5),
+                    )),
+              ],
+            ),
+          ),
+          trailing,
+        ],
+      ),
+    );
+  }
+
+  Widget _miniBadge(String text, Color color) {
+    return Container(
+      margin: const EdgeInsets.only(right: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(text,
+          style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: color)),
+    );
+  }
+
+  Future<void> _handleAction(
+      String action, AppProfile profile, bool isCurrent) async {
+    final manager = Get.find<ProfileManager>();
+
+    switch (action) {
+      case 'change_avatar':
+        _changeAvatar(profile);
+        break;
+      case 'pin':
+        _showPinSetupDialog(profile);
+        break;
+      case 'remove_pin':
+        manager.removePin(profile.id);
+        snackBar('PIN removed');
+        break;
+      case 'export':
+        _exportProfile(profile);
+        break;
+      case 'delete':
+        if (isCurrent) {
+          snackBar('Switch to another profile first');
+          return;
+        }
+        _confirmDelete(profile);
+        break;
+    }
+  }
+
+  Future<void> _changeAvatar(AppProfile profile) async {
+    final path = await pickAndSaveProfileImage();
+    if (path != null) {
+      final manager = Get.find<ProfileManager>();
+      manager.updateProfileAvatar(profile.id, path);
+      snackBar('Avatar updated');
+    }
+  }
+
+  void _showPinSetupDialog(AppProfile profile) {
+    final controller = TextEditingController();
+    final colorScheme = Theme.of(context).colorScheme;
+    final isNew = !profile.hasPin;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text(
+          isNew ? 'Set PIN' : 'Change PIN',
+          style: TextStyle(
+              fontFamily: 'Poppins',
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              isNew
+                  ? 'Set a 4-6 digit PIN for "${profile.name}"'
+                  : 'Enter new PIN for "${profile.name}"',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller,
+              keyboardType: TextInputType.number,
+              obscureText: true,
+              maxLength: 6,
+              autofocus: true,
+              style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontFamily: 'Poppins',
+                  fontSize: 22,
+                  letterSpacing: 8),
+              textAlign: TextAlign.center,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: colorScheme.surface,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+                counterText: '',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text('Cancel',
+                style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7))),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final pin = controller.text.trim();
+              if (pin.length < 4 || pin.length > 6) {
+                snackBar('PIN must be 4-6 digits');
+                return;
+              }
+              if (!RegExp(r'^\d+$').hasMatch(pin)) {
+                snackBar('PIN must contain only numbers');
+                return;
+              }
+              final manager = Get.find<ProfileManager>();
+              manager.setPin(profile.id, pin);
+              Navigator.pop(ctx);
+              snackBar('PIN ${isNew ? "set" : "updated"} successfully');
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: Text(isNew ? 'Set PIN' : 'Update'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _exportProfile(AppProfile profile) async {
+    try {
+      final backupService = Get.find<BackupRestoreService>();
+      backupService.isBackingUp.value = true;
+
+      final path = await backupService.exportBackupToExternal(
+        requestPath: true,
+        backupSettings: true,
+        backupAuthTokens: true,
+      );
+
+      backupService.isBackingUp.value = false;
+
+      if (path != null) {
+        snackBar('Profile "${profile.name}" exported successfully');
+      }
+    } catch (e) {
+      Get.find<BackupRestoreService>().isBackingUp.value = false;
+      snackBar('Export failed: $e');
+    }
+  }
+
+  Future<void> _confirmDelete(AppProfile profile) async {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final shouldExport = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text(
+          'Delete "${profile.name}"?',
+          style: const TextStyle(
+              fontFamily: 'Poppins',
+              fontWeight: FontWeight.bold,
+              color: Colors.red),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'All data for this profile will be permanently deleted, including:\n\n'
+              '• Linked accounts (AniList, MAL, Simkl)\n'
+              '• Settings & preferences\n'
+              '• Watch history & progress\n'
+              '• Custom lists\n\n'
+              'This action cannot be undone.',
+              style: TextStyle(fontSize: 14),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.orange.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.orange.withOpacity(0.3)),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.download_rounded,
+                      color: Colors.orange, size: 20),
+                  const SizedBox(width: 10),
+                  const Expanded(
+                    child: Text(
+                      'Would you like to export this profile\'s data before deleting?',
+                      style: TextStyle(fontSize: 13),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, null),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.pop(ctx, true);
+            },
+            child: const Text('Export & Delete',
+                style: TextStyle(color: Colors.orange)),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('Delete Without Export'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldExport == null) return;
+
+    if (shouldExport == true) {
+      await _exportProfile(profile);
+    }
+
+    final manager = Get.find<ProfileManager>();
+    await manager.deleteProfile(profile.id,
+        currentId: manager.currentProfileId.value);
+    snackBar('Profile "${profile.name}" deleted');
+  }
+}

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -66,19 +66,6 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
               ),
               const SizedBox(height: 8),
             ],
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-              child: Text(
-                '$profiles.length / $kMaxProfiles Profiles',
-                style: TextStyle(
-                  fontFamily: 'Poppins',
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                  color: theme.onSurface.withOpacity(0.6),
-                ),
-              ),
-            ),
             const SizedBox(height: 8),
             ...profiles.map((profile) => _buildProfileCard(
                   profile,
@@ -545,6 +532,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
 
     final pinController = TextEditingController();
     final colorScheme = Theme.of(context).colorScheme;
+    final pinContentKey = GlobalKey<_PinVerifyContentState>();
 
     final verified = await showDialog<bool>(
       context: context,
@@ -580,6 +568,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
           ],
         ),
         content: _PinVerifyContent(
+          key: pinContentKey,
           controller: pinController,
           profile: profile,
         ),
@@ -594,17 +583,23 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
             onPressed: () {
               final pin = pinController.text.trim();
               if (pin.length < 4) {
-                snackBar('PIN must be at least 4 digits');
+                pinContentKey.currentState?.setError('PIN must be at least 4 digits');
                 return;
               }
               final result = manager.verifyPin(profile.id, pin);
               if (result == true) {
                 Navigator.pop(ctx, true);
+              } else if (result == false) {
+                final remaining = kMaxPinAttempts -
+                    (manager.profiles
+                            .firstWhereOrNull((p) => p.id == profile.id)
+                            ?.failedPinAttempts ??
+                        0);
+                pinContentKey.currentState?.setError(
+                    'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} remaining');
+                pinContentKey.currentState?.clearInput();
               } else {
-                snackBar(result == null
-                    ? 'Profile is temporarily locked'
-                    : 'Wrong PIN');
-                if (result == null) Navigator.pop(ctx, false);
+                Navigator.pop(ctx, false);
               }
             },
             style: ElevatedButton.styleFrom(
@@ -1003,7 +998,7 @@ class _PinVerifyContent extends StatefulWidget {
   final TextEditingController controller;
   final AppProfile profile;
   const _PinVerifyContent(
-      {required this.controller, required this.profile});
+      {super.key, required this.controller, required this.profile});
 
   @override
   State<_PinVerifyContent> createState() => _PinVerifyContentState();
@@ -1012,6 +1007,17 @@ class _PinVerifyContent extends StatefulWidget {
 class _PinVerifyContentState extends State<_PinVerifyContent> {
   bool _isError = false;
   String _errorMessage = '';
+
+  void setError(String message) {
+    setState(() {
+      _isError = true;
+      _errorMessage = message;
+    });
+  }
+
+  void clearInput() {
+    widget.controller.clear();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1052,12 +1058,6 @@ class _PinVerifyContentState extends State<_PinVerifyContent> {
             _isError = false;
             _errorMessage = '';
           }),
-          onSubmitted: (_) {
-            final pin = widget.controller.text.trim();
-            if (pin.length >= 4) {
-              Navigator.pop(context, true);
-            }
-          },
         ),
         if (_isError) ...[
           const SizedBox(height: 8),

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -738,9 +738,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
   Future<bool?> _showPatternVerification(AppProfile profile) async {
     final manager = Get.find<ProfileManager>();
     final colorScheme = Theme.of(context).colorScheme;
-    bool? result;
 
-    await showDialog(
+    final result = await showDialog<bool?>(
       context: context,
       barrierDismissible: false,
       builder: (ctx) => StatefulBuilder(
@@ -853,18 +852,6 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
   }
 
   Future<void> _switchToProfile(AppProfile profile) async {
-    if (profile.hasLock) {
-      if (profile.isLocked) {
-        final remaining =
-            profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
-        snackBar(
-            'Profile is locked. Try again in $remaining minute${remaining != 1 ? 's' : ''}');
-        return;
-      }
-      final verified = await _showLockVerification(profile);
-      if (verified != true) return;
-    }
-
     final manager = Get.find<ProfileManager>();
     await manager.switchToProfile(profile.id);
 
@@ -1205,8 +1192,12 @@ class _PasswordVerifyContentState extends State<_PasswordVerifyContent> {
           }),
           onSubmitted: (_) {
             if (widget.controller.text.isNotEmpty) {
-              final parentCtx = context;
-              Navigator.of(parentCtx).pop(true);
+              final manager = Get.find<ProfileManager>();
+              final result = manager.verifyLock(
+                  widget.profile.id, widget.controller.text);
+              if (result == true) {
+                Navigator.of(context).pop(true);
+              }
             }
           },
         ),

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -42,7 +42,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         final manager = Get.find<ProfileManager>();
         final profiles = manager.profiles;
         final currentId = manager.currentProfileId.value;
-        final autoStartId = manager.autoStartProfileId;
+        final autoStartId = manager.autoStartProfileId.value;
 
         return ListView(
           padding: const EdgeInsets.all(16),

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -9,6 +9,8 @@ import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+const String _kCustomQuestionLabel = '✏️ Write your own question';
+
 class ProfileManagementPage extends StatefulWidget {
   const ProfileManagementPage({super.key});
 
@@ -598,6 +600,28 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
           profile: profile,
         ),
         actions: [
+          if (profile.hasSecurityQuestions)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: () async {
+                  final bypassed = await showDialog<bool>(
+                    context: context,
+                    builder: (c) => _ForgotLockDialog(profile: profile),
+                  );
+                  if (bypassed == true) {
+                    Navigator.pop(ctx, true);
+                  }
+                },
+                child: Text('Forgot PIN?',
+                    style: TextStyle(
+                        color: colorScheme.primary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600)),
+              ),
+            ),
+          if (profile.hasSecurityQuestions)
+            const Spacer(),
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
             child: Text('Cancel',
@@ -689,6 +713,28 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
           profile: profile,
         ),
         actions: [
+          if (profile.hasSecurityQuestions)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: () async {
+                  final bypassed = await showDialog<bool>(
+                    context: context,
+                    builder: (c) => _ForgotLockDialog(profile: profile),
+                  );
+                  if (bypassed == true) {
+                    Navigator.pop(ctx, true);
+                  }
+                },
+                child: Text('Forgot Password?',
+                    style: TextStyle(
+                        color: colorScheme.primary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600)),
+              ),
+            ),
+          if (profile.hasSecurityQuestions)
+            const Spacer(),
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
             child: Text('Cancel',
@@ -827,6 +873,28 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
               ],
             ),
             actions: [
+              if (profile.hasSecurityQuestions)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () async {
+                      final bypassed = await showDialog<bool>(
+                        context: context,
+                        builder: (c) => _ForgotLockDialog(profile: profile),
+                      );
+                      if (bypassed == true) {
+                        Navigator.pop(ctx, true);
+                      }
+                    },
+                    child: Text('Forgot Pattern?',
+                        style: TextStyle(
+                            color: colorScheme.primary,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600)),
+                  ),
+                ),
+              if (profile.hasSecurityQuestions)
+                const Spacer(),
               TextButton(
                 onPressed: () => Navigator.pop(ctx, false),
                 child: Text('Cancel',
@@ -1245,10 +1313,47 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
   bool _patternConfirmed = false;
   String? _error;
 
+  final List<Map<String, String>> _qaEntries = [
+    {'q': '', 'a': '', 'isCustom': 'false', 'customQ': ''},
+  ];
+  final Map<int, TextEditingController> _answerControllers = {};
+  final Map<int, TextEditingController> _customQuestionControllers = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final existingQAs = widget.profile.securityQAs;
+    if (existingQAs.isNotEmpty) {
+      _qaEntries.clear();
+      for (final qa in existingQAs) {
+        final isCustom = qa['c'] == true;
+        _qaEntries.add({
+          'q': qa['q'] as String,
+          'a': '',
+          'isCustom': isCustom ? 'true' : 'false',
+          'customQ': isCustom ? qa['q'] as String : '',
+        });
+        if (isCustom) {
+          _customQuestionControllers[_qaEntries.length - 1] =
+              TextEditingController(text: qa['q'] as String);
+        }
+      }
+    }
+    if (_qaEntries.isEmpty) {
+      _qaEntries.add({'q': '', 'a': '', 'isCustom': 'false', 'customQ': ''});
+    }
+  }
+
   @override
   void dispose() {
     _pinController.dispose();
     _passwordController.dispose();
+    for (final c in _answerControllers.values) {
+      c.dispose();
+    }
+    for (final c in _customQuestionControllers.values) {
+      c.dispose();
+    }
     super.dispose();
   }
 
@@ -1261,6 +1366,47 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
     _error = null;
   }
 
+  List<String> get _allQuestions => [
+        ...kSecurityQuestions,
+        _kCustomQuestionLabel,
+      ];
+
+  bool get _canAddMoreQA => _qaEntries.length < kMaxSecurityQuestions;
+
+  void _addQAEntry() {
+    if (!_canAddMoreQA) return;
+    setState(() {
+      _qaEntries.add({'q': '', 'a': '', 'isCustom': 'false', 'customQ': ''});
+    });
+  }
+
+  void _removeQAEntry(int index) {
+    if (_qaEntries.length <= 1) return;
+    _answerControllers[index]?.dispose();
+    _customQuestionControllers[index]?.dispose();
+    _answerControllers.remove(index);
+    _customQuestionControllers.remove(index);
+    setState(() {
+      _qaEntries.removeAt(index);
+    });
+  }
+
+  void _updateQAQuestion(int index, String? question) {
+    if (question == null) return;
+    final isCustom = question == _kCustomQuestionLabel;
+    setState(() {
+      _qaEntries[index]['q'] = isCustom ? '' : question;
+      _qaEntries[index]['isCustom'] = isCustom ? 'true' : 'false';
+      if (isCustom) {
+        _customQuestionControllers.putIfAbsent(
+            index, () => TextEditingController());
+      } else {
+        final ctrl = _customQuestionControllers.remove(index);
+        ctrl?.dispose();
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -1271,8 +1417,8 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
       backgroundColor: colorScheme.surfaceContainer,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 360),
-        child: Padding(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(20),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -1354,21 +1500,6 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
                   );
                 }).toList(),
               ),
-              if (_error != null) ...[
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    const Icon(Icons.error_outline_rounded,
-                        color: Colors.red, size: 14),
-                    const SizedBox(width: 4),
-                    Expanded(
-                      child: Text(_error!,
-                          style:
-                              const TextStyle(color: Colors.red, fontSize: 12)),
-                    ),
-                  ],
-                ),
-              ],
               if (_selectedType == ProfileLockType.pin) ...[
                 const SizedBox(height: 16),
                 TextField(
@@ -1481,6 +1612,226 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
                   ),
                 ),
               ],
+              if (_selectedType != ProfileLockType.none) ...[
+                const SizedBox(height: 20),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary.withOpacity(0.06),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: colorScheme.primary.withOpacity(0.15),
+                    ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(Icons.help_outline_rounded,
+                              size: 16, color: colorScheme.primary),
+                          const SizedBox(width: 6),
+                          Text(
+                            'Recovery Questions',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 13,
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                          const Spacer(),
+                          Text(
+                            '${_qaEntries.length}/$kMaxSecurityQuestions',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: colorScheme.onSurface.withOpacity(0.5),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Add 1-${kMaxSecurityQuestions} questions. Answer any one to recover.',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: colorScheme.onSurface.withOpacity(0.5),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      ..._qaEntries.asMap().entries.map((entry) {
+                        final index = entry.key;
+                        final qa = entry.value;
+                        final isCustom = qa['isCustom'] == 'true';
+                        final selectedQ = qa['q'];
+                        final showCustomField = isCustom || selectedQ == '';
+
+                        return Padding(
+                          padding: EdgeInsets.only(
+                              bottom: index < _qaEntries.length - 1 ? 10 : 0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  Text(
+                                    'Q${index + 1}',
+                                    style: TextStyle(
+                                      fontFamily: 'Poppins',
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 11,
+                                      color: colorScheme.primary,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  if (_qaEntries.length > 1)
+                                    GestureDetector(
+                                      onTap: () => _removeQAEntry(index),
+                                      child: Icon(Icons.close_rounded,
+                                          size: 16,
+                                          color: colorScheme.onSurface
+                                              .withOpacity(0.4)),
+                                    ),
+                                ],
+                              ),
+                              const SizedBox(height: 4),
+                              DropdownButtonFormField<String>(
+                                value: isCustom
+                                    ? _kCustomQuestionLabel
+                                    : (selectedQ != null && selectedQ.isNotEmpty
+                                        ? selectedQ
+                                        : null),
+                                hint: Text(
+                                  'Select a question',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color:
+                                        colorScheme.onSurface.withOpacity(0.5),
+                                  ),
+                                ),
+                                isExpanded: true,
+                                isDense: true,
+                                decoration: InputDecoration(
+                                  filled: true,
+                                  fillColor: colorScheme.surface,
+                                  contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 10, vertical: 8),
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10),
+                                    borderSide: BorderSide.none,
+                                  ),
+                                ),
+                                items: _allQuestions.map((q) {
+                                  return DropdownMenuItem(
+                                    value: q,
+                                    child: Text(q,
+                                        style: const TextStyle(fontSize: 12),
+                                        overflow: TextOverflow.ellipsis),
+                                  );
+                                }).toList(),
+                                onChanged: (val) =>
+                                    _updateQAQuestion(index, val),
+                              ),
+                              if (showCustomField) ...[
+                                const SizedBox(height: 4),
+                                TextField(
+                                  controller: _customQuestionControllers[
+                                          index] ??
+                                      TextEditingController(),
+                                  style: const TextStyle(
+                                      fontFamily: 'Poppins', fontSize: 12),
+                                  decoration: InputDecoration(
+                                    hintText: 'Type your custom question...',
+                                    hintStyle: TextStyle(
+                                      color: colorScheme.onSurface
+                                          .withOpacity(0.4),
+                                      fontSize: 12,
+                                    ),
+                                    filled: true,
+                                    fillColor: colorScheme.surface,
+                                    contentPadding: const EdgeInsets.symmetric(
+                                        horizontal: 10, vertical: 8),
+                                    border: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(10),
+                                      borderSide: BorderSide.none,
+                                    ),
+                                  ),
+                                  onChanged: (val) {
+                                    setState(() {
+                                      _qaEntries[index]['customQ'] = val;
+                                      if (isCustom) {
+                                        _qaEntries[index]['q'] = val;
+                                      }
+                                    });
+                                  },
+                                ),
+                              ],
+                              const SizedBox(height: 4),
+                              TextField(
+                                controller: _answerControllers[index] ??
+                                    (_answerControllers[index] =
+                                        TextEditingController()),
+                                style: const TextStyle(
+                                    fontFamily: 'Poppins', fontSize: 12),
+                                decoration: InputDecoration(
+                                  hintText: 'Your answer',
+                                  hintStyle: TextStyle(
+                                    color: colorScheme.onSurface
+                                        .withOpacity(0.4),
+                                    fontSize: 12,
+                                  ),
+                                  filled: true,
+                                  fillColor: colorScheme.surface,
+                                  contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 10, vertical: 8),
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(10),
+                                    borderSide: BorderSide.none,
+                                  ),
+                                ),
+                                onChanged: (val) {
+                                  setState(() {
+                                    _qaEntries[index]['a'] = val;
+                                  });
+                                },
+                              ),
+                            ],
+                          ),
+                        );
+                      }),
+                      if (_canAddMoreQA) ...[
+                        const SizedBox(height: 8),
+                        Center(
+                          child: TextButton.icon(
+                            onPressed: _addQAEntry,
+                            icon: const Icon(Icons.add_rounded, size: 16),
+                            label: const Text('Add another question',
+                                style: TextStyle(fontSize: 12)),
+                            style: TextButton.styleFrom(
+                              foregroundColor: colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    const Icon(Icons.error_outline_rounded,
+                        color: Colors.red, size: 14),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(_error!,
+                          style:
+                              const TextStyle(color: Colors.red, fontSize: 12)),
+                    ),
+                  ],
+                ),
+              ],
               const SizedBox(height: 20),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
@@ -1493,57 +1844,7 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
-                    onPressed: () {
-                      final manager = Get.find<ProfileManager>();
-                      setState(() => _error = null);
-
-                      switch (_selectedType) {
-                        case ProfileLockType.none:
-                          manager.removeLock(widget.profile.id);
-                          Navigator.pop(context);
-                          snackBar('Protection removed');
-                          break;
-                        case ProfileLockType.pin:
-                          final pin = _pinController.text.trim();
-                          if (pin.length < 4 || pin.length > 6) {
-                            setState(() => _error = 'PIN must be 4-6 digits');
-                            return;
-                          }
-                          if (!RegExp(r'^\d+$').hasMatch(pin)) {
-                            setState(
-                                () => _error = 'PIN must be numbers only');
-                            return;
-                          }
-                          manager.setPin(widget.profile.id, pin);
-                          Navigator.pop(context);
-                          snackBar('PIN ${isNew ? "set" : "updated"} successfully');
-                          break;
-                        case ProfileLockType.password:
-                          final password = _passwordController.text;
-                          if (password.length < 4 || password.length > 32) {
-                            setState(
-                                () => _error = 'Password must be 4-32 characters');
-                            return;
-                          }
-                          manager.setPassword(
-                              widget.profile.id, password);
-                          Navigator.pop(context);
-                          snackBar(
-                              'Password ${isNew ? "set" : "updated"} successfully');
-                          break;
-                        case ProfileLockType.pattern:
-                          if (!_patternConfirmed) {
-                            setState(() => _error = 'Draw and confirm a pattern first');
-                            return;
-                          }
-                          manager.setPattern(
-                              widget.profile.id, _confirmedPattern);
-                          Navigator.pop(context);
-                          snackBar(
-                              'Pattern ${isNew ? "set" : "updated"} successfully');
-                          break;
-                      }
-                    },
+                    onPressed: () => _handleSave(),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: colorScheme.primary,
                       foregroundColor: colorScheme.onPrimary,
@@ -1565,6 +1866,85 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
     );
   }
 
+  void _handleSave() {
+    final manager = Get.find<ProfileManager>();
+    setState(() => _error = null);
+
+    List<Map<String, String>>? securityQAs;
+    if (_selectedType != ProfileLockType.none) {
+      securityQAs = [];
+      for (final qa in _qaEntries) {
+        final question = qa['isCustom'] == 'true'
+            ? (qa['customQ'] ?? '').trim()
+            : (qa['q'] ?? '').trim();
+        final answer = (qa['a'] ?? '').trim();
+
+        if (question.isEmpty) {
+          setState(() => _error =
+              'Please select or type a question for each entry');
+          return;
+        }
+        if (answer.isEmpty) {
+          setState(() => _error = 'Please provide an answer for each question');
+          return;
+        }
+        securityQAs.add({
+          'q': question,
+          'a': answer,
+          'c': qa['isCustom'] ?? 'false',
+        });
+      }
+      if (securityQAs.isEmpty) {
+        setState(() => _error = 'Add at least one recovery question');
+        return;
+      }
+    }
+
+    switch (_selectedType) {
+      case ProfileLockType.none:
+        manager.removeLock(widget.profile.id);
+        Navigator.pop(context);
+        snackBar('Protection removed');
+        break;
+      case ProfileLockType.pin:
+        final pin = _pinController.text.trim();
+        if (pin.length < 4 || pin.length > 6) {
+          setState(() => _error = 'PIN must be 4-6 digits');
+          return;
+        }
+        if (!RegExp(r'^\d+$').hasMatch(pin)) {
+          setState(() => _error = 'PIN must be numbers only');
+          return;
+        }
+        manager.setPin(widget.profile.id, pin,
+            securityQAs: securityQAs);
+        Navigator.pop(context);
+        snackBar('PIN set successfully');
+        break;
+      case ProfileLockType.password:
+        final password = _passwordController.text;
+        if (password.length < 4 || password.length > 32) {
+          setState(() => _error = 'Password must be 4-32 characters');
+          return;
+        }
+        manager.setPassword(widget.profile.id, password,
+            securityQAs: securityQAs);
+        Navigator.pop(context);
+        snackBar('Password set successfully');
+        break;
+      case ProfileLockType.pattern:
+        if (!_patternConfirmed) {
+          setState(() => _error = 'Draw and confirm a pattern first');
+          return;
+        }
+        manager.setPattern(widget.profile.id, _confirmedPattern,
+            securityQAs: securityQAs);
+        Navigator.pop(context);
+        snackBar('Pattern set successfully');
+        break;
+    }
+  }
+
   IconData _chipIcon(ProfileLockType type) {
     switch (type) {
       case ProfileLockType.none:
@@ -1576,5 +1956,278 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
       case ProfileLockType.pattern:
         return Icons.grid_3x3_rounded;
     }
+  }
+}
+
+class _ForgotLockDialog extends StatefulWidget {
+  final AppProfile profile;
+  const _ForgotLockDialog({super.key, required this.profile});
+
+  @override
+  State<_ForgotLockDialog> createState() => _ForgotLockDialogState();
+}
+
+class _ForgotLockDialogState extends State<_ForgotLockDialog> {
+  final _answerController = TextEditingController();
+  bool _isError = false;
+  String _errorMessage = '';
+  bool _isLoading = false;
+  int _selectedQuestionIndex = 0;
+
+  List<String> get _questions => widget.profile.securityQuestionTexts;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_questions.isEmpty) return;
+    _selectedQuestionIndex = 0;
+  }
+
+  @override
+  void dispose() {
+    _answerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (_questions.isEmpty) {
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: const Text('No Recovery Questions'),
+        content: const Text('This profile has no recovery questions set.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    }
+
+    final currentQuestion = _questions[_selectedQuestionIndex];
+    final hasMultiple = _questions.length > 1;
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.help_outline_rounded,
+                  color: Colors.orange, size: 20),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Recovery',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            hasMultiple
+                ? 'Pick a question and answer it to remove the lock from "${widget.profile.name}"'
+                : 'Answer correctly to remove the lock from "${widget.profile.name}"',
+            style: TextStyle(
+              fontSize: 12,
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (hasMultiple) ...[
+            DropdownButtonFormField<int>(
+              value: _selectedQuestionIndex,
+              isExpanded: true,
+              isDense: true,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: colorScheme.surface,
+                prefixIcon: Icon(Icons.quiz_rounded,
+                    size: 18, color: colorScheme.primary),
+                contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12, vertical: 8),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+              items: _questions.asMap().entries.map((entry) {
+                return DropdownMenuItem(
+                  value: entry.key,
+                  child: Text(
+                    'Q${entry.key + 1}: ${entry.value}',
+                    style: const TextStyle(fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                );
+              }).toList(),
+              onChanged: (val) {
+                if (val != null) {
+                  setState(() {
+                    _selectedQuestionIndex = val;
+                    _isError = false;
+                    _errorMessage = '';
+                    _answerController.clear();
+                  });
+                }
+              },
+            ),
+          ] else ...[
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withOpacity(0.06),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: colorScheme.primary.withOpacity(0.15),
+                ),
+              ),
+              child: Text(
+                currentQuestion,
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+          if (hasMultiple) ...[
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withOpacity(0.06),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: colorScheme.primary.withOpacity(0.15),
+                ),
+              ),
+              child: Text(
+                currentQuestion,
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          TextField(
+            controller: _answerController,
+            autofocus: true,
+            style: const TextStyle(fontFamily: 'Poppins', fontSize: 15),
+            decoration: InputDecoration(
+              hintText: 'Your answer',
+              hintStyle: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.4),
+              ),
+              filled: true,
+              fillColor: colorScheme.surface,
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _isError
+                    ? const BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+            ),
+            onChanged: (_) => setState(() {
+              _isError = false;
+              _errorMessage = '';
+            }),
+          ),
+          if (_isError) ...[
+            const SizedBox(height: 8),
+            Text(_errorMessage,
+                style: const TextStyle(color: Colors.red, fontSize: 13)),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            'The lock will be removed. You can set a new one later.',
+            style: TextStyle(
+              fontSize: 11,
+              color: colorScheme.onSurface.withOpacity(0.4),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed:
+              _isLoading ? null : () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+        ElevatedButton(
+          onPressed: _isLoading
+              ? null
+              : () {
+                  final answer = _answerController.text.trim();
+                  if (answer.isEmpty) {
+                    setState(() {
+                      _isError = true;
+                      _errorMessage = 'Please enter your answer';
+                    });
+                    return;
+                  }
+                  setState(() => _isLoading = true);
+                  final manager = Get.find<ProfileManager>();
+                  if (manager.verifySecurityAnswer(
+                      widget.profile.id, answer)) {
+                    manager.bypassLock(widget.profile.id);
+                    Navigator.pop(context, true);
+                  } else {
+                    setState(() {
+                      _isError = true;
+                      _errorMessage = 'Wrong answer. Try again.';
+                      _isLoading = false;
+                    });
+                    _answerController.clear();
+                  }
+                },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.orange,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12)),
+          ),
+          child: _isLoading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text('Verify & Remove Lock',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+        ),
+      ],
+    );
   }
 }

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -880,9 +880,16 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     );
   }
 
+  BackupRestoreService _getBackupService() {
+    if (!Get.isRegistered<BackupRestoreService>()) {
+      Get.put(BackupRestoreService());
+    }
+    return Get.find<BackupRestoreService>();
+  }
+
   Future<void> _exportProfile(AppProfile profile) async {
+    final backupService = _getBackupService();
     try {
-      final backupService = Get.find<BackupRestoreService>();
       backupService.isBackingUp.value = true;
 
       final path = await backupService.exportBackupToExternal(
@@ -897,7 +904,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         snackBar('Profile "${profile.name}" exported successfully');
       }
     } catch (e) {
-      Get.find<BackupRestoreService>().isBackingUp.value = false;
+      backupService.isBackingUp.value = false;
       snackBar('Export failed: $e');
     }
   }

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -204,11 +204,15 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                         value: 'remove_pin', child: Text('Remove PIN')),
                   const PopupMenuItem(
                       value: 'export', child: Text('Export Data')),
-                  if (!isCurrent)
+                  if (!isCurrent) ...[
+                    const PopupMenuItem(
+                        value: 'switch',
+                        child: Text('Switch to Profile')),
                     const PopupMenuItem(
                         value: 'delete',
                         child: Text('Delete Profile',
                             style: TextStyle(color: Colors.red))),
+                  ],
                 ],
               ),
             ],
@@ -329,6 +333,9 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       case 'export':
         _exportProfile(profile);
         break;
+      case 'switch':
+        await _switchToProfile(profile);
+        break;
       case 'delete':
         if (isCurrent) {
           snackBar('Switch to another profile first');
@@ -345,6 +352,95 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       final manager = Get.find<ProfileManager>();
       manager.updateProfileAvatar(profile.id, path);
       snackBar('Avatar updated');
+    }
+  }
+
+  Future<void> _switchToProfile(AppProfile profile) async {
+    if (profile.hasPin) {
+      final pinController = TextEditingController();
+      final colorScheme = Theme.of(context).colorScheme;
+      final success = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: colorScheme.surfaceContainer,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20)),
+          title: Text(
+            'Enter PIN for "${profile.name}"',
+            style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface),
+          ),
+          content: TextField(
+            controller: pinController,
+            keyboardType: TextInputType.number,
+            obscureText: true,
+            maxLength: 6,
+            autofocus: true,
+            style: TextStyle(
+                color: colorScheme.onSurface,
+                fontFamily: 'Poppins',
+                fontSize: 22,
+                letterSpacing: 8),
+            textAlign: TextAlign.center,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+              counterText: '',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text('Cancel',
+                  style: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.7))),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final pin = pinController.text.trim();
+                if (pin.length < 4) {
+                  snackBar('PIN must be at least 4 digits');
+                  return;
+                }
+                final manager = Get.find<ProfileManager>();
+                final result = manager.verifyPin(profile.id, pin);
+                if (result == true) {
+                  Navigator.pop(ctx, true);
+                } else {
+                  snackBar(result == null
+                      ? 'Profile is temporarily locked'
+                      : 'Wrong PIN');
+                  if (result == null) Navigator.pop(ctx, false);
+                }
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: colorScheme.primary,
+                foregroundColor: colorScheme.onPrimary,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
+              child: const Text('Unlock'),
+            ),
+          ],
+        ),
+      );
+      pinController.dispose();
+      if (success != true) return;
+    }
+
+    final manager = Get.find<ProfileManager>();
+    await manager.switchToProfile(profile.id);
+
+    if (mounted) {
+      snackBar('Switched to ${profile.name}');
+      Navigator.of(context).popUntil((route) => route.isFirst);
     }
   }
 

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -3,6 +3,7 @@ import 'package:anymex/controllers/services/backup_restore/backup_restore_servic
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/profile/profile_creation_page.dart';
 import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
+import 'package:anymex/screens/profile/widgets/forgot_lock_dialog.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
@@ -607,7 +608,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                 onPressed: () async {
                   final bypassed = await showDialog<bool>(
                     context: context,
-                    builder: (c) => _ForgotLockDialog(profile: profile),
+                    builder: (c) => ForgotLockDialog(profile: profile),
                   );
                   if (bypassed == true) {
                     Navigator.pop(ctx, true);
@@ -620,8 +621,6 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                         fontWeight: FontWeight.w600)),
               ),
             ),
-          if (profile.hasSecurityQuestions)
-            const Spacer(),
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
             child: Text('Cancel',
@@ -720,7 +719,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                 onPressed: () async {
                   final bypassed = await showDialog<bool>(
                     context: context,
-                    builder: (c) => _ForgotLockDialog(profile: profile),
+                    builder: (c) => ForgotLockDialog(profile: profile),
                   );
                   if (bypassed == true) {
                     Navigator.pop(ctx, true);
@@ -733,8 +732,6 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                         fontWeight: FontWeight.w600)),
               ),
             ),
-          if (profile.hasSecurityQuestions)
-            const Spacer(),
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
             child: Text('Cancel',
@@ -880,7 +877,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                     onPressed: () async {
                       final bypassed = await showDialog<bool>(
                         context: context,
-                        builder: (c) => _ForgotLockDialog(profile: profile),
+                        builder: (c) => ForgotLockDialog(profile: profile),
                       );
                       if (bypassed == true) {
                         Navigator.pop(ctx, true);
@@ -893,8 +890,6 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                             fontWeight: FontWeight.w600)),
                   ),
                 ),
-              if (profile.hasSecurityQuestions)
-                const Spacer(),
               TextButton(
                 onPressed: () => Navigator.pop(ctx, false),
                 child: Text('Cancel',
@@ -1959,275 +1954,3 @@ class _LockSetupSheetState extends State<_LockSetupSheet> {
   }
 }
 
-class _ForgotLockDialog extends StatefulWidget {
-  final AppProfile profile;
-  const _ForgotLockDialog({super.key, required this.profile});
-
-  @override
-  State<_ForgotLockDialog> createState() => _ForgotLockDialogState();
-}
-
-class _ForgotLockDialogState extends State<_ForgotLockDialog> {
-  final _answerController = TextEditingController();
-  bool _isError = false;
-  String _errorMessage = '';
-  bool _isLoading = false;
-  int _selectedQuestionIndex = 0;
-
-  List<String> get _questions => widget.profile.securityQuestionTexts;
-
-  @override
-  void initState() {
-    super.initState();
-    if (_questions.isEmpty) return;
-    _selectedQuestionIndex = 0;
-  }
-
-  @override
-  void dispose() {
-    _answerController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    if (_questions.isEmpty) {
-      return AlertDialog(
-        backgroundColor: colorScheme.surfaceContainer,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        title: const Text('No Recovery Questions'),
-        content: const Text('This profile has no recovery questions set.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
-          ),
-        ],
-      );
-    }
-
-    final currentQuestion = _questions[_selectedQuestionIndex];
-    final hasMultiple = _questions.length > 1;
-
-    return AlertDialog(
-      backgroundColor: colorScheme.surfaceContainer,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      title: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.help_outline_rounded,
-                  color: Colors.orange, size: 20),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  'Recovery',
-                  style: TextStyle(
-                    fontFamily: 'Poppins',
-                    fontWeight: FontWeight.bold,
-                    color: colorScheme.onSurface,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Text(
-            hasMultiple
-                ? 'Pick a question and answer it to remove the lock from "${widget.profile.name}"'
-                : 'Answer correctly to remove the lock from "${widget.profile.name}"',
-            style: TextStyle(
-              fontSize: 12,
-              color: colorScheme.onSurface.withOpacity(0.6),
-            ),
-          ),
-        ],
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (hasMultiple) ...[
-            DropdownButtonFormField<int>(
-              value: _selectedQuestionIndex,
-              isExpanded: true,
-              isDense: true,
-              decoration: InputDecoration(
-                filled: true,
-                fillColor: colorScheme.surface,
-                prefixIcon: Icon(Icons.quiz_rounded,
-                    size: 18, color: colorScheme.primary),
-                contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 12, vertical: 8),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10),
-                  borderSide: BorderSide.none,
-                ),
-              ),
-              items: _questions.asMap().entries.map((entry) {
-                return DropdownMenuItem(
-                  value: entry.key,
-                  child: Text(
-                    'Q${entry.key + 1}: ${entry.value}',
-                    style: const TextStyle(fontSize: 12),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                );
-              }).toList(),
-              onChanged: (val) {
-                if (val != null) {
-                  setState(() {
-                    _selectedQuestionIndex = val;
-                    _isError = false;
-                    _errorMessage = '';
-                    _answerController.clear();
-                  });
-                }
-              },
-            ),
-          ] else ...[
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: colorScheme.primary.withOpacity(0.06),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: colorScheme.primary.withOpacity(0.15),
-                ),
-              ),
-              child: Text(
-                currentQuestion,
-                style: TextStyle(
-                  fontFamily: 'Poppins',
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                  color: colorScheme.onSurface,
-                ),
-              ),
-            ),
-          ],
-          if (hasMultiple) ...[
-            const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: colorScheme.primary.withOpacity(0.06),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: colorScheme.primary.withOpacity(0.15),
-                ),
-              ),
-              child: Text(
-                currentQuestion,
-                style: TextStyle(
-                  fontFamily: 'Poppins',
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                  color: colorScheme.onSurface,
-                ),
-              ),
-            ),
-          ],
-          const SizedBox(height: 12),
-          TextField(
-            controller: _answerController,
-            autofocus: true,
-            style: const TextStyle(fontFamily: 'Poppins', fontSize: 15),
-            decoration: InputDecoration(
-              hintText: 'Your answer',
-              hintStyle: TextStyle(
-                color: colorScheme.onSurface.withOpacity(0.4),
-              ),
-              filled: true,
-              fillColor: colorScheme.surface,
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: _isError
-                    ? const BorderSide(color: Colors.red, width: 2)
-                    : BorderSide.none,
-              ),
-            ),
-            onChanged: (_) => setState(() {
-              _isError = false;
-              _errorMessage = '';
-            }),
-          ),
-          if (_isError) ...[
-            const SizedBox(height: 8),
-            Text(_errorMessage,
-                style: const TextStyle(color: Colors.red, fontSize: 13)),
-          ],
-          const SizedBox(height: 8),
-          Text(
-            'The lock will be removed. You can set a new one later.',
-            style: TextStyle(
-              fontSize: 11,
-              color: colorScheme.onSurface.withOpacity(0.4),
-            ),
-          ),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed:
-              _isLoading ? null : () => Navigator.pop(context, false),
-          child: Text('Cancel',
-              style: TextStyle(
-                  color: colorScheme.onSurface.withOpacity(0.7))),
-        ),
-        ElevatedButton(
-          onPressed: _isLoading
-              ? null
-              : () {
-                  final answer = _answerController.text.trim();
-                  if (answer.isEmpty) {
-                    setState(() {
-                      _isError = true;
-                      _errorMessage = 'Please enter your answer';
-                    });
-                    return;
-                  }
-                  setState(() => _isLoading = true);
-                  final manager = Get.find<ProfileManager>();
-                  if (manager.verifySecurityAnswer(
-                      widget.profile.id, answer)) {
-                    manager.bypassLock(widget.profile.id);
-                    Navigator.pop(context, true);
-                  } else {
-                    setState(() {
-                      _isError = true;
-                      _errorMessage = 'Wrong answer. Try again.';
-                      _isLoading = false;
-                    });
-                    _answerController.clear();
-                  }
-                },
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.orange,
-            foregroundColor: Colors.white,
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12)),
-          ),
-          child: _isLoading
-              ? const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: Colors.white,
-                  ),
-                )
-              : const Text('Verify & Remove Lock',
-                  style: TextStyle(fontWeight: FontWeight.bold)),
-        ),
-      ],
-    );
-  }
-}

--- a/lib/screens/profile/profile_management_page.dart
+++ b/lib/screens/profile/profile_management_page.dart
@@ -2,6 +2,7 @@ import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/services/backup_restore/backup_restore_service.dart';
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
@@ -88,8 +89,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     ColorScheme colorScheme,
     dynamic theme,
   ) {
-    final needsPin =
-        !isCurrent && profile.hasPin;
+    final needsLock = !isCurrent && profile.hasLock;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
@@ -148,11 +148,13 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                             ),
                           ),
                         ],
-                        if (profile.hasPin) ...[
+                        if (profile.hasLock) ...[
                           const SizedBox(width: 6),
-                          Icon(Icons.lock_outline,
-                              size: 14,
-                              color: theme.onSurface.withOpacity(0.5)),
+                          Icon(
+                            _getLockIcon(profile.profileLockType),
+                            size: 14,
+                            color: theme.onSurface.withOpacity(0.5),
+                          ),
                         ],
                       ],
                     ),
@@ -175,11 +177,11 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                                       .withOpacity(0.4))),
                       ],
                     ),
-                    if (needsPin)
+                    if (needsLock)
                       Padding(
                         padding: const EdgeInsets.only(top: 6),
                         child: Text(
-                          'PIN required to make changes',
+                          '${profile.lockLabel} required to make changes',
                           style: TextStyle(
                             fontSize: 11,
                             color: colorScheme.primary.withOpacity(0.7),
@@ -210,22 +212,22 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                           ],
                         )),
                     const PopupMenuItem(
-                        value: 'pin',
+                        value: 'lock',
                         child: Row(
                           children: [
                             Icon(Icons.lock_outline, size: 18),
                             SizedBox(width: 10),
-                            Text('Set / Change PIN'),
+                            Text('Change Protection'),
                           ],
                         )),
-                    if (profile.hasPin)
+                    if (profile.hasLock)
                       const PopupMenuItem(
-                          value: 'remove_pin',
+                          value: 'remove_lock',
                           child: Row(
                             children: [
                               Icon(Icons.lock_open, size: 18),
                               SizedBox(width: 10),
-                              Text('Remove PIN'),
+                              Text('Remove Protection'),
                             ],
                           )),
                     const PopupMenuItem(
@@ -238,14 +240,14 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                           ],
                         )),
                   ] else ...[
-                    if (needsPin)
-                      const PopupMenuItem(
+                    if (needsLock)
+                      PopupMenuItem(
                           value: 'verify',
                           child: Row(
                             children: [
                               Icon(Icons.lock_person, size: 18),
                               SizedBox(width: 10),
-                              Text('Enter PIN to Manage'),
+                              Text('Enter ${profile.lockLabel} to Manage'),
                             ],
                           ))
                     else ...[
@@ -259,22 +261,22 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                             ],
                           )),
                       const PopupMenuItem(
-                          value: 'pin',
+                          value: 'lock',
                           child: Row(
                             children: [
                               Icon(Icons.lock_outline, size: 18),
                               SizedBox(width: 10),
-                              Text('Set / Change PIN'),
+                              Text('Change Protection'),
                             ],
                           )),
-                      if (profile.hasPin)
+                      if (profile.hasLock)
                         const PopupMenuItem(
-                            value: 'remove_pin',
+                            value: 'remove_lock',
                             child: Row(
                               children: [
                                 Icon(Icons.lock_open, size: 18),
                                 SizedBox(width: 10),
-                                Text('Remove PIN'),
+                                Text('Remove Protection'),
                               ],
                             )),
                       const PopupMenuItem(
@@ -316,6 +318,19 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         ],
       ),
     );
+  }
+
+  IconData _getLockIcon(ProfileLockType type) {
+    switch (type) {
+      case ProfileLockType.none:
+        return Icons.lock_open_rounded;
+      case ProfileLockType.pin:
+        return Icons.dialpad_rounded;
+      case ProfileLockType.password:
+        return Icons.password_rounded;
+      case ProfileLockType.pattern:
+        return Icons.grid_3x3_rounded;
+    }
   }
 
   Widget _buildAddButton(ColorScheme colorScheme, dynamic theme) {
@@ -415,14 +430,14 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
 
   Future<void> _handleAction(
       String action, AppProfile profile, bool isCurrent) async {
-    if (!isCurrent && profile.hasPin) {
+    if (!isCurrent && profile.hasLock) {
       if (action == 'verify') {
-        final verified = await _showPinVerification(profile);
+        final verified = await _showLockVerification(profile);
         if (verified != true) return;
         _showUnlockedMenu(profile);
         return;
       }
-      final verified = await _showPinVerification(profile);
+      final verified = await _showLockVerification(profile);
       if (verified != true) return;
     }
 
@@ -430,15 +445,11 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       case 'change_avatar':
         _changeAvatar(profile);
         break;
-      case 'pin':
-        if (!isCurrent && profile.hasPin) {
-          _showChangePinAfterVerify(profile);
-        } else {
-          _showPinSetupDialog(profile);
-        }
+      case 'lock':
+        _showLockSetupDialog(profile);
         break;
-      case 'remove_pin':
-        _confirmRemovePin(profile);
+      case 'remove_lock':
+        _confirmRemoveLock(profile);
         break;
       case 'export':
         _exportProfile(profile);
@@ -489,19 +500,19 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                 },
               ),
               ListTile(
-                leading: const Icon(Icons.lock_outline),
-                title: const Text('Change PIN'),
+                leading: Icon(_getLockIcon(profile.profileLockType)),
+                title: Text('Change ${profile.lockLabel}'),
                 onTap: () {
                   Navigator.pop(ctx);
-                  _showChangePinAfterVerify(profile);
+                  _showLockSetupDialog(profile);
                 },
               ),
               ListTile(
                 leading: const Icon(Icons.lock_open),
-                title: const Text('Remove PIN'),
+                title: Text('Remove ${profile.lockLabel}'),
                 onTap: () {
                   Navigator.pop(ctx);
-                  _confirmRemovePin(profile);
+                  _confirmRemoveLock(profile);
                 },
               ),
               ListTile(
@@ -519,7 +530,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     );
   }
 
-  Future<bool?> _showPinVerification(AppProfile profile) async {
+  Future<bool?> _showLockVerification(AppProfile profile) async {
     final manager = Get.find<ProfileManager>();
 
     if (profile.isLocked) {
@@ -530,9 +541,23 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
       return null;
     }
 
+    switch (profile.profileLockType) {
+      case ProfileLockType.pin:
+        return _showPinVerification(profile);
+      case ProfileLockType.password:
+        return _showPasswordVerification(profile);
+      case ProfileLockType.pattern:
+        return _showPatternVerification(profile);
+      case ProfileLockType.none:
+        return true;
+    }
+  }
+
+  Future<bool?> _showPinVerification(AppProfile profile) async {
+    final manager = Get.find<ProfileManager>();
     final pinController = TextEditingController();
     final colorScheme = Theme.of(context).colorScheme;
-    final pinContentKey = GlobalKey<_PinVerifyContentState>();
+    final contentKey = GlobalKey<_PinVerifyContentState>();
 
     final verified = await showDialog<bool>(
       context: context,
@@ -557,7 +582,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
                         color: colorScheme.onSurface),
                   ),
                   Text(
-                    'Enter this profile\'s PIN to continue',
+                    'Enter PIN to continue',
                     style: TextStyle(
                         fontSize: 12,
                         color: colorScheme.onSurface.withOpacity(0.6)),
@@ -568,7 +593,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
           ],
         ),
         content: _PinVerifyContent(
-          key: pinContentKey,
+          key: contentKey,
           controller: pinController,
           profile: profile,
         ),
@@ -583,21 +608,21 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
             onPressed: () {
               final pin = pinController.text.trim();
               if (pin.length < 4) {
-                pinContentKey.currentState?.setError('PIN must be at least 4 digits');
+                contentKey.currentState?.setError('PIN must be at least 4 digits');
                 return;
               }
-              final result = manager.verifyPin(profile.id, pin);
+              final result = manager.verifyLock(profile.id, pin);
               if (result == true) {
                 Navigator.pop(ctx, true);
               } else if (result == false) {
-                final remaining = kMaxPinAttempts -
+                final remaining = kMaxLockAttempts -
                     (manager.profiles
                             .firstWhereOrNull((p) => p.id == profile.id)
-                            ?.failedPinAttempts ??
+                            ?.failedAttempts ??
                         0);
-                pinContentKey.currentState?.setError(
+                contentKey.currentState?.setError(
                     'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} remaining');
-                pinContentKey.currentState?.clearInput();
+                contentKey.currentState?.clearInput();
               } else {
                 Navigator.pop(ctx, false);
               }
@@ -619,6 +644,205 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     return verified;
   }
 
+  Future<bool?> _showPasswordVerification(AppProfile profile) async {
+    final manager = Get.find<ProfileManager>();
+    final passwordController = TextEditingController();
+    final colorScheme = Theme.of(context).colorScheme;
+    final contentKey = GlobalKey<_PasswordVerifyContentState>();
+
+    final verified = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20)),
+        title: Row(
+          children: [
+            ProfileAvatar(profile: profile, radius: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Verify ${profile.name}',
+                    style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurface),
+                  ),
+                  Text(
+                    'Enter password to continue',
+                    style: TextStyle(
+                        fontSize: 12,
+                        color: colorScheme.onSurface.withOpacity(0.6)),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        content: _PasswordVerifyContent(
+          key: contentKey,
+          controller: passwordController,
+          profile: profile,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text('Cancel',
+                style: TextStyle(
+                    color: colorScheme.onSurface.withOpacity(0.7))),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final password = passwordController.text;
+              if (password.isEmpty) {
+                contentKey.currentState?.setError('Enter a password');
+                return;
+              }
+              final result = manager.verifyLock(profile.id, password);
+              if (result == true) {
+                Navigator.pop(ctx, true);
+              } else if (result == false) {
+                final remaining = kMaxLockAttempts -
+                    (manager.profiles
+                            .firstWhereOrNull((p) => p.id == profile.id)
+                            ?.failedAttempts ??
+                        0);
+                contentKey.currentState?.setError(
+                    'Wrong password. $remaining attempt${remaining != 1 ? 's' : ''} remaining');
+                contentKey.currentState?.clearInput();
+              } else {
+                Navigator.pop(ctx, false);
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: colorScheme.primary,
+              foregroundColor: colorScheme.onPrimary,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('Verify',
+                style: TextStyle(
+                    fontFamily: 'Poppins', fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+    passwordController.dispose();
+    return verified;
+  }
+
+  Future<bool?> _showPatternVerification(AppProfile profile) async {
+    final manager = Get.find<ProfileManager>();
+    final colorScheme = Theme.of(context).colorScheme;
+    bool? result;
+
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => StatefulBuilder(
+        builder: (context, setDialogState) {
+          return AlertDialog(
+            backgroundColor: colorScheme.surfaceContainer,
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20)),
+            title: Row(
+              children: [
+                ProfileAvatar(profile: profile, radius: 20),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Verify ${profile.name}',
+                        style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface),
+                      ),
+                      Text(
+                        'Draw pattern to continue',
+                        style: TextStyle(
+                            fontSize: 12,
+                            color:
+                                colorScheme.onSurface.withOpacity(0.6)),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 220,
+                  height: 220,
+                  child: PatternLock(
+                    onPatternComplete: (pattern) {
+                      final patternStr = pattern.join(',');
+                      final verifyResult =
+                          manager.verifyLock(profile.id, patternStr);
+                      if (verifyResult == true) {
+                        Navigator.pop(ctx, true);
+                      } else if (verifyResult == false) {
+                        final remaining = kMaxLockAttempts -
+                            (manager.profiles
+                                    .firstWhereOrNull(
+                                        (p) => p.id == profile.id)
+                                    ?.failedAttempts ??
+                                0);
+                        setDialogState(() {});
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                                'Wrong pattern. $remaining attempt${remaining != 1 ? 's' : ''} remaining'),
+                            duration: const Duration(seconds: 2),
+                          ),
+                        );
+                      } else {
+                        Navigator.pop(ctx, false);
+                      }
+                    },
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Obx(() {
+                  final attempts = manager.profiles
+                          .firstWhereOrNull((p) => p.id == profile.id)
+                          ?.failedAttempts ?? 0;
+                  if (attempts > 0) {
+                    return Text(
+                      '$attempts / $kMaxLockAttempts attempts',
+                      style: TextStyle(
+                          color: colorScheme.onSurface.withOpacity(0.4),
+                          fontSize: 12),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                }),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: Text('Cancel',
+                    style: TextStyle(
+                        color: colorScheme.onSurface.withOpacity(0.7))),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+
+    return result;
+  }
+
   Future<void> _changeAvatar(AppProfile profile) async {
     final path = await pickAndSaveProfileImage();
     if (path != null) {
@@ -629,7 +853,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
   }
 
   Future<void> _switchToProfile(AppProfile profile) async {
-    if (profile.hasPin) {
+    if (profile.hasLock) {
       if (profile.isLocked) {
         final remaining =
             profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
@@ -637,7 +861,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
             'Profile is locked. Try again in $remaining minute${remaining != 1 ? 's' : ''}');
         return;
       }
-      final verified = await _showPinVerification(profile);
+      final verified = await _showLockVerification(profile);
       if (verified != true) return;
     }
 
@@ -650,98 +874,18 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
     }
   }
 
-  void _showPinSetupDialog(AppProfile profile) {
-    final controller = TextEditingController();
+  void _showLockSetupDialog(AppProfile profile) {
     final colorScheme = Theme.of(context).colorScheme;
-    final isNew = !profile.hasPin;
 
     showDialog(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: colorScheme.surfaceContainer,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20)),
-        title: Text(
-          isNew ? 'Set PIN' : 'Change PIN',
-          style: TextStyle(
-              fontFamily: 'Poppins',
-              fontWeight: FontWeight.bold,
-              color: colorScheme.onSurface),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              isNew
-                  ? 'Set a 4-6 digit PIN for "${profile.name}"'
-                  : 'Enter new PIN for "${profile.name}"',
-              style: TextStyle(
-                  color: colorScheme.onSurface.withOpacity(0.7)),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller,
-              keyboardType: TextInputType.number,
-              obscureText: true,
-              maxLength: 6,
-              autofocus: true,
-              style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontFamily: 'Poppins',
-                  fontSize: 22,
-                  letterSpacing: 8),
-              textAlign: TextAlign.center,
-              decoration: InputDecoration(
-                filled: true,
-                fillColor: colorScheme.surface,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide.none,
-                ),
-                counterText: '',
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: Text('Cancel',
-                style: TextStyle(
-                    color: colorScheme.onSurface.withOpacity(0.7))),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              final pin = controller.text.trim();
-              if (pin.length < 4 || pin.length > 6) {
-                snackBar('PIN must be 4-6 digits');
-                return;
-              }
-              if (!RegExp(r'^\d+$').hasMatch(pin)) {
-                snackBar('PIN must contain only numbers');
-                return;
-              }
-              final manager = Get.find<ProfileManager>();
-              manager.setPin(profile.id, pin);
-              Navigator.pop(ctx);
-              snackBar('PIN ${isNew ? "set" : "updated"} successfully');
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: colorScheme.primary,
-              foregroundColor: colorScheme.onPrimary,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
-            ),
-            child: Text(isNew ? 'Set PIN' : 'Update'),
-          ),
-        ],
-      ),
+      builder: (ctx) => _LockSetupSheet(profile: profile),
     );
   }
 
-  void _showChangePinAfterVerify(AppProfile profile) {
-    final controller = TextEditingController();
+  void _confirmRemoveLock(AppProfile profile) {
     final colorScheme = Theme.of(context).colorScheme;
+    final lockLabel = profile.lockLabel;
 
     showDialog(
       context: context,
@@ -750,93 +894,7 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
         shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20)),
         title: Text(
-          'Change PIN for "${profile.name}"',
-          style: TextStyle(
-              fontFamily: 'Poppins',
-              fontWeight: FontWeight.bold,
-              color: colorScheme.onSurface),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'Enter new PIN (4-6 digits)',
-              style: TextStyle(
-                  color: colorScheme.onSurface.withOpacity(0.7)),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller,
-              keyboardType: TextInputType.number,
-              obscureText: true,
-              maxLength: 6,
-              autofocus: true,
-              style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontFamily: 'Poppins',
-                  fontSize: 22,
-                  letterSpacing: 8),
-              textAlign: TextAlign.center,
-              decoration: InputDecoration(
-                filled: true,
-                fillColor: colorScheme.surface,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide.none,
-                ),
-                counterText: '',
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: Text('Cancel',
-                style: TextStyle(
-                    color: colorScheme.onSurface.withOpacity(0.7))),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              final pin = controller.text.trim();
-              if (pin.length < 4 || pin.length > 6) {
-                snackBar('PIN must be 4-6 digits');
-                return;
-              }
-              if (!RegExp(r'^\d+$').hasMatch(pin)) {
-                snackBar('PIN must contain only numbers');
-                return;
-              }
-              final manager = Get.find<ProfileManager>();
-              manager.setPin(profile.id, pin);
-              Navigator.pop(ctx);
-              snackBar('PIN updated successfully');
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: colorScheme.primary,
-              foregroundColor: colorScheme.onPrimary,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
-            ),
-            child: const Text('Update PIN',
-                style: TextStyle(fontWeight: FontWeight.bold)),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _confirmRemovePin(AppProfile profile) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: colorScheme.surfaceContainer,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20)),
-        title: Text(
-          'Remove PIN from "${profile.name}"?',
+          'Remove $lockLabel from "${profile.name}"?',
           style: TextStyle(
               fontFamily: 'Poppins',
               fontWeight: FontWeight.bold,
@@ -858,8 +916,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
             onPressed: () {
               Navigator.pop(ctx);
               final manager = Get.find<ProfileManager>();
-              manager.removePin(profile.id);
-              snackBar('PIN removed from "${profile.name}"');
+              manager.removeLock(profile.id);
+              snackBar('$lockLabel removed from "${profile.name}"');
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.red,
@@ -867,8 +925,8 @@ class _ProfileManagementPageState extends State<ProfileManagementPage> {
               shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12)),
             ),
-            child: const Text('Remove PIN',
-                style: TextStyle(fontWeight: FontWeight.bold)),
+            child: Text('Remove $lockLabel',
+                style: const TextStyle(fontWeight: FontWeight.bold)),
           ),
         ],
       ),
@@ -1047,7 +1105,7 @@ class _PinVerifyContentState extends State<_PinVerifyContent> {
                   ? const BorderSide(color: Colors.red, width: 2)
                   : BorderSide.none,
             ),
-            hintText: '• • • •',
+            hintText: '\u2022 \u2022 \u2022 \u2022',
             hintStyle: TextStyle(
               color: colorScheme.onSurface.withOpacity(0.2),
               letterSpacing: 4,
@@ -1069,11 +1127,11 @@ class _PinVerifyContentState extends State<_PinVerifyContent> {
           final manager = Get.find<ProfileManager>();
           final attempts = manager.profiles
                   .firstWhereOrNull((p) => p.id == widget.profile.id)
-                  ?.failedPinAttempts ??
+                  ?.failedAttempts ??
               0;
           if (attempts > 0) {
             return Text(
-              '$attempts / $kMaxPinAttempts attempts',
+              '$attempts / $kMaxLockAttempts attempts',
               style: TextStyle(
                   color: colorScheme.onSurface.withOpacity(0.4),
                   fontSize: 12),
@@ -1083,5 +1141,449 @@ class _PinVerifyContentState extends State<_PinVerifyContent> {
         }),
       ],
     );
+  }
+}
+
+class _PasswordVerifyContent extends StatefulWidget {
+  final TextEditingController controller;
+  final AppProfile profile;
+  const _PasswordVerifyContent(
+      {super.key, required this.controller, required this.profile});
+
+  @override
+  State<_PasswordVerifyContent> createState() =>
+      _PasswordVerifyContentState();
+}
+
+class _PasswordVerifyContentState extends State<_PasswordVerifyContent> {
+  bool _isError = false;
+  String _errorMessage = '';
+
+  void setError(String message) {
+    setState(() {
+      _isError = true;
+      _errorMessage = message;
+    });
+  }
+
+  void clearInput() {
+    widget.controller.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: widget.controller,
+          obscureText: true,
+          autofocus: true,
+          style: TextStyle(
+              color: colorScheme.onSurface,
+              fontFamily: 'Poppins',
+              fontSize: 18),
+          decoration: InputDecoration(
+            filled: true,
+            fillColor: colorScheme.surface,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: _isError
+                  ? const BorderSide(color: Colors.red, width: 2)
+                  : BorderSide.none,
+            ),
+            hintText: 'Enter password',
+            hintStyle: TextStyle(
+              color: colorScheme.onSurface.withOpacity(0.3),
+            ),
+          ),
+          onChanged: (_) => setState(() {
+            _isError = false;
+            _errorMessage = '';
+          }),
+          onSubmitted: (_) {
+            if (widget.controller.text.isNotEmpty) {
+              final parentCtx = context;
+              Navigator.of(parentCtx).pop(true);
+            }
+          },
+        ),
+        if (_isError) ...[
+          const SizedBox(height: 8),
+          Text(_errorMessage,
+              style: const TextStyle(color: Colors.red, fontSize: 13)),
+        ],
+        const SizedBox(height: 4),
+        Obx(() {
+          final manager = Get.find<ProfileManager>();
+          final attempts = manager.profiles
+                  .firstWhereOrNull((p) => p.id == widget.profile.id)
+                  ?.failedAttempts ??
+              0;
+          if (attempts > 0) {
+            return Text(
+              '$attempts / $kMaxLockAttempts attempts',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  fontSize: 12),
+            );
+          }
+          return const SizedBox.shrink();
+        }),
+      ],
+    );
+  }
+}
+
+class _LockSetupSheet extends StatefulWidget {
+  final AppProfile profile;
+  const _LockSetupSheet({required this.profile});
+
+  @override
+  State<_LockSetupSheet> createState() => _LockSetupSheetState();
+}
+
+class _LockSetupSheetState extends State<_LockSetupSheet> {
+  ProfileLockType _selectedType = ProfileLockType.none;
+  final TextEditingController _pinController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  List<int> _firstPattern = [];
+  List<int> _confirmedPattern = [];
+  bool _patternConfirmed = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _pinController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _resetInputs() {
+    _pinController.clear();
+    _passwordController.clear();
+    _firstPattern.clear();
+    _confirmedPattern.clear();
+    _patternConfirmed = false;
+    _error = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final theme = context.colors;
+    final isNew = !widget.profile.hasLock;
+
+    return Dialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.lock_outline_rounded, color: colorScheme.primary),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      isNew ? 'Set Protection' : 'Change Protection',
+                      style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontWeight: FontWeight.bold,
+                          fontSize: 18,
+                          color: colorScheme.onSurface),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Choose how to protect "${widget.profile.name}"',
+                style: TextStyle(
+                    fontSize: 13,
+                    color: colorScheme.onSurface.withOpacity(0.6)),
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: ProfileLockType.values.map((type) {
+                  final isSelected = _selectedType == type;
+                  return ChoiceChip(
+                    avatar: Icon(
+                      _chipIcon(type),
+                      size: 16,
+                      color: isSelected
+                          ? colorScheme.onPrimary
+                          : colorScheme.onSurface.withOpacity(0.6),
+                    ),
+                    label: Text(
+                      type == ProfileLockType.none
+                          ? 'None'
+                          : type == ProfileLockType.pin
+                              ? 'PIN'
+                              : type == ProfileLockType.password
+                                  ? 'Password'
+                                  : 'Pattern',
+                      style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontSize: 13,
+                        fontWeight:
+                            isSelected ? FontWeight.w600 : FontWeight.w400,
+                      ),
+                    ),
+                    selected: isSelected,
+                    selectedColor: colorScheme.primary,
+                    onSelected: (val) {
+                      setState(() {
+                        _selectedType = type;
+                        _resetInputs();
+                      });
+                    },
+                    labelStyle: TextStyle(
+                      color: isSelected
+                          ? colorScheme.onPrimary
+                          : colorScheme.onSurface,
+                    ),
+                    side: BorderSide(
+                      color: isSelected
+                          ? colorScheme.primary
+                          : colorScheme.outline.withOpacity(0.3),
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  );
+                }).toList(),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    const Icon(Icons.error_outline_rounded,
+                        color: Colors.red, size: 14),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(_error!,
+                          style:
+                              const TextStyle(color: Colors.red, fontSize: 12)),
+                    ),
+                  ],
+                ),
+              ],
+              if (_selectedType == ProfileLockType.pin) ...[
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _pinController,
+                  keyboardType: TextInputType.number,
+                  obscureText: true,
+                  maxLength: 6,
+                  autofocus: true,
+                  style: const TextStyle(
+                      fontFamily: 'Poppins', fontSize: 22, letterSpacing: 8),
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    labelText: isNew ? 'Create PIN' : 'New PIN',
+                    labelStyle: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.6),
+                    ),
+                    filled: true,
+                    fillColor: colorScheme.surface,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    counterText: '',
+                  ),
+                ),
+              ],
+              if (_selectedType == ProfileLockType.password) ...[
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  maxLength: 32,
+                  autofocus: true,
+                  style: const TextStyle(
+                      fontFamily: 'Poppins', fontSize: 16),
+                  decoration: InputDecoration(
+                    labelText: isNew ? 'Create Password' : 'New Password',
+                    labelStyle: TextStyle(
+                      color: colorScheme.onSurface.withOpacity(0.6),
+                    ),
+                    filled: true,
+                    fillColor: colorScheme.surface,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    counterText: '',
+                  ),
+                ),
+              ],
+              if (_selectedType == ProfileLockType.pattern) ...[
+                const SizedBox(height: 16),
+                Center(
+                  child: Text(
+                    _firstPattern.isEmpty
+                        ? 'Draw a pattern (min 4 dots)'
+                        : _patternConfirmed
+                            ? 'Pattern confirmed'
+                            : 'Draw pattern again to confirm',
+                    style: TextStyle(
+                        fontSize: 12,
+                        color: _patternConfirmed
+                            ? Colors.green.shade400
+                            : colorScheme.onSurface.withOpacity(0.6)),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Center(
+                  child: SizedBox(
+                    width: 220,
+                    height: 220,
+                    child: PatternLock(
+                      onPatternComplete: (pattern) {
+                        if (pattern.length < 4) {
+                          setState(() {
+                            _error = 'Connect at least 4 dots';
+                          });
+                          return;
+                        }
+                        if (_firstPattern.isEmpty) {
+                          setState(() {
+                            _firstPattern = pattern;
+                            _error = null;
+                          });
+                        } else {
+                          bool same = pattern.length == _firstPattern.length;
+                          if (same) {
+                            for (int i = 0; i < pattern.length; i++) {
+                              if (pattern[i] != _firstPattern[i]) {
+                                same = false;
+                                break;
+                              }
+                            }
+                          }
+                          if (same) {
+                            setState(() {
+                              _confirmedPattern = pattern;
+                              _patternConfirmed = true;
+                              _error = null;
+                            });
+                          } else {
+                            setState(() {
+                              _firstPattern.clear();
+                              _error = 'Patterns do not match. Try again.';
+                            });
+                          }
+                        }
+                      },
+                    ),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: Text('Cancel',
+                        style: TextStyle(
+                            color: colorScheme.onSurface.withOpacity(0.7))),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: () {
+                      final manager = Get.find<ProfileManager>();
+                      setState(() => _error = null);
+
+                      switch (_selectedType) {
+                        case ProfileLockType.none:
+                          manager.removeLock(widget.profile.id);
+                          Navigator.pop(context);
+                          snackBar('Protection removed');
+                          break;
+                        case ProfileLockType.pin:
+                          final pin = _pinController.text.trim();
+                          if (pin.length < 4 || pin.length > 6) {
+                            setState(() => _error = 'PIN must be 4-6 digits');
+                            return;
+                          }
+                          if (!RegExp(r'^\d+$').hasMatch(pin)) {
+                            setState(
+                                () => _error = 'PIN must be numbers only');
+                            return;
+                          }
+                          manager.setPin(widget.profile.id, pin);
+                          Navigator.pop(context);
+                          snackBar('PIN ${isNew ? "set" : "updated"} successfully');
+                          break;
+                        case ProfileLockType.password:
+                          final password = _passwordController.text;
+                          if (password.length < 4 || password.length > 32) {
+                            setState(
+                                () => _error = 'Password must be 4-32 characters');
+                            return;
+                          }
+                          manager.setPassword(
+                              widget.profile.id, password);
+                          Navigator.pop(context);
+                          snackBar(
+                              'Password ${isNew ? "set" : "updated"} successfully');
+                          break;
+                        case ProfileLockType.pattern:
+                          if (!_patternConfirmed) {
+                            setState(() => _error = 'Draw and confirm a pattern first');
+                            return;
+                          }
+                          manager.setPattern(
+                              widget.profile.id, _confirmedPattern);
+                          Navigator.pop(context);
+                          snackBar(
+                              'Pattern ${isNew ? "set" : "updated"} successfully');
+                          break;
+                      }
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: colorScheme.primary,
+                      foregroundColor: colorScheme.onPrimary,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                    ),
+                    child: Text(
+                      isNew ? 'Save' : 'Update',
+                      style: const TextStyle(
+                          fontFamily: 'Poppins', fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _chipIcon(ProfileLockType type) {
+    switch (type) {
+      case ProfileLockType.none:
+        return Icons.lock_open_rounded;
+      case ProfileLockType.pin:
+        return Icons.dialpad_rounded;
+      case ProfileLockType.password:
+        return Icons.password_rounded;
+      case ProfileLockType.pattern:
+        return Icons.grid_3x3_rounded;
+    }
   }
 }

--- a/lib/screens/profile/profile_selection_page.dart
+++ b/lib/screens/profile/profile_selection_page.dart
@@ -1,0 +1,530 @@
+import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+class ProfileSelectionPage extends StatefulWidget {
+  const ProfileSelectionPage({super.key});
+
+  @override
+  State<ProfileSelectionPage> createState() => _ProfileSelectionPageState();
+}
+
+class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
+  RxBool autoStart = false.obs;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final theme = context.colors;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            children: [
+              const SizedBox(height: 40),
+              Image.asset(
+                'assets/images/logo.png',
+                width: 80,
+                height: 80,
+                errorBuilder: (_, __, ___) => Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.primaryContainer,
+                  ),
+                  child: Icon(
+                    Icons.play_arrow_rounded,
+                    size: 40,
+                    color: colorScheme.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'AnymeX',
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.bold,
+                  fontSize: 28,
+                  color: theme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Select a profile to continue',
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontSize: 14,
+                  color: theme.onSurface.withOpacity(0.6),
+                ),
+              ),
+              const SizedBox(height: 32),
+              Obx(() => Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: Checkbox(
+                          value: autoStart.value,
+                          onChanged: (val) =>
+                              autoStart.value = val ?? false,
+                          activeColor: colorScheme.primary,
+                          shape: const RoundedRectangleBorder(
+                            borderRadius:
+                                BorderRadius.all(Radius.circular(4)),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      GestureDetector(
+                        onTap: () => autoStart.value = !autoStart.value,
+                        child: Text(
+                          'Open selected profile automatically',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: theme.onSurface.withOpacity(0.7),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )),
+              const SizedBox(height: 24),
+              Expanded(
+                child: Obx(() {
+                  final profiles = Get.find<ProfileManager>().profiles;
+                  if (profiles.isEmpty) {
+                    return Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            'No profiles yet',
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: theme.onSurface.withOpacity(0.5),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  return ListView.separated(
+                    itemCount: profiles.length + 1,
+                    separatorBuilder: (_, __) =>
+                        const SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      if (index == profiles.length) {
+                        return _buildAddProfileCard(
+                            colorScheme, theme, profiles.length);
+                      }
+                      return _buildProfileCard(
+                          context, profiles[index], colorScheme, theme);
+                    },
+                  );
+                }),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProfileCard(BuildContext context, AppProfile profile,
+      ColorScheme colorScheme, dynamic theme) {
+    return GestureDetector(
+      onTap: () => _selectProfile(profile),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainer,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: colorScheme.onSurface.withOpacity(0.1),
+          ),
+        ),
+        child: Row(
+          children: [
+            ProfileAvatar(
+              profile: profile,
+              radius: 28,
+              showLocked: profile.isLocked,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        profile.name,
+                        style: TextStyle(
+                          fontFamily: 'Poppins',
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                          color: theme.onSurface,
+                        ),
+                      ),
+                      if (profile.hasPin) ...[
+                        const SizedBox(width: 8),
+                        Icon(Icons.lock_outline,
+                            size: 14,
+                            color: theme.onSurface.withOpacity(0.5)),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Last used ${_formatDate(profile.lastUsedAt)}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: theme.onSurface.withOpacity(0.5),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      if (profile.anilistLinked)
+                        _buildBadge('AL', Colors.blue, colorScheme),
+                      if (profile.malLinked)
+                        _buildBadge('MAL', Colors.blueAccent, colorScheme),
+                      if (profile.simklLinked)
+                        _buildBadge('Simkl', Colors.green, colorScheme),
+                      if (!profile.anilistLinked &&
+                          !profile.malLinked &&
+                          !profile.simklLinked)
+                        _buildBadge('No services linked',
+                            theme.onSurface.withOpacity(0.3), colorScheme),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              color: theme.onSurface.withOpacity(0.3),
+              size: 28,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBadge(String text, Color color, ColorScheme colorScheme) {
+    return Container(
+      margin: const EdgeInsets.only(right: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withOpacity(0.3), width: 0.5),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAddProfileCard(
+      ColorScheme colorScheme, dynamic theme, int currentCount) {
+    return GestureDetector(
+      onTap: () {
+        if (currentCount >= kMaxProfiles) {
+          snackBar('Maximum of $kMaxProfiles profiles reached');
+          return;
+        }
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const ProfileCreationPage()),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainer,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: colorScheme.primary.withOpacity(0.3),
+            width: 1.5,
+            strokeAlign: BorderSide.strokeAlignOutside,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.add_circle_outline,
+                color: colorScheme.primary, size: 24),
+            const SizedBox(width: 10),
+            Text(
+              'Create New Profile',
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.w600,
+                fontSize: 15,
+                color: colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectProfile(AppProfile profile) async {
+    if (profile.hasPin) {
+      final success = await _showPinDialog(profile);
+      if (success != true) return;
+    }
+
+    final manager = Get.find<ProfileManager>();
+    await manager.switchToProfile(profile.id, autoStart: autoStart.value);
+
+    if (mounted) {
+      Navigator.of(context).pop(true);
+    }
+  }
+
+  Future<bool?> _showPinDialog(AppProfile profile) async {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => _PinEntryDialog(profile: profile),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+    if (diff.inDays < 1) return '${diff.inHours}h ago';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return DateFormat('MMM d').format(date);
+  }
+}
+
+class _PinEntryDialog extends StatefulWidget {
+  final AppProfile profile;
+  const _PinEntryDialog({required this.profile});
+
+  @override
+  State<_PinEntryDialog> createState() => _PinEntryDialogState();
+}
+
+class _PinEntryDialogState extends State<_PinEntryDialog> {
+  final TextEditingController _pinController = TextEditingController();
+  bool _isError = false;
+  String _errorMessage = '';
+
+  @override
+  void dispose() {
+    _pinController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final profile = widget.profile;
+
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text('Profile Locked',
+            style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Too many failed attempts.',
+              style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try again in $remaining minute${remaining != 1 ? 's' : ''}',
+              style: TextStyle(
+                  color: Colors.red,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: 'Poppins'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text('OK',
+                style: TextStyle(color: colorScheme.primary)),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape:
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Text(
+        'Enter PIN',
+        style: TextStyle(
+          fontFamily: 'Poppins',
+          fontWeight: FontWeight.bold,
+          color: colorScheme.onSurface,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Enter PIN for "${profile.name}"',
+            style: TextStyle(
+              color: colorScheme.onSurface.withOpacity(0.7),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _pinController,
+            keyboardType: TextInputType.number,
+            obscureText: true,
+            maxLength: 6,
+            autofocus: true,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontFamily: 'Poppins',
+              fontSize: 24,
+              letterSpacing: 8,
+            ),
+            textAlign: TextAlign.center,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _isError
+                    ? BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+              hintText: '• • • •',
+              hintStyle: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.2),
+                letterSpacing: 4,
+              ),
+              counterText: '',
+            ),
+            onChanged: (_) {
+              if (_isError) {
+                setState(() {
+                  _isError = false;
+                  _errorMessage = '';
+                });
+              }
+            },
+          ),
+          if (_isError) ...[
+            const SizedBox(height: 8),
+            Text(
+              _errorMessage,
+              style: const TextStyle(color: Colors.red, fontSize: 13),
+            ),
+          ],
+          const SizedBox(height: 4),
+          Obx(() {
+            final manager = Get.find<ProfileManager>();
+            final attempts = manager.profiles
+                    .firstWhereOrNull((p) => p.id == profile.id)
+                    ?.failedPinAttempts ??
+                0;
+            if (attempts > 0) {
+              return Text(
+                '$attempts / $kMaxPinAttempts attempts',
+                style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  fontSize: 12,
+                ),
+              );
+            }
+            return const SizedBox.shrink();
+          }),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+        ElevatedButton(
+          onPressed: () => _verifyPin(),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: colorScheme.onPrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: const Text('Unlock'),
+        ),
+      ],
+    );
+  }
+
+  void _verifyPin() {
+    final pin = _pinController.text.trim();
+    if (pin.length < 4) {
+      setState(() {
+        _isError = true;
+        _errorMessage = 'PIN must be at least 4 digits';
+      });
+      return;
+    }
+
+    final manager = Get.find<ProfileManager>();
+    final result = manager.verifyPin(widget.profile.id, pin);
+
+    if (result == true) {
+      Navigator.pop(context, true);
+    } else if (result == false) {
+      setState(() {
+        _isError = true;
+        final remaining = kMaxPinAttempts -
+            (manager.profiles
+                    .firstWhereOrNull((p) => p.id == widget.profile.id)
+                    ?.failedPinAttempts ??
+                0);
+        _errorMessage =
+            'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} remaining';
+      });
+      _pinController.clear();
+    } else {
+      Navigator.pop(context, false);
+    }
+  }
+}

--- a/lib/screens/profile/profile_selection_page.dart
+++ b/lib/screens/profile/profile_selection_page.dart
@@ -1,6 +1,7 @@
 import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
@@ -23,6 +24,19 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
     super.initState();
     final manager = Get.find<ProfileManager>();
     autoStart = (manager.hasAutoStart).obs;
+  }
+
+  IconData _getLockIcon(ProfileLockType type) {
+    switch (type) {
+      case ProfileLockType.none:
+        return Icons.lock_open_rounded;
+      case ProfileLockType.pin:
+        return Icons.dialpad_rounded;
+      case ProfileLockType.password:
+        return Icons.password_rounded;
+      case ProfileLockType.pattern:
+        return Icons.grid_3x3_rounded;
+    }
   }
 
   @override
@@ -190,9 +204,9 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
                             color: theme.onSurface,
                           ),
                         ),
-                        if (profile.hasPin) ...[
+                        if (profile.hasLock) ...[
                           const SizedBox(width: 8),
-                          Icon(Icons.lock_outline,
+                          Icon(_getLockIcon(profile.profileLockType),
                               size: 14,
                               color: theme.onSurface.withOpacity(0.5)),
                         ],
@@ -302,8 +316,8 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
   }
 
   Future<void> _selectProfile(AppProfile profile) async {
-    if (profile.hasPin) {
-      final success = await _showPinDialog(profile);
+    if (profile.hasLock) {
+      final success = await _showLockDialog(profile);
       if (success != true) return;
     }
 
@@ -311,12 +325,29 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
     await manager.switchToProfile(profile.id, autoStart: autoStart.value);
   }
 
-  Future<bool?> _showPinDialog(AppProfile profile) async {
-    return showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => _PinEntryDialog(profile: profile),
-    );
+  Future<bool?> _showLockDialog(AppProfile profile) async {
+    switch (profile.profileLockType) {
+      case ProfileLockType.pin:
+        return showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => _LockEntryDialog(profile: profile),
+        );
+      case ProfileLockType.password:
+        return showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => _PasswordEntryDialog(profile: profile),
+        );
+      case ProfileLockType.pattern:
+        return showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => _PatternEntryDialog(profile: profile),
+        );
+      case ProfileLockType.none:
+        return true;
+    }
   }
 
   String _formatDate(DateTime date) {
@@ -331,22 +362,22 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
   }
 }
 
-class _PinEntryDialog extends StatefulWidget {
+class _LockEntryDialog extends StatefulWidget {
   final AppProfile profile;
-  const _PinEntryDialog({required this.profile});
+  const _LockEntryDialog({required this.profile});
 
   @override
-  State<_PinEntryDialog> createState() => _PinEntryDialogState();
+  State<_LockEntryDialog> createState() => _LockEntryDialogState();
 }
 
-class _PinEntryDialogState extends State<_PinEntryDialog> {
-  final TextEditingController _pinController = TextEditingController();
+class _LockEntryDialogState extends State<_LockEntryDialog> {
+  final TextEditingController _controller = TextEditingController();
   bool _isError = false;
   String _errorMessage = '';
 
   @override
   void dispose() {
-    _pinController.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -398,26 +429,38 @@ class _PinEntryDialogState extends State<_PinEntryDialog> {
       backgroundColor: colorScheme.surfaceContainer,
       shape:
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      title: Text(
-        'Enter PIN',
-        style: TextStyle(
-          fontFamily: 'Poppins',
-          fontWeight: FontWeight.bold,
-          color: colorScheme.onSurface,
-        ),
+      title: Row(
+        children: [
+          ProfileAvatar(profile: profile, radius: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Enter ${profile.lockLabel}',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                Text(
+                  'Enter ${profile.lockLabel.toLowerCase()} for "${profile.name}"',
+                  style: TextStyle(
+                      fontSize: 12,
+                      color: colorScheme.onSurface.withOpacity(0.6)),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            'Enter PIN for "${profile.name}"',
-            style: TextStyle(
-              color: colorScheme.onSurface.withOpacity(0.7),
-            ),
-          ),
-          const SizedBox(height: 16),
           TextField(
-            controller: _pinController,
+            controller: _controller,
             keyboardType: TextInputType.number,
             obscureText: true,
             maxLength: 6,
@@ -435,10 +478,10 @@ class _PinEntryDialogState extends State<_PinEntryDialog> {
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: _isError
-                    ? BorderSide(color: Colors.red, width: 2)
+                    ? const BorderSide(color: Colors.red, width: 2)
                     : BorderSide.none,
               ),
-              hintText: '• • • •',
+              hintText: '\u2022 \u2022 \u2022 \u2022',
               hintStyle: TextStyle(
                 color: colorScheme.onSurface.withOpacity(0.2),
                 letterSpacing: 4,
@@ -466,11 +509,11 @@ class _PinEntryDialogState extends State<_PinEntryDialog> {
             final manager = Get.find<ProfileManager>();
             final attempts = manager.profiles
                     .firstWhereOrNull((p) => p.id == profile.id)
-                    ?.failedPinAttempts ??
+                    ?.failedAttempts ??
                 0;
             if (attempts > 0) {
               return Text(
-                '$attempts / $kMaxPinAttempts attempts',
+                '$attempts / $kMaxLockAttempts attempts',
                 style: TextStyle(
                   color: colorScheme.onSurface.withOpacity(0.4),
                   fontSize: 12,
@@ -489,7 +532,7 @@ class _PinEntryDialogState extends State<_PinEntryDialog> {
                   color: colorScheme.onSurface.withOpacity(0.7))),
         ),
         ElevatedButton(
-          onPressed: () => _verifyPin(),
+          onPressed: () => _verify(),
           style: ElevatedButton.styleFrom(
             backgroundColor: colorScheme.primary,
             foregroundColor: colorScheme.onPrimary,
@@ -503,35 +546,398 @@ class _PinEntryDialogState extends State<_PinEntryDialog> {
     );
   }
 
-  void _verifyPin() {
-    final pin = _pinController.text.trim();
-    if (pin.length < 4) {
+  void _verify() {
+    final input = _controller.text.trim();
+    if (input.length < 4) {
       setState(() {
         _isError = true;
-        _errorMessage = 'PIN must be at least 4 digits';
+        _errorMessage = '${widget.profile.lockLabel} must be at least 4 characters';
       });
       return;
     }
 
     final manager = Get.find<ProfileManager>();
-    final result = manager.verifyPin(widget.profile.id, pin);
+    final result = manager.verifyLock(widget.profile.id, input);
 
     if (result == true) {
       Navigator.pop(context, true);
     } else if (result == false) {
       setState(() {
         _isError = true;
-        final remaining = kMaxPinAttempts -
+        final remaining = kMaxLockAttempts -
             (manager.profiles
                     .firstWhereOrNull((p) => p.id == widget.profile.id)
-                    ?.failedPinAttempts ??
+                    ?.failedAttempts ??
                 0);
         _errorMessage =
-            'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} remaining';
+            'Wrong ${widget.profile.lockLabel.toLowerCase()}. $remaining attempt${remaining != 1 ? 's' : ''} remaining';
       });
-      _pinController.clear();
+      _controller.clear();
     } else {
       Navigator.pop(context, false);
     }
+  }
+}
+
+class _PasswordEntryDialog extends StatefulWidget {
+  final AppProfile profile;
+  const _PasswordEntryDialog({required this.profile});
+
+  @override
+  State<_PasswordEntryDialog> createState() => _PasswordEntryDialogState();
+}
+
+class _PasswordEntryDialogState extends State<_PasswordEntryDialog> {
+  final TextEditingController _controller = TextEditingController();
+  bool _isError = false;
+  String _errorMessage = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final profile = widget.profile;
+
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text('Profile Locked',
+            style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Too many failed attempts.',
+              style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try again in $remaining minute${remaining != 1 ? 's' : ''}',
+              style: TextStyle(
+                  color: Colors.red,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: 'Poppins'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text('OK',
+                style: TextStyle(color: colorScheme.primary)),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape:
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Row(
+        children: [
+          ProfileAvatar(profile: profile, radius: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Enter Password',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                Text(
+                  'Enter password for "${profile.name}"',
+                  style: TextStyle(
+                      fontSize: 12,
+                      color: colorScheme.onSurface.withOpacity(0.6)),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _controller,
+            obscureText: true,
+            autofocus: true,
+            style: const TextStyle(
+              fontFamily: 'Poppins',
+              fontSize: 18,
+            ),
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _isError
+                    ? const BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+              hintText: 'Enter password',
+              hintStyle: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.3),
+              ),
+            ),
+            onChanged: (_) {
+              if (_isError) {
+                setState(() {
+                  _isError = false;
+                  _errorMessage = '';
+                });
+              }
+            },
+            onSubmitted: (_) {
+              if (_controller.text.isNotEmpty) _verify();
+            },
+          ),
+          if (_isError) ...[
+            const SizedBox(height: 8),
+            Text(
+              _errorMessage,
+              style: const TextStyle(color: Colors.red, fontSize: 13),
+            ),
+          ],
+          const SizedBox(height: 4),
+          Obx(() {
+            final manager = Get.find<ProfileManager>();
+            final attempts = manager.profiles
+                    .firstWhereOrNull((p) => p.id == profile.id)
+                    ?.failedAttempts ??
+                0;
+            if (attempts > 0) {
+              return Text(
+                '$attempts / $kMaxLockAttempts attempts',
+                style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  fontSize: 12,
+                ),
+              );
+            }
+            return const SizedBox.shrink();
+          }),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+        ElevatedButton(
+          onPressed: _verify,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: colorScheme.onPrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: const Text('Unlock'),
+        ),
+      ],
+    );
+  }
+
+  void _verify() {
+    final input = _controller.text;
+    if (input.isEmpty) {
+      setState(() {
+        _isError = true;
+        _errorMessage = 'Enter a password';
+      });
+      return;
+    }
+
+    final manager = Get.find<ProfileManager>();
+    final result = manager.verifyLock(widget.profile.id, input);
+
+    if (result == true) {
+      Navigator.pop(context, true);
+    } else if (result == false) {
+      setState(() {
+        _isError = true;
+        final remaining = kMaxLockAttempts -
+            (manager.profiles
+                    .firstWhereOrNull((p) => p.id == widget.profile.id)
+                    ?.failedAttempts ??
+                0);
+        _errorMessage =
+            'Wrong password. $remaining attempt${remaining != 1 ? 's' : ''} remaining';
+      });
+      _controller.clear();
+    } else {
+      Navigator.pop(context, false);
+    }
+  }
+}
+
+class _PatternEntryDialog extends StatefulWidget {
+  final AppProfile profile;
+  const _PatternEntryDialog({required this.profile});
+
+  @override
+  State<_PatternEntryDialog> createState() => _PatternEntryDialogState();
+}
+
+class _PatternEntryDialogState extends State<_PatternEntryDialog> {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final profile = widget.profile;
+
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text('Profile Locked',
+            style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Too many failed attempts.',
+              style: TextStyle(color: colorScheme.onSurface.withOpacity(0.7)),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try again in $remaining minute${remaining != 1 ? 's' : ''}',
+              style: TextStyle(
+                  color: Colors.red,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: 'Poppins'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text('OK',
+                style: TextStyle(color: colorScheme.primary)),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape:
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Row(
+        children: [
+          ProfileAvatar(profile: profile, radius: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Draw Pattern',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                Text(
+                  'Draw pattern for "${profile.name}"',
+                  style: TextStyle(
+                      fontSize: 12,
+                      color: colorScheme.onSurface.withOpacity(0.6)),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 220,
+            height: 220,
+            child: PatternLock(
+              onPatternComplete: (pattern) {
+                final manager = Get.find<ProfileManager>();
+                final patternStr = pattern.join(',');
+                final result =
+                    manager.verifyLock(widget.profile.id, patternStr);
+                if (result == true) {
+                  Navigator.pop(context, true);
+                } else if (result == false) {
+                  final remaining = kMaxLockAttempts -
+                      (manager.profiles
+                              .firstWhereOrNull(
+                                  (p) => p.id == widget.profile.id)
+                              ?.failedAttempts ??
+                          0);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                          'Wrong pattern. $remaining attempt${remaining != 1 ? 's' : ''} remaining'),
+                      duration: const Duration(seconds: 2),
+                    ),
+                  );
+                } else {
+                  Navigator.pop(context, false);
+                }
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+          Obx(() {
+            final manager = Get.find<ProfileManager>();
+            final attempts = manager.profiles
+                    .firstWhereOrNull((p) => p.id == profile.id)
+                    ?.failedAttempts ??
+                0;
+            if (attempts > 0) {
+              return Text(
+                '$attempts / $kMaxLockAttempts attempts',
+                style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                  fontSize: 12,
+                ),
+              );
+            }
+            return const SizedBox.shrink();
+          }),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+      ],
+    );
   }
 }

--- a/lib/screens/profile/profile_selection_page.dart
+++ b/lib/screens/profile/profile_selection_page.dart
@@ -1,6 +1,7 @@
 import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/models/Service/app_profile.dart';
 import 'package:anymex/screens/profile/profile_creation_page.dart';
+import 'package:anymex/screens/profile/widgets/forgot_lock_dialog.dart';
 import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
@@ -525,6 +526,26 @@ class _LockEntryDialogState extends State<_LockEntryDialog> {
         ],
       ),
       actions: [
+        if (profile.hasSecurityQuestions)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: () async {
+                final bypassed = await showDialog<bool>(
+                  context: context,
+                  builder: (c) => ForgotLockDialog(profile: profile),
+                );
+                if (bypassed == true) {
+                  Navigator.pop(context, true);
+                }
+              },
+              child: Text('Forgot PIN?',
+                  style: TextStyle(
+                      color: colorScheme.primary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600)),
+            ),
+          ),
         TextButton(
           onPressed: () => Navigator.pop(context, false),
           child: Text('Cancel',
@@ -738,6 +759,26 @@ class _PasswordEntryDialogState extends State<_PasswordEntryDialog> {
         ],
       ),
       actions: [
+        if (profile.hasSecurityQuestions)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: () async {
+                final bypassed = await showDialog<bool>(
+                  context: context,
+                  builder: (c) => ForgotLockDialog(profile: profile),
+                );
+                if (bypassed == true) {
+                  Navigator.pop(context, true);
+                }
+              },
+              child: Text('Forgot Password?',
+                  style: TextStyle(
+                      color: colorScheme.primary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600)),
+            ),
+          ),
         TextButton(
           onPressed: () => Navigator.pop(context, false),
           child: Text('Cancel',
@@ -931,6 +972,26 @@ class _PatternEntryDialogState extends State<_PatternEntryDialog> {
         ],
       ),
       actions: [
+        if (profile.hasSecurityQuestions)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: () async {
+                final bypassed = await showDialog<bool>(
+                  context: context,
+                  builder: (c) => ForgotLockDialog(profile: profile),
+                );
+                if (bypassed == true) {
+                  Navigator.pop(context, true);
+                }
+              },
+              child: Text('Forgot Pattern?',
+                  style: TextStyle(
+                      color: colorScheme.primary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600)),
+            ),
+          ),
         TextButton(
           onPressed: () => Navigator.pop(context, false),
           child: Text('Cancel',

--- a/lib/screens/profile/profile_selection_page.dart
+++ b/lib/screens/profile/profile_selection_page.dart
@@ -16,7 +16,14 @@ class ProfileSelectionPage extends StatefulWidget {
 }
 
 class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
-  RxBool autoStart = false.obs;
+  late RxBool autoStart;
+
+  @override
+  void initState() {
+    super.initState();
+    final manager = Get.find<ProfileManager>();
+    autoStart = (manager.hasAutoStart).obs;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -148,79 +155,83 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
       ColorScheme colorScheme, dynamic theme) {
     return GestureDetector(
       onTap: () => _selectProfile(profile),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: colorScheme.surfaceContainer,
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: colorScheme.onSurface.withOpacity(0.1),
+      child: AnimatedScale(
+        duration: const Duration(milliseconds: 150),
+        scale: 1.0,
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: colorScheme.onSurface.withOpacity(0.1),
+            ),
           ),
-        ),
-        child: Row(
-          children: [
-            ProfileAvatar(
-              profile: profile,
-              radius: 28,
-              showLocked: profile.isLocked,
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Text(
-                        profile.name,
-                        style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          color: theme.onSurface,
-                        ),
-                      ),
-                      if (profile.hasPin) ...[
-                        const SizedBox(width: 8),
-                        Icon(Icons.lock_outline,
-                            size: 14,
-                            color: theme.onSurface.withOpacity(0.5)),
-                      ],
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Last used ${_formatDate(profile.lastUsedAt)}',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: theme.onSurface.withOpacity(0.5),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      if (profile.anilistLinked)
-                        _buildBadge('AL', Colors.blue, colorScheme),
-                      if (profile.malLinked)
-                        _buildBadge('MAL', Colors.blueAccent, colorScheme),
-                      if (profile.simklLinked)
-                        _buildBadge('Simkl', Colors.green, colorScheme),
-                      if (!profile.anilistLinked &&
-                          !profile.malLinked &&
-                          !profile.simklLinked)
-                        _buildBadge('No services linked',
-                            theme.onSurface.withOpacity(0.3), colorScheme),
-                    ],
-                  ),
-                ],
+          child: Row(
+            children: [
+              ProfileAvatar(
+                profile: profile,
+                radius: 28,
+                showLocked: profile.isLocked,
               ),
-            ),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: theme.onSurface.withOpacity(0.3),
-              size: 28,
-            ),
-          ],
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          profile.name,
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color: theme.onSurface,
+                          ),
+                        ),
+                        if (profile.hasPin) ...[
+                          const SizedBox(width: 8),
+                          Icon(Icons.lock_outline,
+                              size: 14,
+                              color: theme.onSurface.withOpacity(0.5)),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Last used ${_formatDate(profile.lastUsedAt)}',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: theme.onSurface.withOpacity(0.5),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        if (profile.anilistLinked)
+                          _buildBadge('AL', Colors.blue, colorScheme),
+                        if (profile.malLinked)
+                          _buildBadge('MAL', Colors.blueAccent, colorScheme),
+                        if (profile.simklLinked)
+                          _buildBadge('Simkl', Colors.green, colorScheme),
+                        if (!profile.anilistLinked &&
+                            !profile.malLinked &&
+                            !profile.simklLinked)
+                          _buildBadge('No services linked',
+                              theme.onSurface.withOpacity(0.3), colorScheme),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: theme.onSurface.withOpacity(0.3),
+                size: 28,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -298,10 +309,6 @@ class _ProfileSelectionPageState extends State<ProfileSelectionPage> {
 
     final manager = Get.find<ProfileManager>();
     await manager.switchToProfile(profile.id, autoStart: autoStart.value);
-
-    if (mounted) {
-      Navigator.of(context).pop(true);
-    }
   }
 
   Future<bool?> _showPinDialog(AppProfile profile) async {

--- a/lib/screens/profile/widgets/forgot_lock_dialog.dart
+++ b/lib/screens/profile/widgets/forgot_lock_dialog.dart
@@ -1,0 +1,277 @@
+import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class ForgotLockDialog extends StatefulWidget {
+  final AppProfile profile;
+  const ForgotLockDialog({super.key, required this.profile});
+
+  @override
+  State<ForgotLockDialog> createState() => _ForgotLockDialogState();
+}
+
+class _ForgotLockDialogState extends State<ForgotLockDialog> {
+  final _answerController = TextEditingController();
+  bool _isError = false;
+  String _errorMessage = '';
+  bool _isLoading = false;
+  int _selectedQuestionIndex = 0;
+
+  List<String> get _questions => widget.profile.securityQuestionTexts;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_questions.isEmpty) return;
+    _selectedQuestionIndex = 0;
+  }
+
+  @override
+  void dispose() {
+    _answerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (_questions.isEmpty) {
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: const Text('No Recovery Questions'),
+        content: const Text('This profile has no recovery questions set.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    }
+
+    final currentQuestion = _questions[_selectedQuestionIndex];
+    final hasMultiple = _questions.length > 1;
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.help_outline_rounded,
+                  color: Colors.orange, size: 20),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Recovery',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            hasMultiple
+                ? 'Pick a question and answer it to remove the lock from "${widget.profile.name}"'
+                : 'Answer correctly to remove the lock from "${widget.profile.name}"',
+            style: TextStyle(
+              fontSize: 12,
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (hasMultiple) ...[
+            DropdownButtonFormField<int>(
+              value: _selectedQuestionIndex,
+              isExpanded: true,
+              isDense: true,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: colorScheme.surface,
+                prefixIcon: Icon(Icons.quiz_rounded,
+                    size: 18, color: colorScheme.primary),
+                contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12, vertical: 8),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+              items: _questions.asMap().entries.map((entry) {
+                return DropdownMenuItem(
+                  value: entry.key,
+                  child: Text(
+                    'Q${entry.key + 1}: ${entry.value}',
+                    style: const TextStyle(fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                );
+              }).toList(),
+              onChanged: (val) {
+                if (val != null) {
+                  setState(() {
+                    _selectedQuestionIndex = val;
+                    _isError = false;
+                    _errorMessage = '';
+                    _answerController.clear();
+                  });
+                }
+              },
+            ),
+          ] else ...[
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withOpacity(0.06),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: colorScheme.primary.withOpacity(0.15),
+                ),
+              ),
+              child: Text(
+                currentQuestion,
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+          if (hasMultiple) ...[
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.primary.withOpacity(0.06),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: colorScheme.primary.withOpacity(0.15),
+                ),
+              ),
+              child: Text(
+                currentQuestion,
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          TextField(
+            controller: _answerController,
+            autofocus: true,
+            style: const TextStyle(fontFamily: 'Poppins', fontSize: 15),
+            decoration: InputDecoration(
+              hintText: 'Your answer',
+              hintStyle: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.4),
+              ),
+              filled: true,
+              fillColor: colorScheme.surface,
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _isError
+                    ? const BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+            ),
+            onChanged: (_) => setState(() {
+              _isError = false;
+              _errorMessage = '';
+            }),
+          ),
+          if (_isError) ...[
+            const SizedBox(height: 8),
+            Text(_errorMessage,
+                style: const TextStyle(color: Colors.red, fontSize: 13)),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            'The lock will be removed. You can set a new one later.',
+            style: TextStyle(
+              fontSize: 11,
+              color: colorScheme.onSurface.withOpacity(0.4),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed:
+              _isLoading ? null : () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+        ElevatedButton(
+          onPressed: _isLoading
+              ? null
+              : () {
+                  final answer = _answerController.text.trim();
+                  if (answer.isEmpty) {
+                    setState(() {
+                      _isError = true;
+                      _errorMessage = 'Please enter your answer';
+                    });
+                    return;
+                  }
+                  setState(() => _isLoading = true);
+                  final manager = Get.find<ProfileManager>();
+                  if (manager.verifySecurityAnswer(
+                      widget.profile.id, answer)) {
+                    manager.bypassLock(widget.profile.id);
+                    Navigator.pop(context, true);
+                  } else {
+                    setState(() {
+                      _isError = true;
+                      _errorMessage = 'Wrong answer. Try again.';
+                      _isLoading = false;
+                    });
+                    _answerController.clear();
+                  }
+                },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.orange,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12)),
+          ),
+          child: _isLoading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text('Verify & Remove Lock',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/profile/widgets/pattern_lock.dart
+++ b/lib/screens/profile/widgets/pattern_lock.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+
+class PatternLock extends StatefulWidget {
+  final List<int> initialPattern;
+  final ValueChanged<List<int>> onPatternComplete;
+  final Color? activeColor;
+  final Color? dotColor;
+  final Color? lineColor;
+  final int minDots;
+  final bool readOnly;
+
+  const PatternLock({
+    super.key,
+    this.initialPattern = const [],
+    required this.onPatternComplete,
+    this.activeColor,
+    this.dotColor,
+    this.lineColor,
+    this.minDots = 4,
+    this.readOnly = false,
+  });
+
+  @override
+  State<PatternLock> createState() => PatternLockState();
+}
+
+class PatternLockState extends State<PatternLock> {
+  final List<int> _selectedDots = [];
+  Offset? _currentPosition;
+  bool _isDrawing = false;
+
+  final double _dotSize = 20;
+  final double _hitRadius = 30;
+  static const int _gridSize = 3;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDots.addAll(widget.initialPattern);
+    if (widget.initialPattern.isNotEmpty) {
+      _isDrawing = false;
+    }
+  }
+
+  void reset() {
+    setState(() {
+      _selectedDots.clear();
+      _currentPosition = null;
+      _isDrawing = false;
+    });
+  }
+
+  List<int> get currentPattern => List.unmodifiable(_selectedDots);
+
+  List<Offset> _getDotPositions(double width, double height) {
+    final positions = <Offset>[];
+    final padding = width * 0.2;
+    final availableWidth = width - (padding * 2);
+    final availableHeight = height - (padding * 2);
+    final spacingX = availableWidth / (_gridSize - 1);
+    final spacingY = availableHeight / (_gridSize - 1);
+
+    for (int row = 0; row < _gridSize; row++) {
+      for (int col = 0; col < _gridSize; col++) {
+        positions.add(Offset(
+          padding + (col * spacingX),
+          padding + (row * spacingY),
+        ));
+      }
+    }
+    return positions;
+  }
+
+  int? _getDotAtPosition(Offset position, List<Offset> dotPositions) {
+    for (int i = 0; i < dotPositions.length; i++) {
+      if ((position - dotPositions[i]).distance <= _hitRadius) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  void _handlePanStart(DragStartDetails details, List<Offset> dotPositions) {
+    if (widget.readOnly) return;
+    final dotIndex = _getDotAtPosition(details.localPosition, dotPositions);
+    if (dotIndex != null) {
+      setState(() {
+        _selectedDots.clear();
+        _selectedDots.add(dotIndex);
+        _currentPosition = details.localPosition;
+        _isDrawing = true;
+      });
+    }
+  }
+
+  void _handlePanUpdate(DragUpdateDetails details, List<Offset> dotPositions) {
+    if (!_isDrawing || widget.readOnly) return;
+
+    final dotIndex = _getDotAtPosition(details.localPosition, dotPositions);
+    if (dotIndex != null && !_selectedDots.contains(dotIndex)) {
+      setState(() {
+        _selectedDots.add(dotIndex);
+        _currentPosition = dotPositions[dotIndex];
+      });
+    } else {
+      setState(() {
+        _currentPosition = details.localPosition;
+      });
+    }
+  }
+
+  void _handlePanEnd(DragEndDetails details) {
+    if (!_isDrawing || widget.readOnly) return;
+
+    if (_selectedDots.length >= widget.minDots) {
+      widget.onPatternComplete(List.from(_selectedDots));
+    }
+
+    if (!widget.readOnly) {
+      Future.delayed(const Duration(milliseconds: 400), () {
+        if (mounted) {
+          setState(() {
+            _selectedDots.clear();
+            _currentPosition = null;
+            _isDrawing = false;
+          });
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final primaryColor = widget.activeColor ?? colorScheme.primary;
+    final dotColor = widget.dotColor ?? colorScheme.onSurface.withOpacity(0.2);
+    final lineColor = widget.lineColor ?? primaryColor;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.maxWidth;
+        final height = size;
+        final dotPositions = _getDotPositions(size, height);
+
+        return GestureDetector(
+          onPanStart: (details) => _handlePanStart(details, dotPositions),
+          onPanUpdate: (details) => _handlePanUpdate(details, dotPositions),
+          onPanEnd: _handlePanEnd,
+          child: SizedBox(
+            width: size,
+            height: height,
+            child: CustomPaint(
+              painter: _PatternPainter(
+                dotPositions: dotPositions,
+                selectedDots: _selectedDots,
+                currentPosition: _currentPosition,
+                isDrawing: _isDrawing,
+                dotSize: _dotSize,
+                dotColor: dotColor,
+                activeColor: primaryColor,
+                lineColor: lineColor,
+                hasError: _selectedDots.isNotEmpty &&
+                    _selectedDots.length < widget.minDots &&
+                    !_isDrawing,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PatternPainter extends CustomPainter {
+  final List<Offset> dotPositions;
+  final List<int> selectedDots;
+  final Offset? currentPosition;
+  final bool isDrawing;
+  final double dotSize;
+  final Color dotColor;
+  final Color activeColor;
+  final Color lineColor;
+  final bool hasError;
+
+  _PatternPainter({
+    required this.dotPositions,
+    required this.selectedDots,
+    this.currentPosition,
+    required this.isDrawing,
+    required this.dotSize,
+    required this.dotColor,
+    required this.activeColor,
+    required this.lineColor,
+    required this.hasError,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final errorColor = Colors.red.shade400;
+    final effectiveActiveColor = hasError ? errorColor : activeColor;
+    final effectiveLineColor = hasError ? errorColor : lineColor;
+
+    final linePaint = Paint()
+      ..color = effectiveLineColor
+      ..strokeWidth = 3
+      ..strokeCap = StrokeCap.round;
+
+    final lineShadowPaint = Paint()
+      ..color = effectiveLineColor.withOpacity(0.15)
+      ..strokeWidth = 12
+      ..strokeCap = StrokeCap.round;
+
+    if (selectedDots.length >= 2) {
+      for (int i = 0; i < selectedDots.length - 1; i++) {
+        final start = dotPositions[selectedDots[i]];
+        final end = dotPositions[selectedDots[i + 1]];
+        canvas.drawLine(start, end, lineShadowPaint);
+        canvas.drawLine(start, end, linePaint);
+      }
+    }
+
+    if (isDrawing && currentPosition != null && selectedDots.isNotEmpty) {
+      final lastDot = dotPositions[selectedDots.last];
+      canvas.drawLine(lastDot, currentPosition!, lineShadowPaint);
+      canvas.drawLine(lastDot, currentPosition!, linePaint);
+    }
+
+    for (int i = 0; i < dotPositions.length; i++) {
+      final pos = dotPositions[i];
+      final isSelected = selectedDots.contains(i);
+
+      if (isSelected) {
+        final glowPaint = Paint()
+          ..color = effectiveActiveColor.withOpacity(0.2);
+        canvas.drawCircle(pos, dotSize * 1.3, glowPaint);
+
+        final bgPaint = Paint()..color = effectiveActiveColor;
+        canvas.drawCircle(pos, dotSize * 0.85, bgPaint);
+
+        final centerPaint = Paint()
+          ..color = effectiveActiveColor.withOpacity(0.4);
+        canvas.drawCircle(pos, dotSize * 0.45, centerPaint);
+      } else {
+        final borderPaint = Paint()
+          ..color = dotColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2;
+        canvas.drawCircle(pos, dotSize * 0.55, borderPaint);
+
+        final centerPaint = Paint()..color = dotColor;
+        canvas.drawCircle(pos, dotSize * 0.18, centerPaint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _PatternPainter oldDelegate) {
+    return oldDelegate.selectedDots != selectedDots ||
+        oldDelegate.currentPosition != currentPosition ||
+        oldDelegate.isDrawing != isDrawing ||
+        oldDelegate.hasError != hasError;
+  }
+}

--- a/lib/screens/profile/widgets/profile_avatar.dart
+++ b/lib/screens/profile/widgets/profile_avatar.dart
@@ -20,6 +20,10 @@ class ProfileAvatar extends StatelessWidget {
     this.showLocked = false,
   });
 
+  bool _isGif(String path) {
+    return path.toLowerCase().endsWith('.gif');
+  }
+
   @override
   Widget build(BuildContext context) {
     if (showLocked) {
@@ -38,6 +42,37 @@ class ProfileAvatar extends StatelessWidget {
     if (profile.avatarPath.isNotEmpty) {
       final file = File(profile.avatarPath);
       if (file.existsSync()) {
+        if (_isGif(profile.avatarPath)) {
+          return ClipOval(
+            child: SizedBox(
+              width: radius * 2,
+              height: radius * 2,
+              child: Image.file(
+                file,
+                fit: BoxFit.cover,
+                width: radius * 2,
+                height: radius * 2,
+                filterQuality: FilterQuality.medium,
+                errorBuilder: (context, error, stackTrace) {
+                  return CircleAvatar(
+                    radius: radius,
+                    backgroundColor: fallbackColor ??
+                        Theme.of(context).colorScheme.primaryContainer,
+                    child: Text(
+                      profile.initials,
+                      style: TextStyle(
+                        fontSize: radius * 0.7,
+                        fontWeight: FontWeight.bold,
+                        color:
+                            Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+        }
         return CircleAvatar(
           radius: radius,
           backgroundColor:
@@ -65,9 +100,8 @@ class ProfileAvatar extends StatelessWidget {
 
 Future<String?> pickAndSaveProfileImage() async {
   final result = await FilePicker.platform.pickFiles(
-    type: FileType.image,
-    allowCompression: true,
-    compressionQuality: 85,
+    type: FileType.custom,
+    allowedExtensions: ['jpg', 'jpeg', 'png', 'webp', 'gif', 'bmp'],
   );
 
   if (result == null || result.files.isEmpty) return null;

--- a/lib/screens/profile/widgets/profile_avatar.dart
+++ b/lib/screens/profile/widgets/profile_avatar.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class ProfileAvatar extends StatelessWidget {
+  final AppProfile profile;
+  final double radius;
+  final Color? fallbackColor;
+  final bool showLocked;
+
+  const ProfileAvatar({
+    super.key,
+    required this.profile,
+    this.radius = 28,
+    this.fallbackColor,
+    this.showLocked = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (showLocked) {
+      return CircleAvatar(
+        radius: radius,
+        backgroundColor:
+            fallbackColor ?? Theme.of(context).colorScheme.primaryContainer,
+        child: Icon(
+          Icons.lock_rounded,
+          size: radius * 0.6,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      );
+    }
+
+    if (profile.avatarPath.isNotEmpty) {
+      final file = File(profile.avatarPath);
+      if (file.existsSync()) {
+        return CircleAvatar(
+          radius: radius,
+          backgroundColor:
+              fallbackColor ?? Theme.of(context).colorScheme.primaryContainer,
+          backgroundImage: FileImage(file),
+        );
+      }
+    }
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor:
+          fallbackColor ?? Theme.of(context).colorScheme.primaryContainer,
+      child: Text(
+        profile.initials,
+        style: TextStyle(
+          fontSize: radius * 0.7,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.onPrimaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+Future<String?> pickAndSaveProfileImage() async {
+  final result = await FilePicker.platform.pickFiles(
+    type: FileType.image,
+    allowCompression: true,
+    compressionQuality: 85,
+  );
+
+  if (result == null || result.files.isEmpty) return null;
+
+  final pickedFile = result.files.first;
+  if (pickedFile.path == null) return null;
+
+  final srcFile = File(pickedFile.path!);
+  if (!srcFile.existsSync()) return null;
+
+  try {
+    final appDir = await getApplicationDocumentsDirectory();
+    final profilesDir = Directory(p.join(appDir.path, 'profile_avatars'));
+    if (!profilesDir.existsSync()) {
+      profilesDir.createSync(recursive: true);
+    }
+
+    final ext = p.extension(pickedFile.name).toLowerCase();
+    final destPath = p.join(
+      profilesDir.path,
+      '${DateTime.now().millisecondsSinceEpoch}$ext',
+    );
+
+    final destFile = await srcFile.copy(destPath);
+    return destFile.path;
+  } catch (e) {
+    debugPrint('Error saving profile image: $e');
+    return null;
+  }
+}

--- a/lib/screens/profile/widgets/profile_switcher_overlay.dart
+++ b/lib/screens/profile/widgets/profile_switcher_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/widgets/pattern_lock.dart';
 import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/non_widgets/snackbar.dart';
@@ -7,8 +8,25 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 
+IconData _getLockIcon(ProfileLockType type) {
+  switch (type) {
+    case ProfileLockType.none:
+      return Icons.lock_open_rounded;
+    case ProfileLockType.pin:
+      return Icons.dialpad_rounded;
+    case ProfileLockType.password:
+      return Icons.password_rounded;
+    case ProfileLockType.pattern:
+      return Icons.grid_3x3_rounded;
+  }
+}
+
 Future<void> showProfileSwitcher(BuildContext context) async {
   final manager = Get.find<ProfileManager>();
+  if (!manager.isMultiProfileEnabled.value) {
+    snackBar('Enable profiles in Settings first');
+    return;
+  }
   if (manager.profiles.length <= 1) {
     snackBar('Create another profile to switch');
     return;
@@ -55,7 +73,7 @@ Future<void> showProfileSwitcher(BuildContext context) async {
               const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
             children: [
-              if (profile.hasPin && !isCurrent)
+              if (profile.hasLock && !isCurrent)
                 Container(
                   width: 36,
                   height: 36,
@@ -68,7 +86,7 @@ Future<void> showProfileSwitcher(BuildContext context) async {
                     ),
                   ),
                   child: Center(
-                    child: Icon(Icons.lock_outline,
+                    child: Icon(_getLockIcon(profile.profileLockType),
                         size: 14, color: colorScheme.onSurface.withOpacity(0.5)),
                   ),
                 )
@@ -151,11 +169,11 @@ Future<void> showProfileSwitcher(BuildContext context) async {
         .firstWhereOrNull((p) => p.id == selectedId);
     if (profile == null) return;
 
-    if (profile.hasPin) {
+    if (profile.hasLock) {
       final success = await showDialog<bool>(
         context: context,
         barrierDismissible: false,
-        builder: (context) => _SwitcherPinDialog(profile: profile),
+        builder: (context) => _SwitcherLockDialog(profile: profile),
       );
       if (success != true) return;
     }
@@ -190,22 +208,22 @@ String _formatDate(DateTime date) {
   return DateFormat('MMM d').format(date);
 }
 
-class _SwitcherPinDialog extends StatefulWidget {
+class _SwitcherLockDialog extends StatefulWidget {
   final AppProfile profile;
-  const _SwitcherPinDialog({required this.profile});
+  const _SwitcherLockDialog({required this.profile});
 
   @override
-  State<_SwitcherPinDialog> createState() => _SwitcherPinDialogState();
+  State<_SwitcherLockDialog> createState() => _SwitcherLockDialogState();
 }
 
-class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
-  final _pinController = TextEditingController();
+class _SwitcherLockDialogState extends State<_SwitcherLockDialog> {
+  final _controller = TextEditingController();
   bool _isError = false;
   String _errorMessage = '';
 
   @override
   void dispose() {
-    _pinController.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -239,12 +257,16 @@ class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
       );
     }
 
+    if (profile.profileLockType == ProfileLockType.pattern) {
+      return _buildPatternDialog(colorScheme, profile);
+    }
+
     return AlertDialog(
       backgroundColor: colorScheme.surfaceContainer,
       shape:
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       title: Text(
-        'Enter PIN for "${profile.name}"',
+        'Enter ${profile.lockLabel} for "${profile.name}"',
         style: TextStyle(
             fontFamily: 'Poppins',
             fontWeight: FontWeight.bold,
@@ -254,17 +276,19 @@ class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
         mainAxisSize: MainAxisSize.min,
         children: [
           TextField(
-            controller: _pinController,
-            keyboardType: TextInputType.number,
+            controller: _controller,
+            keyboardType: profile.isPinLocked
+                ? TextInputType.number
+                : TextInputType.text,
             obscureText: true,
-            maxLength: 6,
+            maxLength: profile.isPinLocked ? 6 : 32,
             autofocus: true,
             style: TextStyle(
                 color: colorScheme.onSurface,
                 fontFamily: 'Poppins',
-                fontSize: 22,
-                letterSpacing: 8),
-            textAlign: TextAlign.center,
+                fontSize: profile.isPinLocked ? 22 : 16,
+                letterSpacing: profile.isPinLocked ? 8 : 0),
+            textAlign: profile.isPinLocked ? TextAlign.center : TextAlign.start,
             decoration: InputDecoration(
               filled: true,
               fillColor: colorScheme.surface,
@@ -279,6 +303,11 @@ class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
             onChanged: (_) {
               if (_isError) setState(() => _isError = false);
             },
+            onSubmitted: profile.isPasswordLocked
+                ? (_) {
+                    if (_controller.text.isNotEmpty) _verify();
+                  }
+                : null,
           ),
           if (_isError) ...[
             const SizedBox(height: 8),
@@ -295,7 +324,7 @@ class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
                   color: colorScheme.onSurface.withOpacity(0.7))),
         ),
         ElevatedButton(
-          onPressed: _verifyPin,
+          onPressed: _verify,
           style: ElevatedButton.styleFrom(
             backgroundColor: colorScheme.primary,
             foregroundColor: colorScheme.onPrimary,
@@ -308,33 +337,107 @@ class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
     );
   }
 
-  void _verifyPin() {
-    final pin = _pinController.text.trim();
-    if (pin.length < 4) {
-      setState(() {
-        _isError = true;
-        _errorMessage = 'PIN must be at least 4 digits';
-      });
-      return;
+  Widget _buildPatternDialog(ColorScheme colorScheme, AppProfile profile) {
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape:
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Text(
+        'Draw Pattern for "${profile.name}"',
+        style: TextStyle(
+            fontFamily: 'Poppins',
+            fontWeight: FontWeight.bold,
+            color: colorScheme.onSurface),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 220,
+            height: 220,
+            child: PatternLock(
+              onPatternComplete: (pattern) {
+                final manager = Get.find<ProfileManager>();
+                final patternStr = pattern.join(',');
+                final result =
+                    manager.verifyLock(profile.id, patternStr);
+                if (result == true) {
+                  Navigator.pop(context, true);
+                } else if (result == false) {
+                  final remaining = kMaxLockAttempts -
+                      (manager.profiles
+                              .firstWhereOrNull(
+                                  (p) => p.id == profile.id)
+                              ?.failedAttempts ??
+                          0);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                          'Wrong pattern. $remaining attempt${remaining != 1 ? 's' : ''} remaining'),
+                      duration: const Duration(seconds: 2),
+                    ),
+                  );
+                } else {
+                  Navigator.pop(context, false);
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+      ],
+    );
+  }
+
+  void _verify() {
+    final profile = widget.profile;
+    String input;
+
+    if (profile.isPinLocked) {
+      input = _controller.text.trim();
+      if (input.length < 4) {
+        setState(() {
+          _isError = true;
+          _errorMessage = 'PIN must be at least 4 digits';
+        });
+        return;
+      }
+    } else {
+      input = _controller.text;
+      if (input.isEmpty) {
+        setState(() {
+          _isError = true;
+          _errorMessage = 'Enter a password';
+        });
+        return;
+      }
     }
 
-    final result = Get.find<ProfileManager>().verifyPin(widget.profile.id, pin);
+    final result =
+        Get.find<ProfileManager>().verifyLock(widget.profile.id, input);
 
     if (result == true) {
       Navigator.pop(context, true);
     } else if (result == false) {
       setState(() {
         _isError = true;
-        final remaining = kMaxPinAttempts -
+        final remaining = kMaxLockAttempts -
             (Get.find<ProfileManager>()
                     .profiles
                     .firstWhereOrNull((p) => p.id == widget.profile.id)
-                    ?.failedPinAttempts ??
+                    ?.failedAttempts ??
                 0);
         _errorMessage =
-            'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} left';
+            'Wrong ${profile.lockLabel.toLowerCase()}. $remaining attempt${remaining != 1 ? 's' : ''} left';
       });
-      _pinController.clear();
+      _controller.clear();
     } else {
       Navigator.pop(context, false);
     }

--- a/lib/screens/profile/widgets/profile_switcher_overlay.dart
+++ b/lib/screens/profile/widgets/profile_switcher_overlay.dart
@@ -1,0 +1,342 @@
+import 'package:anymex/controllers/profile/profile_manager.dart';
+import 'package:anymex/models/Service/app_profile.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+Future<void> showProfileSwitcher(BuildContext context) async {
+  final manager = Get.find<ProfileManager>();
+  if (manager.profiles.length <= 1) {
+    snackBar('Create another profile to switch');
+    return;
+  }
+
+  final colorScheme = Theme.of(context).colorScheme;
+  final theme = context.colors;
+  final renderBox = context.findRenderObject() as RenderBox;
+  final offset = renderBox.localToGlobal(Offset.zero);
+  final size = renderBox.size;
+
+  await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      offset.dx,
+      offset.dy + size.height + 8,
+      offset.dx + size.width,
+      offset.dy,
+    ),
+    color: colorScheme.surfaceContainer,
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    elevation: 12,
+    items: [
+      PopupMenuItem(
+        enabled: false,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Text(
+          'Switch Profile',
+          style: TextStyle(
+            fontFamily: 'Poppins',
+            fontWeight: FontWeight.bold,
+            fontSize: 14,
+            color: theme.onSurface.withOpacity(0.6),
+          ),
+        ),
+      ),
+      const PopupMenuDivider(height: 4),
+      ...manager.profiles.map((profile) {
+        final isCurrent = profile.id == manager.currentProfileId.value;
+        return PopupMenuItem<String>(
+          value: profile.id,
+          enabled: !isCurrent,
+          padding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              if (profile.hasPin && !isCurrent)
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.surface,
+                    border: Border.all(
+                      color: colorScheme.onSurface.withOpacity(0.1),
+                      width: 1,
+                    ),
+                  ),
+                  child: Center(
+                    child: Icon(Icons.lock_outline,
+                        size: 14, color: colorScheme.onSurface.withOpacity(0.5)),
+                  ),
+                )
+              else
+                ProfileAvatar(
+                  profile: profile,
+                  radius: 18,
+                ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          profile.name,
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontWeight: FontWeight.w600,
+                            fontSize: 14,
+                            color: isCurrent
+                                ? colorScheme.primary
+                                : theme.onSurface,
+                          ),
+                        ),
+                        if (isCurrent) ...[
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color:
+                                  colorScheme.primary.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              'Active',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _formatDate(profile.lastUsedAt),
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: theme.onSurface.withOpacity(0.4),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (profile.anilistLinked)
+                    _miniBadge('AL', Colors.blue, colorScheme),
+                  if (profile.malLinked)
+                    _miniBadge('MAL', Colors.blueAccent, colorScheme),
+                  if (profile.simklLinked)
+                    _miniBadge('Sk', Colors.green, colorScheme),
+                ],
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    ],
+  ).then((selectedId) async {
+    if (selectedId == null) return;
+
+    final profile = manager.profiles
+        .firstWhereOrNull((p) => p.id == selectedId);
+    if (profile == null) return;
+
+    if (profile.hasPin) {
+      final success = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => _SwitcherPinDialog(profile: profile),
+      );
+      if (success != true) return;
+    }
+
+    await manager.switchToProfile(profile.id);
+    snackBar('Switched to ${profile.name}');
+  });
+}
+
+Widget _miniBadge(String text, Color color, ColorScheme colorScheme) {
+  return Container(
+    margin: const EdgeInsets.only(left: 3),
+    padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+    decoration: BoxDecoration(
+      color: color.withOpacity(0.15),
+      borderRadius: BorderRadius.circular(4),
+    ),
+    child: Text(
+      text,
+      style: TextStyle(fontSize: 9, fontWeight: FontWeight.bold, color: color),
+    ),
+  );
+}
+
+String _formatDate(DateTime date) {
+  final now = DateTime.now();
+  final diff = now.difference(date);
+  if (diff.inMinutes < 1) return 'Just now';
+  if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+  if (diff.inDays < 1) return '${diff.inHours}h ago';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  return DateFormat('MMM d').format(date);
+}
+
+class _SwitcherPinDialog extends StatefulWidget {
+  final AppProfile profile;
+  const _SwitcherPinDialog({required this.profile});
+
+  @override
+  State<_SwitcherPinDialog> createState() => _SwitcherPinDialogState();
+}
+
+class _SwitcherPinDialogState extends State<_SwitcherPinDialog> {
+  final _pinController = TextEditingController();
+  bool _isError = false;
+  String _errorMessage = '';
+
+  @override
+  void dispose() {
+    _pinController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final profile = widget.profile;
+
+    if (profile.isLocked) {
+      final remaining =
+          profile.lockedUntil!.difference(DateTime.now()).inMinutes + 1;
+      return AlertDialog(
+        backgroundColor: colorScheme.surfaceContainer,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Text('Profile Locked',
+            style: TextStyle(
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface)),
+        content: Text(
+          'Try again in $remaining minute${remaining != 1 ? 's' : ''}',
+          style: const TextStyle(color: Colors.red, fontWeight: FontWeight.w600),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text('OK', style: TextStyle(color: colorScheme.primary)),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      backgroundColor: colorScheme.surfaceContainer,
+      shape:
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Text(
+        'Enter PIN for "${profile.name}"',
+        style: TextStyle(
+            fontFamily: 'Poppins',
+            fontWeight: FontWeight.bold,
+            color: colorScheme.onSurface),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _pinController,
+            keyboardType: TextInputType.number,
+            obscureText: true,
+            maxLength: 6,
+            autofocus: true,
+            style: TextStyle(
+                color: colorScheme.onSurface,
+                fontFamily: 'Poppins',
+                fontSize: 22,
+                letterSpacing: 8),
+            textAlign: TextAlign.center,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: _isError
+                    ? const BorderSide(color: Colors.red, width: 2)
+                    : BorderSide.none,
+              ),
+              counterText: '',
+            ),
+            onChanged: (_) {
+              if (_isError) setState(() => _isError = false);
+            },
+          ),
+          if (_isError) ...[
+            const SizedBox(height: 8),
+            Text(_errorMessage,
+                style: const TextStyle(color: Colors.red, fontSize: 13)),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text('Cancel',
+              style: TextStyle(
+                  color: colorScheme.onSurface.withOpacity(0.7))),
+        ),
+        ElevatedButton(
+          onPressed: _verifyPin,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: colorScheme.onPrimary,
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12)),
+          ),
+          child: const Text('Unlock'),
+        ),
+      ],
+    );
+  }
+
+  void _verifyPin() {
+    final pin = _pinController.text.trim();
+    if (pin.length < 4) {
+      setState(() {
+        _isError = true;
+        _errorMessage = 'PIN must be at least 4 digits';
+      });
+      return;
+    }
+
+    final result = Get.find<ProfileManager>().verifyPin(widget.profile.id, pin);
+
+    if (result == true) {
+      Navigator.pop(context, true);
+    } else if (result == false) {
+      setState(() {
+        _isError = true;
+        final remaining = kMaxPinAttempts -
+            (Get.find<ProfileManager>()
+                    .profiles
+                    .firstWhereOrNull((p) => p.id == widget.profile.id)
+                    ?.failedPinAttempts ??
+                0);
+        _errorMessage =
+            'Wrong PIN. $remaining attempt${remaining != 1 ? 's' : ''} left';
+      });
+      _pinController.clear();
+    } else {
+      Navigator.pop(context, false);
+    }
+  }
+}

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -1,5 +1,6 @@
 import 'package:anymex/screens/downloads/download_screen.dart';
 import 'package:anymex/screens/other_features.dart';
+import 'package:anymex/screens/profile/profile_management_page.dart';
 import 'package:anymex/screens/settings/search/settings_registry.dart';
 import 'package:anymex/screens/settings/search/settings_search_icons.dart';
 import 'package:anymex/screens/settings/sub_settings/settings_about.dart';
@@ -255,6 +256,11 @@ class _SettingsPageState extends State<SettingsPage> {
 
   List<Widget> _buildCategoryWidgets() {
     final items = [
+      _CategoryItem(
+          icon: HugeIcons.strokeRoundedUser02,
+          title: "Profiles",
+          description: "Manage profiles, PIN locks, and switching",
+          destination: () => const ProfileManagementPage()),
       _CategoryItem(
           icon: IconlyLight.profile,
           title: "Accounts",

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -1,4 +1,4 @@
-import 'package:anymex/screens/downloads/download_screen.dart';
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/screens/other_features.dart';
 import 'package:anymex/screens/profile/profile_management_page.dart';
 import 'package:anymex/screens/settings/search/settings_registry.dart';
@@ -23,6 +23,7 @@ import 'package:anymex/widgets/common/glow.dart';
 import 'package:anymex/widgets/custom_widgets/custom_expansion_tile.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -39,6 +40,7 @@ class _CategoryItem {
   final void Function()? customTap;
   final bool isDebugOnly;
   final bool addDividerAbove;
+  final bool Function()? isVisible;
 
   const _CategoryItem({
     required this.icon,
@@ -48,6 +50,7 @@ class _CategoryItem {
     this.customTap,
     this.isDebugOnly = false,
     this.addDividerAbove = false,
+    this.isVisible,
   });
 }
 
@@ -234,24 +237,26 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Widget _buildCategoryList(EdgeInsets padding) {
-    return SuperListView(
-      padding: padding,
-      children: [
-        const SizedBox(height: 16),
-        Container(
-          decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              color:
-                  Theme.of(context).colorScheme.surfaceContainer.opaque(0.3)),
-          child: Column(
-            children: [
-              ..._buildCategoryWidgets(),
-            ],
+    return Obx(() {
+      return SuperListView(
+        padding: padding,
+        children: [
+          const SizedBox(height: 16),
+          Container(
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                color:
+                    Theme.of(context).colorScheme.surfaceContainer.opaque(0.3)),
+            child: Column(
+              children: [
+                ..._buildCategoryWidgets(),
+              ],
+            ),
           ),
-        ),
-        30.height(),
-      ],
-    );
+          30.height(),
+        ],
+      );
+    });
   }
 
   List<Widget> _buildCategoryWidgets() {
@@ -260,7 +265,27 @@ class _SettingsPageState extends State<SettingsPage> {
           icon: HugeIcons.strokeRoundedUser02,
           title: "Profiles",
           description: "Manage profiles, PIN locks, and switching",
-          destination: () => const ProfileManagementPage()),
+          destination: () => const ProfileManagementPage(),
+          isVisible: () {
+            final manager = Get.find<ProfileManager>();
+            return manager.isMultiProfileEnabled.value;
+          }),
+      _CategoryItem(
+          icon: Icons.person_add_rounded,
+          title: "Enable Profiles",
+          description: "Set up multiple profiles to keep your data separate",
+          customTap: () {
+            final manager = Get.find<ProfileManager>();
+            manager.enableMultiProfile();
+            snackBar('Profiles enabled');
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const ProfileManagementPage()),
+            );
+          },
+          isVisible: () {
+            final manager = Get.find<ProfileManager>();
+            return !manager.isMultiProfileEnabled.value;
+          }),
       _CategoryItem(
           icon: IconlyLight.profile,
           title: "Accounts",
@@ -355,6 +380,7 @@ class _SettingsPageState extends State<SettingsPage> {
     final widgets = <Widget>[];
     for (final item in items) {
       if (item.isDebugOnly && !kDebugMode) continue;
+      if (item.isVisible != null && !item.isVisible!()) continue;
 
       if (item.addDividerAbove) {
         widgets.add(const SizedBox(height: 10));

--- a/lib/screens/settings/sub_settings/settings_accounts.dart
+++ b/lib/screens/settings/sub_settings/settings_accounts.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/discord/discord_login.dart';
 import 'package:anymex/controllers/discord/discord_rpc.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
@@ -443,6 +444,7 @@ class TrackingServiceCard extends StatelessWidget {
               title: const Text("Log Out"),
               onTap: () {
                 service.logout();
+                Get.find<ProfileManager>().updateServiceBadges();
                 Navigator.pop(context);
               },
               shape: RoundedRectangleBorder(

--- a/lib/screens/settings/sub_settings/settings_backup.dart
+++ b/lib/screens/settings/sub_settings/settings_backup.dart
@@ -97,7 +97,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         RestorePreviewSheet(
           info: info,
           isEncrypted: isEncrypted,
-        onConfirm: (restoreSettings, restoreAuthTokens) async {
+        onConfirm: (restoreSettings, restoreAuthTokens, createNewProfile) async {
             Get.back();
             try {
               await controller.restoreBackup(
@@ -106,6 +106,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 merge: false,
                 restoreSettings: restoreSettings,
                 restoreAuthTokens: restoreAuthTokens,
+                createNewProfile: createNewProfile,
               );
               if (mounted) {
                 snackBar("Backup restored successfully!");

--- a/lib/screens/settings/sub_settings/settings_downloads.dart
+++ b/lib/screens/settings/sub_settings/settings_downloads.dart
@@ -7,6 +7,7 @@ import 'package:anymex/widgets/helper/platform_builder.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
 import 'package:iconsax/iconsax.dart';
 
 class SettingsDownloads extends StatelessWidget {
@@ -50,7 +51,9 @@ class SettingsDownloads extends StatelessWidget {
                                       String? result = await FilePicker.platform
                                           .getDirectoryPath();
                                       if (result != null) {
-                                        settings.saveDownloadPath(result);
+                                        if (!settings.saveDownloadPath(result)) {
+                                          snackBar('This folder is already used by another profile. Please choose a different folder.');
+                                        }
                                       }
                                     },
                                   ),

--- a/lib/screens/settings/sub_settings/settings_storage_manager.dart
+++ b/lib/screens/settings/sub_settings/settings_storage_manager.dart
@@ -59,9 +59,9 @@ class _SettingsStorageManagerState extends State<SettingsStorageManager> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Factory Reset'),
+        title: const Text('Reset Profile Data'),
         content: const Text(
-          'This will permanently delete all data stored of AnymeX. This cannot be undone.',
+          'This will permanently delete all data for the current profile (library, custom lists, settings). Other profiles will not be affected. This cannot be undone.',
         ),
         actions: [
           TextButton(
@@ -70,7 +70,7 @@ class _SettingsStorageManagerState extends State<SettingsStorageManager> {
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Delete All'),
+            child: const Text('Delete Profile Data'),
           ),
         ],
       ),
@@ -81,7 +81,7 @@ class _SettingsStorageManagerState extends State<SettingsStorageManager> {
     setState(() => _isRunningAction = true);
     try {
       await _service.factoryResetIsar();
-      snackBar('Isar data deleted');
+      snackBar('Profile data reset successfully');
     } catch (e) {
       snackBar('Factory reset failed: $e');
     } finally {
@@ -210,9 +210,9 @@ class _SettingsStorageManagerState extends State<SettingsStorageManager> {
                           ),
                           CustomTile(
                             icon: Icons.warning_rounded,
-                            title: 'Factory reset',
+                            title: 'Reset profile data',
                             description:
-                                'Delete everything stored of AnymeX permanently.',
+                                'Delete library, lists & settings for the current profile only.',
                             descColor: context.colors.error,
                             onTap: _factoryResetIsar,
                           ),

--- a/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
+++ b/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
@@ -165,7 +165,8 @@ class LoadingDialog extends StatelessWidget {
 class RestorePreviewSheet extends StatelessWidget {
   final Map<String, dynamic> info;
   final bool isEncrypted;
-  final Function(bool restoreSettings, bool restoreAuthTokens) onConfirm;
+  final Function(bool restoreSettings, bool restoreAuthTokens,
+      bool createNewProfile) onConfirm;
 
   const RestorePreviewSheet({
     super.key,
@@ -183,6 +184,11 @@ class RestorePreviewSheet extends StatelessWidget {
 
     final restoreSettings = true.obs;
     final restoreAuthTokens = false.obs;
+    final createNewProfile = false.obs;
+
+    final hasProfileLock = info['hasProfileLock'] as bool? ?? false;
+    final profileLockType = info['profileLockType'] as String? ?? 'none';
+    final canCreateNewProfile = info['canCreateNewProfile'] as bool? ?? false;
 
     return DraggableScrollableSheet(
       initialChildSize: 0.9,
@@ -269,38 +275,7 @@ class RestorePreviewSheet extends StatelessWidget {
                     novelCustomListsCount: info['novelCustomListsCount'] ?? 0,
                   ),
                   const SizedBox(height: 12),
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.errorContainer.opaque(0.2),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: theme.colorScheme.error.opaque(0.3),
-                      ),
-                    ),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Icon(
-                          Icons.warning_amber_rounded,
-                          color: theme.colorScheme.error,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            "Data will replace the CURRENT profile's library & settings. Create a new profile first if you want to keep existing data separate.",
-                            style: TextStyle(
-                              color: theme.colorScheme.error,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  if (hasSettings || hasAuthTokens) ...[
+                  if (hasProfileLock || hasSettings || hasAuthTokens) ...[
                     Text(
                       "RESTORE OPTIONS",
                       style: TextStyle(
@@ -332,11 +307,208 @@ class RestorePreviewSheet extends StatelessWidget {
                             controlAffinity: ListTileControlAffinity.trailing,
                             contentPadding: EdgeInsets.zero,
                           )),
+                    if (hasProfileLock)
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        margin: const EdgeInsets.symmetric(vertical: 8),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.secondaryContainer
+                              .opaque(0.3),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(Icons.lock_rounded,
+                                size: 16, color: theme.colorScheme.primary),
+                            const SizedBox(width: 8),
+                            Text(
+                              "Profile has ${profileLockType == 'pin' ? 'PIN' : profileLockType == 'pattern' ? 'pattern' : 'password'} lock — will be restored",
+                              style: TextStyle(
+                                color: theme.colorScheme.onSurfaceVariant,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    const SizedBox(height: 16),
+                    if (canCreateNewProfile)
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surfaceContainerHighest
+                              .opaque(0.3),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "RESTORE TO",
+                              style: TextStyle(
+                                color: theme.colorScheme.primary,
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                letterSpacing: 1.5,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Obx(() => Row(
+                                children: [
+                                  Expanded(
+                                    child: GestureDetector(
+                                      onTap: () =>
+                                          createNewProfile.value = false,
+                                      child: AnimatedContainer(
+                                        duration:
+                                            const Duration(milliseconds: 200),
+                                        padding: const EdgeInsets.symmetric(
+                                            horizontal: 12, vertical: 12),
+                                        decoration: BoxDecoration(
+                                          color: !createNewProfile.value
+                                              ? theme.colorScheme.primary
+                                                  .opaque(0.1)
+                                              : Colors.transparent,
+                                          borderRadius:
+                                              BorderRadius.circular(10),
+                                          border: Border.all(
+                                            color: !createNewProfile.value
+                                                ? theme.colorScheme.primary
+                                                : theme.colorScheme.outline
+                                                    .opaque(0.2),
+                                            width: 1.5,
+                                          ),
+                                        ),
+                                        child: Row(
+                                          children: [
+                                            Icon(
+                                              !createNewProfile.value
+                                                  ? Icons
+                                                      .radio_button_checked
+                                                  : Icons
+                                                      .radio_button_unchecked,
+                                              size: 18,
+                                              color:
+                                                  !createNewProfile.value
+                                                      ? theme
+                                                          .colorScheme.primary
+                                                      : theme.colorScheme
+                                                          .onSurfaceVariant,
+                                            ),
+                                            const SizedBox(width: 8),
+                                            Expanded(
+                                              child: Column(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                children: [
+                                                  Text(
+                                                    "Current Profile",
+                                                    style: TextStyle(
+                                                      fontWeight:
+                                                          FontWeight.w600,
+                                                      fontSize: 13,
+                                                      color: theme.colorScheme
+                                                          .onSurface,
+                                                    ),
+                                                  ),
+                                                  Text(
+                                                    "Replace existing data",
+                                                    style: TextStyle(
+                                                      fontSize: 11,
+                                                      color: theme.colorScheme
+                                                          .onSurfaceVariant,
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 10),
+                                  Expanded(
+                                    child: GestureDetector(
+                                      onTap: () =>
+                                          createNewProfile.value = true,
+                                      child: AnimatedContainer(
+                                        duration:
+                                            const Duration(milliseconds: 200),
+                                        padding: const EdgeInsets.symmetric(
+                                            horizontal: 12, vertical: 12),
+                                        decoration: BoxDecoration(
+                                          color: createNewProfile.value
+                                              ? theme.colorScheme.primary
+                                                  .opaque(0.1)
+                                              : Colors.transparent,
+                                          borderRadius:
+                                              BorderRadius.circular(10),
+                                          border: Border.all(
+                                            color: createNewProfile.value
+                                                ? theme.colorScheme.primary
+                                                : theme.colorScheme.outline
+                                                    .opaque(0.2),
+                                            width: 1.5,
+                                          ),
+                                        ),
+                                        child: Row(
+                                          children: [
+                                            Icon(
+                                              createNewProfile.value
+                                                  ? Icons
+                                                      .radio_button_checked
+                                                  : Icons
+                                                      .radio_button_unchecked,
+                                              size: 18,
+                                              color: createNewProfile.value
+                                                  ? theme
+                                                      .colorScheme.primary
+                                                  : theme.colorScheme
+                                                      .onSurfaceVariant,
+                                            ),
+                                            const SizedBox(width: 8),
+                                            Expanded(
+                                              child: Column(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                children: [
+                                                  Text(
+                                                    "New Profile",
+                                                    style: TextStyle(
+                                                      fontWeight:
+                                                          FontWeight.w600,
+                                                      fontSize: 13,
+                                                      color: theme.colorScheme
+                                                          .onSurface,
+                                                    ),
+                                                  ),
+                                                  Text(
+                                                    "Create fresh profile",
+                                                    style: TextStyle(
+                                                      fontSize: 11,
+                                                      color: theme.colorScheme
+                                                          .onSurfaceVariant,
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              )),
+                        ],
+                      ),
+                    ),
                     const SizedBox(height: 24),
                   ],
                   ElevatedButton(
-                    onPressed: () => onConfirm(
-                        restoreSettings.value, restoreAuthTokens.value),
+                    onPressed: () => onConfirm(restoreSettings.value,
+                        restoreAuthTokens.value, createNewProfile.value),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: theme.colorScheme.primary,
                       foregroundColor: theme.colorScheme.onPrimary,

--- a/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
+++ b/lib/screens/settings/sub_settings/widgets/backup_and_restore_widgets.dart
@@ -257,6 +257,7 @@ class RestorePreviewSheet extends StatelessWidget {
                     username: info['username'] ?? 'Unknown User',
                     avatar: info['avatar'],
                     appVersion: info['appVersion'] ?? 'Unknown',
+                    profileName: info['profileName'] as String? ?? '',
                   ),
                   const SizedBox(height: 24),
                   LibraryStatsCard(
@@ -278,6 +279,7 @@ class RestorePreviewSheet extends StatelessWidget {
                       ),
                     ),
                     child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Icon(
                           Icons.warning_amber_rounded,
@@ -286,7 +288,7 @@ class RestorePreviewSheet extends StatelessWidget {
                         const SizedBox(width: 12),
                         Expanded(
                           child: Text(
-                            "This will completely replace your current library. All existing data will be overwritten.",
+                            "Data will replace the CURRENT profile's library & settings. Create a new profile first if you want to keep existing data separate.",
                             style: TextStyle(
                               color: theme.colorScheme.error,
                               fontSize: 13,
@@ -365,12 +367,14 @@ class UserInfoCard extends StatelessWidget {
   final String username;
   final String? avatar;
   final String appVersion;
+  final String profileName;
 
   const UserInfoCard({
     super.key,
     required this.username,
     this.avatar,
     required this.appVersion,
+    this.profileName = '',
   });
 
   @override
@@ -409,7 +413,9 @@ class UserInfoCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    "Backup Owner",
+                    profileName.isNotEmpty
+                        ? "Profile: $profileName"
+                        : "Backup Owner",
                     style: TextStyle(
                       color: theme.colorScheme.onSurfaceVariant,
                       fontSize: 12,

--- a/lib/widgets/non_widgets/settings_sheet.dart
+++ b/lib/widgets/non_widgets/settings_sheet.dart
@@ -334,6 +334,7 @@ class SettingsSheet extends StatelessWidget {
   }
 
   Widget _buildProfileHeader(BuildContext context, ColorScheme theme) {
+    return Obx(() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
@@ -441,9 +442,11 @@ class SettingsSheet extends StatelessWidget {
         ],
       ),
     );
+    });
   }
 
   Widget _buildMenuSection(BuildContext context, ColorScheme theme) {
+    return Obx(() {
     final items = <_SheetMenuItem>[
       if (serviceHandler.isLoggedIn.value &&
           serviceHandler.serviceType.value == ServicesType.anilist)
@@ -523,6 +526,7 @@ class SettingsSheet extends StatelessWidget {
         }).toList(),
       ),
     );
+    });
   }
 
   Widget _buildMenuItem(

--- a/lib/widgets/non_widgets/settings_sheet.dart
+++ b/lib/widgets/non_widgets/settings_sheet.dart
@@ -1,10 +1,13 @@
 import 'dart:io';
 
+import 'package:anymex/controllers/profile/profile_manager.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/screens/downloads/download_screen.dart';
 import 'package:anymex/screens/extensions/ExtensionScreen.dart';
 import 'package:anymex/screens/local_source/local_source_view.dart';
 import 'package:anymex/screens/profile/profile_page.dart';
+import 'package:anymex/screens/profile/widgets/profile_avatar.dart';
+import 'package:anymex/screens/profile/widgets/profile_switcher_overlay.dart';
 import 'package:anymex/screens/settings/settings.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/theme_extensions.dart';
@@ -25,6 +28,7 @@ class SettingsSheet extends StatelessWidget {
   SettingsSheet({super.key});
 
   final serviceHandler = Get.find<ServiceHandler>();
+  final profileManager = Get.find<ProfileManager>();
 
   static void show(BuildContext context) {
     showModalBottomSheet(
@@ -251,6 +255,17 @@ class SettingsSheet extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                 ),
               ),
+              Obx(() {
+                if (profileManager.isMultiProfileEnabled.value) {
+                  return Column(
+                    children: [
+                      _buildProfileSwitchRow(context, theme),
+                      const SizedBox(height: 10),
+                    ],
+                  );
+                }
+                return const SizedBox.shrink();
+              }),
               _buildProfileHeader(context, theme),
               const SizedBox(height: 10),
               _buildMenuSection(context, theme),
@@ -260,6 +275,62 @@ class SettingsSheet extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _buildProfileSwitchRow(BuildContext context, ColorScheme theme) {
+    return Obx(() {
+      final profile = profileManager.currentProfile.value;
+      if (profile == null) return const SizedBox.shrink();
+
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: theme.surfaceContainer.opaque(0.35),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: theme.outline.opaque(0.12)),
+        ),
+        child: Row(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: theme.primary.opaque(0.3),
+                  width: 2,
+                ),
+              ),
+              child: ProfileAvatar(
+                profile: profile,
+                radius: 22,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: AnymexText(
+                text: profile.name,
+                variant: TextVariant.semiBold,
+                size: 14,
+              ),
+            ),
+            AnymexOnTap(
+              onTap: () => showProfileSwitcher(context),
+              child: Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: theme.surfaceContainerHighest.opaque(0.5),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(
+                  Icons.swap_horiz_rounded,
+                  size: 18,
+                  color: theme.onSurface.opaque(0.7),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    });
   }
 
   Widget _buildProfileHeader(BuildContext context, ColorScheme theme) {
@@ -328,6 +399,7 @@ class SettingsSheet extends StatelessWidget {
                       } else {
                         await serviceHandler.login(context);
                       }
+                      profileManager.updateServiceBadges();
                       Get.back();
                     },
                     child: Row(


### PR DESCRIPTION
Adds a complete multi-account profile system with lock protection, security question recovery, and optional skip mode.

## Features

### Multi-Account Profiles
- Create, switch and delete profiles with custom avatars
- Profile switcher overlay with quick switching
- Profile management page with full CRUD

### Profile Lock Protection
- PIN, Password & Pattern lock support
- Lockdown on multiple failed attempts
- Configurable lock timeout

### Security Question Recovery
- Set security question when enabling a lock
- 15 anime-themed security questions to choose from
- "Forgot PIN/Password/Pattern?" button to recover access
- SHA256 hashed answers with case-insensitive verification
- Backward compatible with profiles without security questions

### Skip Multi-Profile Mode
- Skip profile setup on first launch — creates default "My Profile"
- App behaves as single-user, all profile UI hidden
- Enable multi-profile later from Settings anytime