### PR TITLE
feat: add WebView cookie management for extensions

### DIFF
--- a/lib/controllers/source/source_controller.dart
+++ b/lib/controllers/source/source_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:anymex/controllers/cacher/cache_controller.dart';
+import 'package:anymex/utils/cloudflare_helper.dart';
 import 'package:anymex/controllers/service_handler/params.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
 import 'package:anymex/controllers/services/widgets/widgets_builders.dart';
@@ -506,12 +507,21 @@ class SourceController extends GetxController implements BaseService {
   Future<Media> fetchDetails(FetchDetailsParams params) async {
     final isAnime = lastUpdatedSource.value == 'ANIME';
     final source = isAnime ? activeSource.value! : activeMangaSource.value!;
-    final data = await source.methods.getDetail(DMedia.withUrl(params.id));
+    try {
+      final data = await source.methods.getDetail(DMedia.withUrl(params.id));
 
-    if (serviceHandler.serviceType.value != ServicesType.extensions) {
-      cacheController.addCache(data.toJson());
+      if (serviceHandler.serviceType.value != ServicesType.extensions) {
+        cacheController.addCache(data.toJson());
+      }
+      return Media.froDMedia(data, isAnime ? ItemType.anime : ItemType.manga);
+    } catch (e) {
+      if (Get.context != null &&
+          (CloudflareHelper.isCloudflareError(e) ||
+              CloudflareHelper.isAuthError(e))) {
+        CloudflareHelper.promptWebView(Get.context!, source, e);
+      }
+      rethrow;
     }
-    return Media.froDMedia(data, isAnime ? ItemType.anime : ItemType.manga);
   }
 
   @override
@@ -519,15 +529,23 @@ class SourceController extends GetxController implements BaseService {
     final source =
         params.isManga ? activeMangaSource.value : activeSource.value;
     final type = params.isManga ? ItemType.manga : ItemType.anime;
-    return (await source!.methods.search(params.query, params.page, []))
-        .list
-        .map((e) => Media.froDMedia(e, type))
-        .toList();
+    try {
+      return (await source!.methods.search(params.query, params.page, []))
+          .list
+          .map((e) => Media.froDMedia(e, type))
+          .toList();
+    } catch (e) {
+      if (Get.context != null &&
+          (CloudflareHelper.isCloudflareError(e) ||
+              CloudflareHelper.isAuthError(e))) {
+        CloudflareHelper.promptWebView(Get.context!, source!, e);
+      }
+      rethrow;
+    }
   }
 
   Future<void> checkForUpdates(BuildContext context) async {
     try {
-      // await _bridge.checkForUpdates();
       final updatesCount = [
         ...availableExtensions,
         ...availableMangaExtensions,

--- a/lib/screens/anime/widgets/episode_section.dart
+++ b/lib/screens/anime/widgets/episode_section.dart
@@ -11,6 +11,7 @@ import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/screens/anime/widgets/episode_list_builder.dart';
 import 'package:anymex/screens/anime/widgets/wrongtitle_modal.dart';
 import 'package:anymex/screens/extensions/ExtensionSettings/ExtensionSettings.dart';
+import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/language.dart';
 import 'package:anymex/utils/logger.dart';
@@ -38,8 +39,6 @@ class EpisodeSection extends StatefulWidget {
   final RxBool disableAnifyForCurrentSource;
   final Future<void> Function() mapToAnilist;
   final Future<void> Function(Media) getDetailsFromSource;
-  // final List<SourcePreference> Function({required Source source})
-  //     getSourcePreference;
 
   const EpisodeSection({
     super.key,
@@ -428,6 +427,57 @@ class _EpisodeSectionState extends State<EpisodeSection> {
                         ),
                       ),
                       const SizedBox(width: 12),
+                      AnymexOnTap(
+                        onTap: () {
+                          final activeSource = sourceController.activeSource.value;
+                          if (activeSource != null) {
+                            final baseUrl = activeSource.baseUrl ?? '';
+                            if (baseUrl.isNotEmpty) {
+                              context.openExtensionWebView(
+                                url: baseUrl,
+                                sourceName: activeSource.name ?? 'Extension',
+                              );
+                            } else {
+                              navigate(
+                                () => SourcePreferenceScreen(source: activeSource),
+                              );
+                            }
+                          }
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          decoration: BoxDecoration(
+                            color:
+                                context.colors.tertiaryContainer.opaque(0.4),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .outline
+                                  .opaque(0.3),
+                              width: 1,
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.cookie_outlined,
+                                size: 14,
+                                color: context.colors.tertiary,
+                              ),
+                              const SizedBox(width: 6),
+                              AnymexText(
+                                text: "WebView",
+                                size: 12,
+                                color: context.colors.tertiary,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
                       AnymexOnTap(
                         onTap: () {
                           showWrongTitleModal(

--- a/lib/screens/anime/widgets/episode_section.dart
+++ b/lib/screens/anime/widgets/episode_section.dart
@@ -227,6 +227,19 @@ class _EpisodeSectionState extends State<EpisodeSection> {
       label: "SELECT SOURCE",
       icon: Icons.extension_rounded,
       onChanged: (DropdownItem item) => handleSourceChange(item.value),
+      secondaryActionIcon: Icons.cookie_outlined,
+      onSecondaryActionPressed: () {
+        final activeSource = sourceController.activeSource.value;
+        if (activeSource != null) {
+          final baseUrl = activeSource.baseUrl ?? '';
+          if (baseUrl.isNotEmpty) {
+            context.openExtensionWebView(
+              url: baseUrl,
+              sourceName: activeSource.name ?? 'Extension',
+            );
+          }
+        }
+      },
       actionIcon: Icons.settings_outlined,
       onActionPressed: () => openSourcePreferences(context),
     );
@@ -494,58 +507,7 @@ class _EpisodeSectionState extends State<EpisodeSection> {
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10),
-                child: Row(
-                  children: [
-                    Expanded(child: buildSourceDropdown()),
-                    const SizedBox(width: 8),
-                    Obx(() {
-                      final activeSource = sourceController.activeSource.value;
-                      if (activeSource == null) return const SizedBox.shrink();
-                      return Container(
-                        decoration: BoxDecoration(
-                          color: context.colors.tertiaryContainer.opaque(0.3),
-                          borderRadius: BorderRadius.circular(10),
-                          border: Border.all(
-                            color: context.colors.outline.opaque(0.2),
-                          ),
-                        ),
-                        child: AnymexOnTap(
-                          onTap: () {
-                            final baseUrl = activeSource.baseUrl ?? '';
-                            if (baseUrl.isNotEmpty) {
-                              context.openExtensionWebView(
-                                url: baseUrl,
-                                sourceName: activeSource.name ?? 'Extension',
-                              );
-                            }
-                          },
-                          child: IconButton(
-                            onPressed: () {
-                              final baseUrl = activeSource.baseUrl ?? '';
-                              if (baseUrl.isNotEmpty) {
-                                context.openExtensionWebView(
-                                  url: baseUrl,
-                                  sourceName: activeSource.name ?? 'Extension',
-                                );
-                              }
-                            },
-                            icon: Icon(
-                              Icons.cookie_outlined,
-                              size: 18,
-                              color: context.colors.tertiary,
-                            ),
-                            tooltip: "WebView",
-                            padding: const EdgeInsets.all(8),
-                            constraints: const BoxConstraints(
-                              minWidth: 36,
-                              minHeight: 36,
-                            ),
-                          ),
-                        ),
-                      );
-                    }),
-                  ],
-                ),
+                child: buildSourceDropdown(),
               ),
             ),
             SliverToBoxAdapter(

--- a/lib/screens/anime/widgets/episode_section.dart
+++ b/lib/screens/anime/widgets/episode_section.dart
@@ -429,57 +429,6 @@ class _EpisodeSectionState extends State<EpisodeSection> {
                       const SizedBox(width: 12),
                       AnymexOnTap(
                         onTap: () {
-                          final activeSource = sourceController.activeSource.value;
-                          if (activeSource != null) {
-                            final baseUrl = activeSource.baseUrl ?? '';
-                            if (baseUrl.isNotEmpty) {
-                              context.openExtensionWebView(
-                                url: baseUrl,
-                                sourceName: activeSource.name ?? 'Extension',
-                              );
-                            } else {
-                              navigate(
-                                () => SourcePreferenceScreen(source: activeSource),
-                              );
-                            }
-                          }
-                        },
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 8),
-                          decoration: BoxDecoration(
-                            color:
-                                context.colors.tertiaryContainer.opaque(0.4),
-                            borderRadius: BorderRadius.circular(12),
-                            border: Border.all(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .outline
-                                  .opaque(0.3),
-                              width: 1,
-                            ),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                Icons.cookie_outlined,
-                                size: 14,
-                                color: context.colors.tertiary,
-                              ),
-                              const SizedBox(width: 6),
-                              AnymexText(
-                                text: "WebView",
-                                size: 12,
-                                color: context.colors.tertiary,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      AnymexOnTap(
-                        onTap: () {
                           showWrongTitleModal(
                             context,
                             widget.anilistData.title,
@@ -546,7 +495,56 @@ class _EpisodeSectionState extends State<EpisodeSection> {
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10),
                 child: Row(
-                  children: [Expanded(child: buildSourceDropdown())],
+                  children: [
+                    Expanded(child: buildSourceDropdown()),
+                    const SizedBox(width: 8),
+                    Obx(() {
+                      final activeSource = sourceController.activeSource.value;
+                      if (activeSource == null) return const SizedBox.shrink();
+                      return Container(
+                        decoration: BoxDecoration(
+                          color: context.colors.tertiaryContainer.opaque(0.3),
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: context.colors.outline.opaque(0.2),
+                          ),
+                        ),
+                        child: AnymexOnTap(
+                          onTap: () {
+                            final baseUrl = activeSource.baseUrl ?? '';
+                            if (baseUrl.isNotEmpty) {
+                              context.openExtensionWebView(
+                                url: baseUrl,
+                                sourceName: activeSource.name ?? 'Extension',
+                              );
+                            }
+                          },
+                          child: IconButton(
+                            onPressed: () {
+                              final baseUrl = activeSource.baseUrl ?? '';
+                              if (baseUrl.isNotEmpty) {
+                                context.openExtensionWebView(
+                                  url: baseUrl,
+                                  sourceName: activeSource.name ?? 'Extension',
+                                );
+                              }
+                            },
+                            icon: Icon(
+                              Icons.cookie_outlined,
+                              size: 18,
+                              color: context.colors.tertiary,
+                            ),
+                            tooltip: "WebView",
+                            padding: const EdgeInsets.all(8),
+                            constraints: const BoxConstraints(
+                              minWidth: 36,
+                              minHeight: 36,
+                            ),
+                          ),
+                        ),
+                      );
+                    }),
+                  ],
                 ),
               ),
             ),

--- a/lib/screens/extensions/ExtensionItem.dart
+++ b/lib/screens/extensions/ExtensionItem.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:anymex/controllers/source/source_controller.dart';
 import 'package:anymex/screens/extensions/ExtensionSettings/ExtensionSettings.dart';
+import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/language.dart';
 import 'package:anymex/utils/logger.dart';
@@ -105,7 +106,6 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
     final theme = context.colors;
     final updateAvailable = widget.source.hasUpdate ?? false;
 
-    // Use Obx only for the installed check that depends on reactive lists
     return Obx(() {
       final isInstalled = _isInstalled;
 
@@ -165,7 +165,7 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
     }
 
     return SizedBox(
-      width: updateAvailable ? 150 : 104,
+      width: updateAvailable ? 196 : 150,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
@@ -190,6 +190,34 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
             ),
             const SizedBox(width: 8),
           ],
+          Container(
+            decoration: BoxDecoration(
+              color: theme.primaryContainer.withOpacity(0.6),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: AnymexOnTap(
+              child: IconButton(
+                onPressed: () {
+                  final baseUrl = widget.source.baseUrl ?? '';
+                  if (baseUrl.isNotEmpty) {
+                    context.openExtensionWebView(
+                      url: baseUrl,
+                      sourceName: widget.source.name ?? 'Extension',
+                    );
+                  } else {
+                    _showWebViewUrlDialog(theme);
+                  }
+                },
+                icon: Icon(
+                  Icons.language_rounded,
+                  size: 18,
+                  color: theme.onPrimaryContainer,
+                ),
+                tooltip: "Open WebView",
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
           Container(
             decoration: BoxDecoration(
               color: theme.errorContainer.withAlpha(122),
@@ -227,6 +255,77 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
                 tooltip: "Settings",
               ),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showWebViewUrlDialog(ColorScheme theme) {
+    final urlController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+        title: const Text(
+          'Open WebView',
+          style: TextStyle(fontFamily: 'Poppins-SemiBold'),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'This extension doesn\'t have a base URL. Enter the website URL to open in WebView for login/cookie management:',
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontSize: 13,
+                color: theme.onSurface.withOpacity(0.7),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: urlController,
+              style: const TextStyle(fontFamily: 'Poppins', fontSize: 14),
+              decoration: InputDecoration(
+                hintText: 'https://example.com',
+                hintStyle: TextStyle(
+                  fontFamily: 'Poppins',
+                  color: theme.onSurface.withOpacity(0.4),
+                ),
+                filled: true,
+                fillColor: theme.surfaceContainerHighest.withOpacity(0.3),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: theme.outline),
+                ),
+                prefixIcon: const Icon(Icons.language_rounded, size: 20),
+              ),
+              keyboardType: TextInputType.url,
+              autocorrect: false,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              final url = urlController.text.trim();
+              if (url.isNotEmpty) {
+                String finalUrl = url;
+                if (!finalUrl.startsWith('http')) {
+                  finalUrl = 'https://$finalUrl';
+                }
+                context.openExtensionWebView(
+                  url: finalUrl,
+                  sourceName: widget.source.name ?? 'Extension',
+                );
+              }
+            },
+            child: const Text('Open'),
           ),
         ],
       ),
@@ -358,7 +457,6 @@ class _ExtensionIcon extends StatelessWidget {
   }
 }
 
-/// Extracted stateless subtitle widget
 class _ExtensionSubtitle extends StatelessWidget {
   final Source source;
   final ColorScheme theme;

--- a/lib/screens/extensions/ExtensionItem.dart
+++ b/lib/screens/extensions/ExtensionItem.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:anymex/controllers/source/source_controller.dart';
 import 'package:anymex/screens/extensions/ExtensionSettings/ExtensionSettings.dart';
-import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/language.dart';
 import 'package:anymex/utils/logger.dart';
@@ -165,7 +164,7 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
     }
 
     return SizedBox(
-      width: updateAvailable ? 196 : 150,
+      width: updateAvailable ? 150 : 104,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
@@ -190,34 +189,7 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
             ),
             const SizedBox(width: 8),
           ],
-          Container(
-            decoration: BoxDecoration(
-              color: theme.primaryContainer.withOpacity(0.6),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: AnymexOnTap(
-              child: IconButton(
-                onPressed: () {
-                  final baseUrl = widget.source.baseUrl ?? '';
-                  if (baseUrl.isNotEmpty) {
-                    context.openExtensionWebView(
-                      url: baseUrl,
-                      sourceName: widget.source.name ?? 'Extension',
-                    );
-                  } else {
-                    _showWebViewUrlDialog(theme);
-                  }
-                },
-                icon: Icon(
-                  Icons.language_rounded,
-                  size: 18,
-                  color: theme.onPrimaryContainer,
-                ),
-                tooltip: "Open WebView",
-              ),
-            ),
-          ),
-          const SizedBox(width: 8),
+
           Container(
             decoration: BoxDecoration(
               color: theme.errorContainer.withAlpha(122),
@@ -255,77 +227,6 @@ class _ExtensionListTileWidgetState extends State<ExtensionListTileWidget> {
                 tooltip: "Settings",
               ),
             ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showWebViewUrlDialog(ColorScheme theme) {
-    final urlController = TextEditingController();
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
-        title: const Text(
-          'Open WebView',
-          style: TextStyle(fontFamily: 'Poppins-SemiBold'),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'This extension doesn\'t have a base URL. Enter the website URL to open in WebView for login/cookie management:',
-              style: TextStyle(
-                fontFamily: 'Poppins',
-                fontSize: 13,
-                color: theme.onSurface.withOpacity(0.7),
-              ),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: urlController,
-              style: const TextStyle(fontFamily: 'Poppins', fontSize: 14),
-              decoration: InputDecoration(
-                hintText: 'https://example.com',
-                hintStyle: TextStyle(
-                  fontFamily: 'Poppins',
-                  color: theme.onSurface.withOpacity(0.4),
-                ),
-                filled: true,
-                fillColor: theme.surfaceContainerHighest.withOpacity(0.3),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: theme.outline),
-                ),
-                prefixIcon: const Icon(Icons.language_rounded, size: 20),
-              ),
-              keyboardType: TextInputType.url,
-              autocorrect: false,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.pop(dialogContext);
-              final url = urlController.text.trim();
-              if (url.isNotEmpty) {
-                String finalUrl = url;
-                if (!finalUrl.startsWith('http')) {
-                  finalUrl = 'https://$finalUrl';
-                }
-                context.openExtensionWebView(
-                  url: finalUrl,
-                  sourceName: widget.source.name ?? 'Extension',
-                );
-              }
-            },
-            child: const Text('Open'),
           ),
         ],
       ),

--- a/lib/screens/extensions/ExtensionSettings/ExtensionSettings.dart
+++ b/lib/screens/extensions/ExtensionSettings/ExtensionSettings.dart
@@ -1,3 +1,4 @@
+import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/screens/other_features.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/common/glow.dart';
@@ -6,6 +7,7 @@ import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
 import 'package:expressive_loading_indicator/expressive_loading_indicator.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:get/get.dart';
 
 class SourcePreferenceScreen extends StatefulWidget {
@@ -28,6 +30,337 @@ class _SourcePreferenceScreenState extends State<SourcePreferenceScreen> {
     preference.value = await widget.source.methods.getPreference();
   }
 
+  Widget _buildWebViewSection(ColorScheme theme) {
+    final baseUrl = widget.source.baseUrl ?? '';
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.primaryContainer.opaque(0.2),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: theme.primary.opaque(0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.cookie_outlined,
+                color: theme.primary,
+                size: 22,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AnymexText(
+                      text: 'WebView & Cookies',
+                      variant: TextVariant.semiBold,
+                      size: 15,
+                      color: theme.primary,
+                    ),
+                    const SizedBox(height: 2),
+                    AnymexText(
+                      text: 'Login to the source website or pass Cloudflare challenges',
+                      size: 11,
+                      color: theme.onSurface.opaque(0.6),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _ActionChip(
+                  icon: Icons.language_rounded,
+                  label: 'Open WebView',
+                  color: theme.primary,
+                  onColor: theme.onPrimary,
+                  containerColor: theme.primary.opaque(0.15),
+                  onTap: () {
+                    if (baseUrl.isNotEmpty) {
+                      context.openExtensionWebView(
+                        url: baseUrl,
+                        sourceName: widget.source.name ?? 'Extension',
+                      );
+                    } else {
+                      _showManualUrlDialog(theme);
+                    }
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _ActionChip(
+                  icon: Icons.info_outline_rounded,
+                  label: 'View Cookies',
+                  color: theme.tertiary,
+                  onColor: theme.onTertiary,
+                  containerColor: theme.tertiary.opaque(0.15),
+                  onTap: () => _showCookieInfo(theme),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _ActionChip(
+                  icon: Icons.delete_sweep_outlined,
+                  label: 'Clear Data',
+                  color: theme.error,
+                  onColor: theme.onError,
+                  containerColor: theme.error.opaque(0.15),
+                  onTap: () => _clearCookiesForSource(theme),
+                ),
+              ),
+            ],
+          ),
+          if (baseUrl.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: theme.surfaceContainerHighest.opaque(0.3),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.link_rounded,
+                    size: 14,
+                    color: theme.onSurface.opaque(0.5),
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      baseUrl,
+                      style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontSize: 11,
+                        color: theme.onSurface.opaque(0.5),
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _showManualUrlDialog(ColorScheme theme) {
+    final urlController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: theme.surfaceContainerHigh,
+        title: const Text(
+          'Open WebView',
+          style: TextStyle(fontFamily: 'Poppins-SemiBold'),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'This extension doesn\'t have a base URL. Enter the website URL:',
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontSize: 13,
+                color: theme.onSurface.withOpacity(0.7),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: urlController,
+              style: const TextStyle(fontFamily: 'Poppins', fontSize: 14),
+              decoration: InputDecoration(
+                hintText: 'https://example.com',
+                hintStyle: TextStyle(
+                  fontFamily: 'Poppins',
+                  color: theme.onSurface.withOpacity(0.4),
+                ),
+                filled: true,
+                fillColor: theme.surfaceContainerHighest.withOpacity(0.3),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: theme.outline),
+                ),
+                prefixIcon: const Icon(Icons.language_rounded, size: 20),
+              ),
+              keyboardType: TextInputType.url,
+              autocorrect: false,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              final url = urlController.text.trim();
+              if (url.isNotEmpty) {
+                String finalUrl = url;
+                if (!finalUrl.startsWith('http')) {
+                  finalUrl = 'https://$finalUrl';
+                }
+                context.openExtensionWebView(
+                  url: finalUrl,
+                  sourceName: widget.source.name ?? 'Extension',
+                );
+              }
+            },
+            child: const Text('Open'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showCookieInfo(ColorScheme theme) async {
+    final baseUrl = widget.source.baseUrl ?? '';
+    if (baseUrl.isEmpty) {
+      return;
+    }
+
+    final cookieManager = CookieManager.instance();
+    try {
+      final cookies = await cookieManager.getCookies(url: WebUri(baseUrl));
+      if (!mounted) return;
+
+      showDialog(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: theme.surfaceContainerHigh,
+          title: Text(
+            'Cookies (${cookies.length})',
+            style: const TextStyle(fontFamily: 'Poppins-SemiBold'),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 350,
+            child: cookies.isEmpty
+                ? Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.cookie_outlined,
+                            size: 48, color: theme.onSurface.opaque(0.3)),
+                        const SizedBox(height: 12),
+                        const Text('No cookies found',
+                            style: TextStyle(fontFamily: 'Poppins')),
+                        const SizedBox(height: 6),
+                        Text(
+                          'Open the WebView and login first',
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontSize: 12,
+                            color: theme.onSurface.withOpacity(0.5),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : ListView.separated(
+                    itemCount: cookies.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final cookie = cookies[index];
+                      return ListTile(
+                        dense: true,
+                        leading: Icon(
+                          Icons.cookie_outlined,
+                          size: 18,
+                          color: theme.primary,
+                        ),
+                        title: Text(
+                          cookie.name,
+                          style: const TextStyle(
+                            fontFamily: 'Poppins',
+                            fontSize: 12,
+                          ),
+                        ),
+                        subtitle: Text(
+                          '${cookie.value.substring(0, cookie.value.length > 40 ? 40 : cookie.value.length)}${cookie.value.length > 40 ? '...' : ''}',
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontSize: 10,
+                            color: theme.onSurface.withOpacity(0.6),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+    }
+  }
+
+  Future<void> _clearCookiesForSource(ColorScheme theme) async {
+    final baseUrl = widget.source.baseUrl ?? '';
+    if (baseUrl.isEmpty) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: theme.surfaceContainerHigh,
+        title: const Text(
+          'Clear Cookies',
+          style: TextStyle(fontFamily: 'Poppins-SemiBold'),
+        ),
+        content: Text(
+          'Clear all cookies for ${widget.source.name}? You may need to login again.',
+          style: const TextStyle(fontFamily: 'Poppins'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    final cookieManager = CookieManager.instance();
+    final uri = Uri.parse(baseUrl);
+    try {
+      final cookies = await cookieManager.getCookies(url: WebUri(baseUrl));
+      for (final cookie in cookies) {
+        await cookieManager.deleteCookie(
+          url: WebUri('https://${cookie.domain ?? uri.host}'),
+          name: cookie.name,
+          domain: cookie.domain,
+        );
+      }
+    } catch (e) {
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     var theme = context.colors;
@@ -39,6 +372,8 @@ class _SourcePreferenceScreenState extends State<SourcePreferenceScreen> {
             NestedHeader(
               title: "${widget.source.name} Settings",
             ),
+            _buildWebViewSection(theme),
+            const SizedBox(height: 12),
             Expanded(
               child: Obx(
                 () {
@@ -273,6 +608,58 @@ class _SourcePreferenceScreenState extends State<SourcePreferenceScreen> {
 }
 
 enum _PreferenceType { toggle, list, text }
+
+class _ActionChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final Color onColor;
+  final Color containerColor;
+  final VoidCallback onTap;
+
+  const _ActionChip({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onColor,
+    required this.containerColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: containerColor,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            children: [
+              Icon(icon, size: 18, color: color),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 class _PreferenceTile extends StatelessWidget {
   const _PreferenceTile({

--- a/lib/screens/extensions/extension_webview.dart
+++ b/lib/screens/extensions/extension_webview.dart
@@ -1,0 +1,536 @@
+import 'dart:collection';
+
+import 'package:anymex/utils/logger.dart';
+import 'package:anymex/utils/theme_extensions.dart';
+import 'package:anymex/widgets/custom_widgets/custom_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:get/get.dart';
+
+class ExtensionWebViewPage extends StatefulWidget {
+  final String url;
+  final String sourceName;
+
+  const ExtensionWebViewPage({
+    super.key,
+    required this.url,
+    required this.sourceName,
+  });
+
+  @override
+  State<ExtensionWebViewPage> createState() => _ExtensionWebViewPageState();
+}
+
+class _ExtensionWebViewPageState extends State<ExtensionWebViewPage> {
+  late InAppWebViewController _controller;
+  bool _isLoading = true;
+  double _progress = 0;
+  String _currentUrl = '';
+  bool _cloudflareDetected = false;
+  String? _pageTitle;
+
+  static const String _cloudflareDetectScript = '''
+    (function() {
+      var cfIndicators = [
+        document.getElementById('challenge-running'),
+        document.getElementById('challenge-stage'),
+        document.querySelector('.challenge-platform'),
+        document.querySelector('[data-ray]'),
+        document.title && document.title.includes('Just a moment'),
+        document.title && document.title.includes('Attention Required'),
+        document.querySelector('iframe[src*="challenges.cloudflare.com"]'),
+        document.body && document.body.innerText && document.body.innerText.includes('Checking your browser'),
+        document.body && document.body.innerText && document.body.innerText.includes('Enable JavaScript and cookies to continue'),
+      ];
+      var detected = cfIndicators.some(function(el) { return !!el; });
+      if (detected) {
+        window.flutter_inappwebview.callHandler('onCloudflareDetected', true);
+      }
+    })();
+  ''';
+
+  @override
+  void initState() {
+    super.initState();
+    _currentUrl = widget.url;
+  }
+
+  Future<void> _clearCookiesForDomain() async {
+    final cookieManager = CookieManager.instance();
+    final uri = Uri.parse(widget.url);
+    final domain = uri.host;
+
+    try {
+      final cookies = await cookieManager.getCookies(url: WebUri(widget.url));
+      for (final cookie in cookies) {
+        await cookieManager.deleteCookie(
+          url: WebUri('https://${cookie.domain ?? domain}'),
+          name: cookie.name,
+          domain: cookie.domain,
+        );
+      }
+      Logger.i('Cleared cookies for $domain');
+    } catch (e) {
+      Logger.e('Error clearing cookies: $e');
+    }
+  }
+
+  Future<void> _clearAllData() async {
+    try {
+      await _controller.evaluateJavascript(source: '''
+        try { localStorage.clear(); } catch(e) {}
+        try { sessionStorage.clear(); } catch(e) {}
+      ''');
+      await _controller.clearCache();
+      await CookieManager.instance().deleteAllCookies();
+      Logger.i('Cleared all WebView data');
+    } catch (e) {
+      Logger.e('Error clearing all data: $e');
+    }
+
+    if (mounted) {
+      _controller.loadUrl(
+        urlRequest: URLRequest(url: WebUri(widget.url)),
+      );
+    }
+  }
+
+  Future<void> _showCookieInfo() async {
+    final cookieManager = CookieManager.instance();
+    try {
+      final cookies =
+          await cookieManager.getCookies(url: WebUri(_currentUrl));
+      if (!mounted) return;
+
+      final cookieList = cookies
+          .map((c) => '${c.name}=${c.value}${c.domain != null ? ' (${c.domain})' : ''}')
+          .toList();
+
+      showDialog(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+          title: Text(
+            'Cookies (${cookies.length})',
+            style: const TextStyle(fontFamily: 'Poppins-SemiBold'),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 400,
+            child: cookies.isEmpty
+                ? const Center(
+                    child: Text('No cookies found for this domain'))
+                : ListView.separated(
+                    itemCount: cookieList.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final cookie = cookies[index];
+                      return ListTile(
+                        dense: true,
+                        leading: Icon(
+                          Icons.cookie_outlined,
+                          size: 18,
+                          color: context.colors.primary,
+                        ),
+                        title: Text(
+                          cookie.name,
+                          style: const TextStyle(
+                            fontFamily: 'Poppins',
+                            fontSize: 12,
+                          ),
+                        ),
+                        subtitle: Text(
+                          '${cookie.value.substring(0, cookie.value.length > 50 ? 50 : cookie.value.length)}${cookie.value.length > 50 ? '...' : ''}',
+                          style: TextStyle(
+                            fontFamily: 'Poppins',
+                            fontSize: 10,
+                            color: context.colors.onSurface.withOpacity(0.6),
+                          ),
+                        ),
+                        trailing: Text(
+                          cookie.domain ?? '',
+                          style: TextStyle(
+                            fontSize: 9,
+                            color: context.colors.onSurface.withOpacity(0.4),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      Logger.e('Error reading cookies: $e');
+    }
+  }
+
+  void _onCloudflareDetected(bool detected) {
+    if (detected && !_cloudflareDetected) {
+      setState(() => _cloudflareDetected = true);
+      Logger.i('Cloudflare challenge detected - user can solve it in WebView');
+    } else if (!detected && _cloudflareDetected) {
+      setState(() => _cloudflareDetected = false);
+      Logger.i('Cloudflare challenge passed successfully');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.colors;
+
+    return Scaffold(
+      backgroundColor: theme.surface,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildAppBar(theme),
+
+            if (_cloudflareDetected) _buildCloudflareBanner(theme),
+
+            if (_isLoading && _progress > 0 && _progress < 1)
+              LinearProgressIndicator(
+                value: _progress,
+                backgroundColor: theme.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(theme.primary),
+                minHeight: 3,
+              ),
+
+            _buildUrlBar(theme),
+
+            Expanded(
+              child: InAppWebView(
+                initialUrlRequest: URLRequest(url: WebUri(widget.url)),
+                initialSettings: InAppWebViewSettings(
+                  javaScriptEnabled: true,
+                  domStorageEnabled: true,
+                  databaseEnabled: true,
+                  supportZoom: true,
+                  useWideViewPort: true,
+                  loadWithOverviewMode: true,
+                  allowUniversalAccessFromFileURLs: true,
+                  allowFileAccessFromFileURLs: true,
+                  limitsNavigationsToAppBoundDomains: false,
+                  mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+                  thirdPartyCookiesEnabled: true,
+                  userAgent:
+                      'Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36',
+                  cacheEnabled: true,
+                  allowFileAccess: true,
+                  blockNetworkLoads: false,
+                ),
+                onWebViewCreated: (controller) {
+                  _controller = controller;
+
+                  _controller.addJavaScriptHandler(
+                    handlerName: 'onCloudflareDetected',
+                    callback: (args) {
+                      if (args.isNotEmpty) {
+                        _onCloudflareDetected(args[0] as bool);
+                      }
+                    },
+                  );
+                },
+                onLoadStart: (controller, url) {
+                  if (mounted) {
+                    setState(() {
+                      _isLoading = true;
+                      _currentUrl = url?.toString() ?? widget.url;
+                    });
+                  }
+                },
+                onLoadStop: (controller, url) async {
+                  if (mounted) {
+                    setState(() {
+                      _isLoading = false;
+                      _progress = 1.0;
+                      _currentUrl = url?.toString() ?? widget.url;
+                    });
+                  }
+
+                  try {
+                    final title = await controller.getTitle();
+                    if (mounted) {
+                      setState(() => _pageTitle = title);
+                    }
+                  } catch (_) {}
+
+                  try {
+                    await controller.evaluateJavascript(
+                        source: _cloudflareDetectScript);
+                  } catch (_) {}
+                },
+                onProgressChanged: (controller, progress) {
+                  if (mounted) {
+                    setState(() => _progress = progress / 100);
+                  }
+                },
+                onUpdateVisitedHistory: (controller, url, isReload) async {
+                  if (mounted) {
+                    setState(() => _currentUrl = url?.toString() ?? widget.url);
+                  }
+                  try {
+                    await controller.evaluateJavascript(
+                        source: _cloudflareDetectScript);
+                  } catch (_) {}
+                },
+                shouldOverrideUrlLoading:
+                    (controller, navigationAction) async =>
+                        NavigationActionPolicy.ALLOW,
+                onReceivedHttpAuthRequest:
+                    (controller, challenge) async {
+                  return HttpAuthResponse(
+                    action: HttpAuthResponseAction.CANCEL,
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAppBar(ColorScheme theme) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 8),
+      decoration: BoxDecoration(
+        color: theme.surface,
+        border: Border(
+          bottom: BorderSide(
+            color: theme.outline.withOpacity(0.15),
+            width: 1,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: Icon(Icons.close, color: theme.onSurface),
+            onPressed: () => Navigator.of(context).pop(),
+            tooltip: 'Close',
+          ),
+          const SizedBox(width: 4),
+
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: theme.primaryContainer.withOpacity(0.5),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              Icons.language_rounded,
+              color: theme.primary,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.sourceName,
+                  style: const TextStyle(
+                    fontFamily: 'Poppins-SemiBold',
+                    fontSize: 15,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  'WebView Login & Cookies',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontSize: 11,
+                    color: theme.onSurface.withOpacity(0.6),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          IconButton(
+            icon: Icon(Icons.cookie_outlined, color: theme.onSurface.withOpacity(0.7)),
+            onPressed: _showCookieInfo,
+            tooltip: 'View Cookies',
+          ),
+
+          IconButton(
+            icon: Icon(Icons.delete_sweep_outlined, color: theme.onSurface.withOpacity(0.7)),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  backgroundColor:
+                      Theme.of(context).colorScheme.surfaceContainerHigh,
+                  title: const Text(
+                    'Clear Data',
+                    style: TextStyle(fontFamily: 'Poppins-SemiBold'),
+                  ),
+                  content: const Text(
+                    'Clear all cookies and site data? The page will reload.',
+                    style: TextStyle(fontFamily: 'Poppins'),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.pop(ctx);
+                        _clearAllData();
+                      },
+                      child: const Text('Clear & Reload'),
+                    ),
+                  ],
+                ),
+              );
+            },
+            tooltip: 'Clear Data',
+          ),
+
+          if (_isLoading)
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(theme.primary),
+              ),
+            )
+          else
+            IconButton(
+              icon: Icon(Icons.refresh_rounded, color: theme.primary),
+              onPressed: () => _controller.reload(),
+              tooltip: 'Refresh',
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCloudflareBanner(ColorScheme theme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.orange.shade900.withOpacity(0.2),
+        border: Border(
+          bottom: BorderSide(
+            color: Colors.orange.shade900.withOpacity(0.3),
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.shield_outlined,
+            color: Colors.orange,
+            size: 20,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Cloudflare Challenge Detected',
+                  style: TextStyle(
+                    fontFamily: 'Poppins-SemiBold',
+                    fontSize: 13,
+                    color: Colors.orange,
+                  ),
+                ),
+                Text(
+                  'Wait for the challenge to complete automatically',
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontSize: 11,
+                    color: Colors.orange.withOpacity(0.8),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_isLoading)
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                    Colors.orange.withOpacity(0.8)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUrlBar(ColorScheme theme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.surfaceContainerHighest.withOpacity(0.3),
+        border: Border(
+          bottom: BorderSide(
+            color: theme.outline.withOpacity(0.1),
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.lock_outline,
+            size: 12,
+            color: _currentUrl.startsWith('https')
+                ? Colors.green
+                : Colors.orange,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              _currentUrl,
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontSize: 11,
+                color: theme.onSurface.withOpacity(0.6),
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+extension ExtensionWebViewNavigation on BuildContext {
+  Future<void> openExtensionWebView({
+    required String url,
+    required String sourceName,
+  }) async {
+    if (url.isEmpty) {
+      return;
+    }
+
+    await Navigator.of(this).push(
+      MaterialPageRoute(
+        builder: (context) => ExtensionWebViewPage(
+          url: url,
+          sourceName: sourceName,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/manga/widgets/chapter_section.dart
+++ b/lib/screens/manga/widgets/chapter_section.dart
@@ -193,58 +193,7 @@ class ChapterSection extends StatelessWidget {
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10),
-                child: Row(
-                  children: [
-                    Expanded(child: buildMangaSourceDropdown()),
-                    const SizedBox(width: 8),
-                    Obx(() {
-                      final activeSource = sourceController.activeMangaSource.value;
-                      if (activeSource == null) return const SizedBox.shrink();
-                      return Container(
-                        decoration: BoxDecoration(
-                          color: context.colors.tertiaryContainer.opaque(0.3),
-                          borderRadius: BorderRadius.circular(10),
-                          border: Border.all(
-                            color: context.colors.outline.opaque(0.2),
-                          ),
-                        ),
-                        child: AnymexOnTap(
-                          onTap: () {
-                            final baseUrl = activeSource.baseUrl ?? '';
-                            if (baseUrl.isNotEmpty) {
-                              context.openExtensionWebView(
-                                url: baseUrl,
-                                sourceName: activeSource.name ?? 'Extension',
-                              );
-                            }
-                          },
-                          child: IconButton(
-                            onPressed: () {
-                              final baseUrl = activeSource.baseUrl ?? '';
-                              if (baseUrl.isNotEmpty) {
-                                context.openExtensionWebView(
-                                  url: baseUrl,
-                                  sourceName: activeSource.name ?? 'Extension',
-                                );
-                              }
-                            },
-                            icon: Icon(
-                              Icons.cookie_outlined,
-                              size: 18,
-                              color: context.colors.tertiary,
-                            ),
-                            tooltip: "WebView",
-                            padding: const EdgeInsets.all(8),
-                            constraints: const BoxConstraints(
-                              minWidth: 36,
-                              minHeight: 36,
-                            ),
-                          ),
-                        ),
-                      );
-                    }),
-                  ],
-                ),
+                child: buildMangaSourceDropdown(),
               ),
             ),
             SliverToBoxAdapter(
@@ -394,6 +343,19 @@ class ChapterSection extends StatelessWidget {
       selectedItem: selectedItem,
       label: "SELECT SOURCE",
       icon: Icons.extension_rounded,
+      secondaryActionIcon: Icons.cookie_outlined,
+      onSecondaryActionPressed: () {
+        final activeSource = sourceController.activeMangaSource.value;
+        if (activeSource != null) {
+          final baseUrl = activeSource.baseUrl ?? '';
+          if (baseUrl.isNotEmpty && Get.context != null) {
+            Get.context!.openExtensionWebView(
+              url: baseUrl,
+              sourceName: activeSource.name ?? 'Extension',
+            );
+          }
+        }
+      },
       actionIcon: Icons.settings_outlined,
       onActionPressed: () => openSourcePreferences(Get.context!),
       onChanged: (DropdownItem item) async {

--- a/lib/screens/manga/widgets/chapter_section.dart
+++ b/lib/screens/manga/widgets/chapter_section.dart
@@ -3,6 +3,7 @@ import 'package:anymex/database/data_keys/keys.dart';
 import 'package:anymex/database/isar_models/chapter.dart';
 import 'package:anymex/models/Media/media.dart';
 import 'package:anymex/screens/extensions/ExtensionSettings/ExtensionSettings.dart';
+import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/screens/manga/widgets/chapter_list_builder.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/language.dart';
@@ -131,6 +132,59 @@ class ChapterSection extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 12),
+                      AnymexOnTap(
+                        onTap: () {
+                          final activeSource = sourceController.activeMangaSource.value;
+                          if (activeSource != null) {
+                            final baseUrl = activeSource.baseUrl ?? '';
+                            if (baseUrl.isNotEmpty) {
+                              context.openExtensionWebView(
+                                url: baseUrl,
+                                sourceName: activeSource.name ?? 'Extension',
+                              );
+                            } else {
+                              navigate(
+                                () => SourcePreferenceScreen(source: activeSource),
+                              );
+                            }
+                          }
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 8),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .tertiaryContainer
+                                .opaque(0.4),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .outline
+                                  .opaque(0.3),
+                              width: 1,
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.cookie_outlined,
+                                size: 14,
+                                color: context.colors.tertiary,
+                              ),
+                              const SizedBox(width: 6),
+                              AnymexText(
+                                text: "WebView",
+                                size: 12,
+                                color: context.colors.tertiary,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
                       AnymexOnTap(
                         onTap: () {
                           showWrongTitleModal(

--- a/lib/screens/manga/widgets/chapter_section.dart
+++ b/lib/screens/manga/widgets/chapter_section.dart
@@ -134,59 +134,6 @@ class ChapterSection extends StatelessWidget {
                       const SizedBox(width: 12),
                       AnymexOnTap(
                         onTap: () {
-                          final activeSource = sourceController.activeMangaSource.value;
-                          if (activeSource != null) {
-                            final baseUrl = activeSource.baseUrl ?? '';
-                            if (baseUrl.isNotEmpty) {
-                              context.openExtensionWebView(
-                                url: baseUrl,
-                                sourceName: activeSource.name ?? 'Extension',
-                              );
-                            } else {
-                              navigate(
-                                () => SourcePreferenceScreen(source: activeSource),
-                              );
-                            }
-                          }
-                        },
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 8),
-                          decoration: BoxDecoration(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .tertiaryContainer
-                                .opaque(0.4),
-                            borderRadius: BorderRadius.circular(12),
-                            border: Border.all(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .outline
-                                  .opaque(0.3),
-                              width: 1,
-                            ),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                Icons.cookie_outlined,
-                                size: 14,
-                                color: context.colors.tertiary,
-                              ),
-                              const SizedBox(width: 6),
-                              AnymexText(
-                                text: "WebView",
-                                size: 12,
-                                color: context.colors.tertiary,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      AnymexOnTap(
-                        onTap: () {
                           showWrongTitleModal(
                             context,
                             anilistData.title,
@@ -246,7 +193,58 @@ class ChapterSection extends StatelessWidget {
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10),
-                child: buildMangaSourceDropdown(),
+                child: Row(
+                  children: [
+                    Expanded(child: buildMangaSourceDropdown()),
+                    const SizedBox(width: 8),
+                    Obx(() {
+                      final activeSource = sourceController.activeMangaSource.value;
+                      if (activeSource == null) return const SizedBox.shrink();
+                      return Container(
+                        decoration: BoxDecoration(
+                          color: context.colors.tertiaryContainer.opaque(0.3),
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: context.colors.outline.opaque(0.2),
+                          ),
+                        ),
+                        child: AnymexOnTap(
+                          onTap: () {
+                            final baseUrl = activeSource.baseUrl ?? '';
+                            if (baseUrl.isNotEmpty) {
+                              context.openExtensionWebView(
+                                url: baseUrl,
+                                sourceName: activeSource.name ?? 'Extension',
+                              );
+                            }
+                          },
+                          child: IconButton(
+                            onPressed: () {
+                              final baseUrl = activeSource.baseUrl ?? '';
+                              if (baseUrl.isNotEmpty) {
+                                context.openExtensionWebView(
+                                  url: baseUrl,
+                                  sourceName: activeSource.name ?? 'Extension',
+                                );
+                              }
+                            },
+                            icon: Icon(
+                              Icons.cookie_outlined,
+                              size: 18,
+                              color: context.colors.tertiary,
+                            ),
+                            tooltip: "WebView",
+                            padding: const EdgeInsets.all(8),
+                            constraints: const BoxConstraints(
+                              minWidth: 36,
+                              minHeight: 36,
+                            ),
+                          ),
+                        ),
+                      );
+                    }),
+                  ],
+                ),
               ),
             ),
             SliverToBoxAdapter(

--- a/lib/screens/novel/details/widgets/chapters_section.dart
+++ b/lib/screens/novel/details/widgets/chapters_section.dart
@@ -1,18 +1,14 @@
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
-import 'package:anymex/controllers/source/source_controller.dart';
 import 'package:anymex/database/isar_models/chapter.dart';
-import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/screens/manga/widgets/chapter_ranges.dart';
 import 'package:anymex/screens/novel/details/controller/details_controller.dart';
 import 'package:anymex/screens/novel/details/widgets/chapter_item.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/string_extensions.dart';
-import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/animation/animations.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
-import 'package:anymex/widgets/helper/tv_wrapper.dart';
 import 'package:anymex_extension_runtime_bridge/Models/DEpisode.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -116,48 +112,6 @@ class _ChapterSliverSectionState extends State<ChapterSliverSection> {
                 size: 18,
               ),
               const Spacer(),
-              AnymexOnTap(
-                onTap: () {
-                  final activeSource = sourceController.activeNovelSource.value;
-                  if (activeSource != null) {
-                    final baseUrl = activeSource.baseUrl ?? '';
-                    if (baseUrl.isNotEmpty) {
-                      context.openExtensionWebView(
-                        url: baseUrl,
-                        sourceName: activeSource.name ?? 'Extension',
-                      );
-                    }
-                  }
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: context.colors.tertiaryContainer.opaque(0.4),
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: context.colors.outline.opaque(0.3),
-                      width: 1,
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.cookie_outlined,
-                        size: 14,
-                        color: context.colors.tertiary,
-                      ),
-                      const SizedBox(width: 4),
-                      AnymexText(
-                        text: "WebView",
-                        size: 11,
-                        color: context.colors.tertiary,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
               IconButton(
                   onPressed: sortToggle, icon: const Icon(Icons.sort_rounded))
             ],

--- a/lib/screens/novel/details/widgets/chapters_section.dart
+++ b/lib/screens/novel/details/widgets/chapters_section.dart
@@ -1,14 +1,18 @@
 import 'package:anymex/controllers/offline/offline_storage_controller.dart';
 import 'package:anymex/controllers/service_handler/service_handler.dart';
+import 'package:anymex/controllers/source/source_controller.dart';
 import 'package:anymex/database/isar_models/chapter.dart';
+import 'package:anymex/screens/extensions/extension_webview.dart';
 import 'package:anymex/screens/manga/widgets/chapter_ranges.dart';
 import 'package:anymex/screens/novel/details/controller/details_controller.dart';
 import 'package:anymex/screens/novel/details/widgets/chapter_item.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/string_extensions.dart';
+import 'package:anymex/utils/theme_extensions.dart';
 import 'package:anymex/widgets/animation/animations.dart';
 import 'package:anymex/widgets/custom_widgets/custom_text.dart';
 import 'package:anymex/widgets/helper/platform_builder.dart';
+import 'package:anymex/widgets/helper/tv_wrapper.dart';
 import 'package:anymex_extension_runtime_bridge/Models/DEpisode.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -112,6 +116,48 @@ class _ChapterSliverSectionState extends State<ChapterSliverSection> {
                 size: 18,
               ),
               const Spacer(),
+              AnymexOnTap(
+                onTap: () {
+                  final activeSource = sourceController.activeNovelSource.value;
+                  if (activeSource != null) {
+                    final baseUrl = activeSource.baseUrl ?? '';
+                    if (baseUrl.isNotEmpty) {
+                      context.openExtensionWebView(
+                        url: baseUrl,
+                        sourceName: activeSource.name ?? 'Extension',
+                      );
+                    }
+                  }
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: context.colors.tertiaryContainer.opaque(0.4),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(
+                      color: context.colors.outline.opaque(0.3),
+                      width: 1,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.cookie_outlined,
+                        size: 14,
+                        color: context.colors.tertiary,
+                      ),
+                      const SizedBox(width: 4),
+                      AnymexText(
+                        text: "WebView",
+                        size: 11,
+                        color: context.colors.tertiary,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
               IconButton(
                   onPressed: sortToggle, icon: const Icon(Icons.sort_rounded))
             ],

--- a/lib/utils/cloudflare_helper.dart
+++ b/lib/utils/cloudflare_helper.dart
@@ -1,0 +1,121 @@
+import 'package:anymex/screens/extensions/extension_webview.dart';
+import 'package:anymex/utils/logger.dart';
+import 'package:anymex/widgets/non_widgets/snackbar.dart';
+import 'package:anymex_extension_runtime_bridge/anymex_extension_runtime_bridge.dart';
+import 'package:flutter/material.dart';
+
+class CloudflareHelper {
+  static const _cloudflarePatterns = [
+    'cloudflare',
+    'just a moment',
+    'attention required',
+    'checking your browser',
+    'enable javascript and cookies',
+    'challenge-platform',
+    'ddos-guard',
+    'cf-browser-verification',
+    'ray id',
+    'access denied',
+    'error 1020',
+    'error 1015',
+    'error 1010',
+    'error 1005',
+    'blocked',
+  ];
+
+  static const _authPatterns = [
+    'login required',
+    'sign in',
+    'unauthorized',
+    'authentication required',
+    'please log in',
+    'log in to continue',
+    'premium only',
+    'subscription required',
+  ];
+
+  static bool isCloudflareError(dynamic error) {
+    final errorStr = error.toString().toLowerCase();
+    return _cloudflarePatterns.any((pattern) => errorStr.contains(pattern));
+  }
+
+  static bool isAuthError(dynamic error) {
+    final errorStr = error.toString().toLowerCase();
+    return _authPatterns.any((pattern) => errorStr.contains(pattern));
+  }
+
+  static bool isBlockStatusCode(int? statusCode) {
+    if (statusCode == null) return false;
+    return statusCode == 403 ||
+        statusCode == 503 ||
+        statusCode == 502 ||
+        statusCode == 429;
+  }
+
+  static void promptWebView(BuildContext context, Source source, dynamic error) {
+    final isCf = isCloudflareError(error);
+    final isAuth = isAuthError(error);
+    final baseUrl = source.baseUrl ?? '';
+
+    if (!isCf && !isAuth) return;
+    if (baseUrl.isEmpty) return;
+
+    final message = isCf
+        ? 'Cloudflare detected for ${source.name}. Open WebView to pass the challenge?'
+        : 'Login may be required for ${source.name}. Open WebView to login?';
+
+    Logger.i('Challenge detected for ${source.name}: ${error.toString()}');
+
+    snackBar(
+      message,
+      duration: 5000,
+    );
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+        title: Row(
+          children: [
+            Icon(
+              isCf ? Icons.shield_outlined : Icons.login_rounded,
+              color: isCf ? Colors.orange : Theme.of(context).colorScheme.primary,
+              size: 24,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                isCf ? 'Cloudflare Challenge' : 'Login Required',
+                style: const TextStyle(fontFamily: 'Poppins-SemiBold', fontSize: 16),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        content: Text(
+          isCf
+              ? '${source.name} is protected by Cloudflare. You need to pass the challenge in WebView before using this extension.'
+              : '${source.name} may require you to login. Open WebView to authenticate?',
+          style: const TextStyle(fontFamily: 'Poppins', fontSize: 14),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Later'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              context.openExtensionWebView(
+                url: baseUrl,
+                sourceName: source.name ?? 'Extension',
+              );
+            },
+            child: const Text('Open WebView'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_widgets/anymex_dropdown.dart
+++ b/lib/widgets/custom_widgets/anymex_dropdown.dart
@@ -9,6 +9,8 @@ class AnymexDropdown extends StatefulWidget {
   final IconData icon;
   final IconData? actionIcon;
   final VoidCallback? onActionPressed;
+  final IconData? secondaryActionIcon;
+  final VoidCallback? onSecondaryActionPressed;
 
   const AnymexDropdown({
     super.key,
@@ -19,6 +21,8 @@ class AnymexDropdown extends StatefulWidget {
     required this.icon,
     this.actionIcon,
     this.onActionPressed,
+    this.secondaryActionIcon,
+    this.onSecondaryActionPressed,
   });
 
   @override
@@ -479,6 +483,31 @@ class _AnymexDropdownState extends State<AnymexDropdown>
                       ],
                     ),
                   ),
+                  if (widget.secondaryActionIcon != null &&
+                      widget.onSecondaryActionPressed != null &&
+                      widget.selectedItem != null)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 8.0),
+                      child: Material(
+                        color: Colors.transparent,
+                        borderRadius: BorderRadius.circular(20),
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(20),
+                          onTap: widget.onSecondaryActionPressed,
+                          child: Padding(
+                            padding: const EdgeInsets.all(6.0),
+                            child: Icon(
+                              widget.secondaryActionIcon,
+                              size: 20,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .tertiary
+                                  .opaque(0.8, iReallyMeanIt: true),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
                   if (widget.actionIcon != null &&
                       widget.onActionPressed != null &&
                       widget.selectedItem != null)


### PR DESCRIPTION
## WebView Cookie Management for Extensions

Adds a WebView screen that allows users to open extension websites, log in, solve Cloudflare challenges, and manage cookies for authenticated extension access.

### Requires Bridge Fix
Cookie injection into extension HTTP requests needs a fix in [AnymeXExtensionRuntimeBridge](https://github.com/RyanYuuki/AnymeXExtensionRuntimeBridge) — `m_client.dart` has `getCookiesPref()` returning `{}` and `setCookie()` never saving due to commented-out `loadData`/`saveData` calls. The fix should make `MCookieManager` read cookies from `CookieManager.instance()` before each request.
```