### PR TITLE
feat: ability to clear continue watching entities + some fixes

### DIFF
--- a/lib/controllers/source/source_controller.dart
+++ b/lib/controllers/source/source_controller.dart
@@ -112,12 +112,24 @@ class SourceController extends GetxController implements BaseService {
   void _applyOrderToInstalledList(ItemType type, List<String> orderedIds) {
     final list = _installedFor(type);
     final current = list.toList();
-    if (current.isEmpty) return;
+    if (current.isEmpty || orderedIds.isEmpty) return;
 
     final orderMap = <String, int>{};
     for (var i = 0; i < orderedIds.length; i++) {
       orderMap[orderedIds[i]] = i;
     }
+
+    bool isSorted = true;
+    for (int i = 0; i < current.length - 1; i++) {
+      final aIdx = orderMap[current[i].id?.toString() ?? ''] ?? orderedIds.length;
+      final bIdx = orderMap[current[i + 1].id?.toString() ?? ''] ?? orderedIds.length;
+      if (aIdx > bIdx) {
+        isSorted = false;
+        break;
+      }
+    }
+
+    if (isSorted) return;
 
     final sorted = List<Source>.from(current)
       ..sort((a, b) {
@@ -126,7 +138,7 @@ class SourceController extends GetxController implements BaseService {
         return aIdx.compareTo(bIdx);
       });
 
-    list.value = sorted;
+    list.assignAll(sorted);
   }
 
   void _rebuildSectionsOrder(ItemType type, List<String> orderedIds) {
@@ -192,9 +204,21 @@ class SourceController extends GetxController implements BaseService {
   void onInit() {
     super.onInit();
 
-    ever(installedExtensions, (_) => _scheduleRebuild(ItemType.anime));
-    ever(installedMangaExtensions, (_) => _scheduleRebuild(ItemType.manga));
-    ever(installedNovelExtensions, (_) => _scheduleRebuild(ItemType.novel));
+   
+    _loadExtensionOrders();
+
+    ever(installedExtensions, (_) {
+      _applyOrderToInstalledList(ItemType.anime, _extensionOrders[ItemType.anime] ?? []);
+      _scheduleRebuild(ItemType.anime);
+    });
+    ever(installedMangaExtensions, (_) {
+      _applyOrderToInstalledList(ItemType.manga, _extensionOrders[ItemType.manga] ?? []);
+      _scheduleRebuild(ItemType.manga);
+    });
+    ever(installedNovelExtensions, (_) {
+      _applyOrderToInstalledList(ItemType.novel, _extensionOrders[ItemType.novel] ?? []);
+      _scheduleRebuild(ItemType.novel);
+    });
 
     _initialize();
   }

--- a/lib/screens/anime/studio_details_page.dart
+++ b/lib/screens/anime/studio_details_page.dart
@@ -293,7 +293,13 @@ class _StudioDetailsSheetContentState extends State<StudioDetailsSheetContent> {
             child: Align(
               alignment: Alignment.centerRight,
               child: GestureDetector(
-                onTap: () => showOnlyOnList.value = !showOnlyOnList.value,
+                onTap: () {
+                  if (!anilistAuth.isLoggedIn.value) {
+                    snackBar("Please login to use this filter!");
+                    return;
+                  }
+                  showOnlyOnList.value = !showOnlyOnList.value;
+                },
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -2020,11 +2020,12 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
   }
 
   void changeEpisode(Episode episode) {
-    _basePlayer.pause();
     _trackLocally();
     if (!isOffline.value) {
       _trackOnline(_shouldMarkAsCompleted);
     }
+    _basePlayer.pause();
+    _basePlayer.open('');
     isEpisodePaneOpened.value = false;
     resetListeners();
     fetchEpisode(episode);

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -1585,6 +1585,16 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
     onUserInteraction();
   }
 
+  Future<T?> showSheetWithPause<T>(Future<T?> Function() openSheet) async {
+    final wasPlaying = isPlaying.value;
+    if (wasPlaying) _basePlayer.pause();
+    try {
+      return await openSheet();
+    } finally {
+      if (wasPlaying) _basePlayer.play();
+    }
+  }
+
   void setRate(double rate) {
     playbackSpeed.value = rate;
     _basePlayer.setRate(rate);
@@ -2044,8 +2054,10 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
 
   void openColorProfileBottomSheet(BuildContext context) {
     if (_basePlayer is MediaKitPlayer) {
-      ColorProfileBottomSheet.showColorProfileSheet(
-          context, this, (_basePlayer as MediaKitPlayer).nativePlayer);
+      showSheetWithPause(() async {
+        await ColorProfileBottomSheet.showColorProfileSheet(
+            context, this, (_basePlayer as MediaKitPlayer).nativePlayer);
+      });
     } else {
       snackBar('Color profiles only available with MediaKit player');
     }

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -1712,12 +1712,14 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
     }
   }
 
-  Future<void> setBrightness(double value, {bool isDragging = false}) async {
+  void setBrightness(double value, {bool isDragging = false}) {
     brightness.value = value;
     brightnessIndicator.value = true;
 
     try {
-      await ScreenBrightness.instance.setApplicationScreenBrightness(value);
+      ScreenBrightness.instance
+          .setApplicationScreenBrightness(value)
+          .catchError((_) => 0.0);
     } catch (_) {}
 
     _brightnessTimer?.cancel();

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -1298,7 +1298,7 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
       snackBar('Failed to load episode. Check your connection.');
     } finally {
       PlayerBottomSheets.hideLoader();
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
       updateNavigatorState();
     }
   }
@@ -1712,15 +1712,17 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
     }
   }
 
-  void setBrightness(double value, {bool isDragging = false}) {
+  Future<void> setBrightness(double value, {bool isDragging = false}) async {
     brightness.value = value;
     brightnessIndicator.value = true;
 
-    try {
+    unawaited(
       ScreenBrightness.instance
           .setApplicationScreenBrightness(value)
-          .catchError((_) => 0.0);
-    } catch (_) {}
+          .catchError((e) {
+        Logger.e("Error setting brightness: $e");
+      }),
+    );
 
     _brightnessTimer?.cancel();
 

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -1258,7 +1258,7 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
       }
 
       resetListeners();
-      _basePlayer.open('');
+      await _basePlayer.stop();
       setExternalSub(null);
       currentEpisode.value = episode;
       _hasTrackedInitialLocal = false;
@@ -2029,7 +2029,7 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
       _trackOnline(_shouldMarkAsCompleted);
     }
     _basePlayer.pause();
-    _basePlayer.open('');
+    unawaited(_basePlayer.stop());
     isEpisodePaneOpened.value = false;
     resetListeners();
     fetchEpisode(episode);

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -1298,6 +1298,7 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
       snackBar('Failed to load episode. Check your connection.');
     } finally {
       PlayerBottomSheets.hideLoader();
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
       updateNavigatorState();
     }
   }

--- a/lib/screens/anime/watch/controls/themes/player_control_themes/ios26_player_control_theme.dart
+++ b/lib/screens/anime/watch/controls/themes/player_control_themes/ios26_player_control_theme.dart
@@ -7,6 +7,7 @@ import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
 import 'package:anymex/screens/anime/watch/controls/themes/setup/player_control_theme.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/bottom_sheet.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/control_button.dart';
+import 'package:anymex/screens/anime/watch/controls/widgets/decoder_quick_button.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/progress_slider.dart';
 import 'package:anymex/screens/settings/sub_settings/settings_player.dart';
 import 'package:expressive_loading_indicator/expressive_loading_indicator.dart';
@@ -127,6 +128,7 @@ class Ios26PlayerControlTheme extends PlayerControlTheme {
                       if (qualityText.isEmpty) return const SizedBox.shrink();
                       return _GlassTag(text: qualityText);
                     }),
+                    DecoderQuickButton.glass(isMobile: !isDesktop),
                   ],
                 ),
               ],
@@ -330,13 +332,14 @@ class Ios26PlayerControlTheme extends PlayerControlTheme {
                                     onTap: controller.isLocked.value
                                         ? null
                                         : controller.performSkipAction,
-                                    countdownProgress: controller
-                                            .isAutoSkipCountdownActive
-                                        ? controller.autoSkipCountdownRemaining
-                                            .value /
-                                            PlayerController
-                                                .autoSkipCountdownSeconds
-                                        : null,
+                                    countdownProgress:
+                                        controller.isAutoSkipCountdownActive
+                                            ? controller
+                                                    .autoSkipCountdownRemaining
+                                                    .value /
+                                                PlayerController
+                                                    .autoSkipCountdownSeconds
+                                            : null,
                                   )),
                             ),
                             const SizedBox(height: 8),
@@ -359,12 +362,13 @@ class Ios26PlayerControlTheme extends PlayerControlTheme {
                                 onTap: controller.isLocked.value
                                     ? null
                                     : controller.performSkipAction,
-                                countdownProgress: controller
-                                        .isAutoSkipCountdownActive
-                                    ? controller.autoSkipCountdownRemaining
-                                            .value /
-                                        PlayerController.autoSkipCountdownSeconds
-                                    : null,
+                                countdownProgress:
+                                    controller.isAutoSkipCountdownActive
+                                        ? controller.autoSkipCountdownRemaining
+                                                .value /
+                                            PlayerController
+                                                .autoSkipCountdownSeconds
+                                        : null,
                               )),
                         ),
                       ],
@@ -725,7 +729,8 @@ class _GlassActionChip extends StatelessWidget {
                   child: TweenAnimationBuilder<double>(
                     duration: const Duration(milliseconds: 1000),
                     curve: Curves.linear,
-                    tween: Tween<double>(begin: 0.0, end: 1.0 - countdownProgress!),
+                    tween: Tween<double>(
+                        begin: 0.0, end: 1.0 - countdownProgress!),
                     builder: (context, value, child) {
                       return FractionallySizedBox(
                         alignment: Alignment.centerLeft,
@@ -740,7 +745,8 @@ class _GlassActionChip extends StatelessWidget {
                   ),
                 ),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/lib/screens/anime/watch/controls/themes/player_control_themes/ios26_player_control_theme.dart
+++ b/lib/screens/anime/watch/controls/themes/player_control_themes/ios26_player_control_theme.dart
@@ -149,19 +149,21 @@ class Ios26PlayerControlTheme extends PlayerControlTheme {
             icon: CupertinoIcons.settings_solid,
             tooltip: 'Settings',
             onPressed: () {
-              showModalBottomSheet(
-                context: Get.context!,
-                isScrollControlled: true,
-                backgroundColor: Colors.transparent,
-                builder: (sheetContext) => Container(
-                  height: MediaQuery.of(sheetContext).size.height,
-                  clipBehavior: Clip.antiAlias,
-                  decoration: const BoxDecoration(
-                    color: Colors.transparent,
-                    borderRadius:
-                        BorderRadius.vertical(top: Radius.circular(28)),
+              controller.showSheetWithPause(
+                () => showModalBottomSheet(
+                  context: Get.context!,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  builder: (sheetContext) => Container(
+                    height: MediaQuery.of(sheetContext).size.height,
+                    clipBehavior: Clip.antiAlias,
+                    decoration: const BoxDecoration(
+                      color: Colors.transparent,
+                      borderRadius:
+                          BorderRadius.vertical(top: Radius.circular(28)),
+                    ),
+                    child: const SettingsPlayer(isModal: true),
                   ),
-                  child: const SettingsPlayer(isModal: true),
                 ),
               );
             },

--- a/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_desktop_player_theme.dart.dart
+++ b/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_desktop_player_theme.dart.dart
@@ -4,6 +4,7 @@ import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
 import 'package:anymex/screens/anime/watch/controls/themes/player_control_themes/netflix_shared.dart';
 import 'package:anymex/screens/anime/watch/controls/themes/setup/player_control_theme.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/bottom_sheet.dart';
+import 'package:anymex/screens/anime/watch/controls/widgets/decoder_quick_button.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/progress_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -58,6 +59,11 @@ class NetflixDesktopPlayerControlTheme extends PlayerControlTheme {
                               ),
                             )),
                       ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Padding(
+                      padding: EdgeInsets.only(top: 5),
+                      child: DecoderQuickButton.netflix(),
                     ),
                     const SizedBox(width: 4),
                     NFRawButton(
@@ -156,7 +162,8 @@ class NetflixDesktopPlayerControlTheme extends PlayerControlTheme {
                         NFDesktopButton(
                           icon: Symbols.subtitles_rounded,
                           size: 30,
-                          onTap: () => controller.isTracksPaneOpened.value = !controller.isTracksPaneOpened.value,
+                          onTap: () => controller.isTracksPaneOpened.value =
+                              !controller.isTracksPaneOpened.value,
                         ),
                         const SizedBox(width: 20),
                         NFDesktopButton(

--- a/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_mobile_player_theme.dart
+++ b/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_mobile_player_theme.dart
@@ -4,6 +4,7 @@ import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
 import 'package:anymex/screens/anime/watch/controls/themes/player_control_themes/netflix_shared.dart';
 import 'package:anymex/screens/anime/watch/controls/themes/setup/player_control_theme.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/bottom_sheet.dart';
+import 'package:anymex/screens/anime/watch/controls/widgets/decoder_quick_button.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/progress_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -74,6 +75,11 @@ class NetflixMobilePlayerControlTheme extends PlayerControlTheme {
                               ),
                             )),
                       ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Padding(
+                      padding: EdgeInsets.only(top: 5),
+                      child: DecoderQuickButton.netflix(isMobile: true),
                     ),
                     const SizedBox(width: 4),
                     NFRawButton(
@@ -252,7 +258,9 @@ class NetflixMobilePlayerControlTheme extends PlayerControlTheme {
                               NFLabeledButton(
                                 icon: Symbols.subtitles_rounded,
                                 label: 'Audio & Subtitles',
-                                onTap: () => controller.isTracksPaneOpened.value = !controller.isTracksPaneOpened.value,
+                                onTap: () =>
+                                    controller.isTracksPaneOpened.value =
+                                        !controller.isTracksPaneOpened.value,
                               ),
                               Obx(() => NFLabeledButton(
                                     icon: Icons.skip_next_rounded,

--- a/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_shared.dart
+++ b/lib/screens/anime/watch/controls/themes/player_control_themes/netflix_shared.dart
@@ -23,16 +23,18 @@ String buildNFTitle(PlayerController c) {
 }
 
 void showNFMoreSheet(BuildContext context, PlayerController controller) {
-  showModalBottomSheet(
-    context: context,
-    isDismissible: true,
-    enableDrag: true,
-    isScrollControlled: true,
-    backgroundColor: const Color(0xFF141414),
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+  controller.showSheetWithPause(
+    () => showModalBottomSheet(
+      context: context,
+      isDismissible: true,
+      enableDrag: true,
+      isScrollControlled: true,
+      backgroundColor: const Color(0xFF141414),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => NFMoreSheet(controller: controller, ctx: context),
     ),
-    builder: (_) => NFMoreSheet(controller: controller, ctx: context),
   );
 }
 
@@ -337,13 +339,15 @@ class NFMoreSheet extends StatelessWidget {
               label: 'Player settings',
               onTap: () {
                 Get.back();
-                showModalBottomSheet(
-                  context: Get.context!,
-                  isScrollControlled: true,
-                  backgroundColor: Colors.transparent,
-                  builder: (c) => SizedBox(
-                    height: MediaQuery.of(c).size.height,
-                    child: const SettingsPlayer(isModal: true),
+                controller.showSheetWithPause(
+                  () => showModalBottomSheet(
+                    context: Get.context!,
+                    isScrollControlled: true,
+                    backgroundColor: Colors.transparent,
+                    builder: (c) => SizedBox(
+                      height: MediaQuery.of(c).size.height,
+                      child: const SettingsPlayer(isModal: true),
+                    ),
                   ),
                 );
               },

--- a/lib/screens/anime/watch/controls/themes/setup/json_player_control_theme.dart
+++ b/lib/screens/anime/watch/controls/themes/setup/json_player_control_theme.dart
@@ -10,6 +10,8 @@ import 'package:anymex/screens/settings/sub_settings/settings_player.dart';
 import 'package:expressive_loading_indicator/expressive_loading_indicator.dart';
 import 'package:anymex/widgets/common/marquee_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:anymex/controllers/settings/settings.dart';
 import 'package:get/get.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
 
@@ -562,7 +564,10 @@ class ThemeRenderer {
         final text = _getTitleText();
         if (text.isEmpty) return null;
         return _makeTextThing(
-            value: text, item: item, maxLines: item.grabInt('maxLines', 1), isMarquee: true);
+            value: text,
+            item: item,
+            maxLines: item.grabInt('maxLines', 1),
+            isMarquee: true);
 
       case 'episode_badge':
         return _makeBadgeThing(_getEpisodeLabel(), item);
@@ -576,6 +581,9 @@ class ThemeRenderer {
         final label = _heightToQuality(controller.videoHeight.value);
         if (label.isEmpty) return null;
         return _makeBadgeThing(label, item);
+
+      case 'decoder_button':
+        return _makeDecoderThing(item);
 
       case 'label_stack':
         return _makeLabelStackThing(item);
@@ -866,8 +874,46 @@ class ThemeRenderer {
   Widget _makeChipThing(String text, ThemeItem item) =>
       _makeBadgeThing(text, item);
 
+  Widget _makeDecoderThing(ThemeItem item) {
+    final settings = Get.find<Settings>();
+    final current = settings.hardwareDecoder;
+    final next = _nextDecoder(current);
+
+    return Tooltip(
+      message: '${_decoderLabel(current)} → ${_decoderLabel(next)}',
+      child: GestureDetector(
+        onTap: () {
+          HapticFeedback.lightImpact();
+          settings.hardwareDecoder = next;
+        },
+        child: _makeBadgeThing(_decoderLabel(current), item),
+      ),
+    );
+  }
+
+  String _nextDecoder(String current) {
+    if (Platform.isAndroid) {
+      return switch (current) {
+        'hw' => 'hw+',
+        'hw+' => 'sw',
+        _ => 'hw',
+      };
+    }
+    return current == 'hw' ? 'sw' : 'hw';
+  }
+
+  String _decoderLabel(String value) => switch (value) {
+        'hw+' => 'HW+',
+        'hw' => 'HW',
+        'sw' => 'SW',
+        _ => value.toUpperCase(),
+      };
+
   Widget _makeTextThing(
-      {required String value, required ThemeItem item, int maxLines = 1, bool isMarquee = false}) {
+      {required String value,
+      required ThemeItem item,
+      int maxLines = 1,
+      bool isMarquee = false}) {
     final style = def.styles.text.mash(item.style);
     final textColor = _resolveColor(style.textColor, fallback: Colors.white);
     final textAlign = _parseTextAlign(item.grabString('textAlign'));
@@ -1148,17 +1194,21 @@ class ThemeRenderer {
         break;
       case 'subtitles':
       case 'source':
-        controller.isSourcePaneOpened.value = !controller.isSourcePaneOpened.value;
+        controller.isSourcePaneOpened.value =
+            !controller.isSourcePaneOpened.value;
         break;
       case 'server':
-        controller.isSourcePaneOpened.value = !controller.isSourcePaneOpened.value;
+        controller.isSourcePaneOpened.value =
+            !controller.isSourcePaneOpened.value;
         break;
       case 'sync_subs':
-        controller.isSyncSubsPaneOpened.value = !controller.isSyncSubsPaneOpened.value;
+        controller.isSyncSubsPaneOpened.value =
+            !controller.isSyncSubsPaneOpened.value;
         break;
       case 'tracks':
       case 'audio_track':
-        controller.isTracksPaneOpened.value = !controller.isTracksPaneOpened.value;
+        controller.isTracksPaneOpened.value =
+            !controller.isTracksPaneOpened.value;
         break;
       case 'quality':
         if (!controller.isOffline.value) {
@@ -2264,7 +2314,8 @@ BottomSlotDef _defaultBottomLocked() {
 const Set<String> _badgeIds = {
   'episode_badge',
   'series_badge',
-  'quality_badge'
+  'quality_badge',
+  'decoder_button',
 };
 
 const Map<String, IconData> _iconMap = {
@@ -2314,6 +2365,7 @@ final Set<String> _supportedThemeItemIds = {
   'episode_badge',
   'series_badge',
   'quality_badge',
+  'decoder_button',
   'label_stack',
   'watching_label',
   'text',

--- a/lib/screens/anime/watch/controls/themes/setup/json_player_control_theme.dart
+++ b/lib/screens/anime/watch/controls/themes/setup/json_player_control_theme.dart
@@ -1186,18 +1186,20 @@ class ThemeRenderer {
   }
 
   void _popSettingsSheet() {
-    showModalBottomSheet(
-      context: Get.context ?? context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetCtx) => Container(
-        height: MediaQuery.of(sheetCtx).size.height,
-        clipBehavior: Clip.antiAlias,
-        decoration: const BoxDecoration(
-          color: Colors.transparent,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    controller.showSheetWithPause(
+      () => showModalBottomSheet(
+        context: Get.context ?? context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        builder: (sheetCtx) => Container(
+          height: MediaQuery.of(sheetCtx).size.height,
+          clipBehavior: Clip.antiAlias,
+          decoration: const BoxDecoration(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+          ),
+          child: const SettingsPlayer(isModal: true),
         ),
-        child: const SettingsPlayer(isModal: true),
       ),
     );
   }

--- a/lib/screens/anime/watch/controls/top_controls.dart
+++ b/lib/screens/anime/watch/controls/top_controls.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 
 import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
 import 'package:anymex/screens/anime/watch/controls/widgets/control_button.dart';
+import 'package:anymex/screens/anime/watch/controls/widgets/decoder_quick_button.dart';
 import 'package:anymex/screens/settings/sub_settings/settings_player.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:flutter/material.dart';
@@ -92,7 +93,7 @@ class TopControls extends StatelessWidget {
     final controller = Get.find<PlayerController>();
     final isDark = theme.brightness == Brightness.dark;
 
-    if (controller.currentOrientation.value == DeviceOrientation.portraitUp || 
+    if (controller.currentOrientation.value == DeviceOrientation.portraitUp ||
         controller.currentOrientation.value == DeviceOrientation.portraitDown) {
       return _buildMobilePortrait(theme, controller, isDark);
     }
@@ -189,6 +190,8 @@ class TopControls extends StatelessWidget {
             () => _QualityChip(
                 videoHeight: controller.videoHeight.value, isMobile: true),
           ),
+          const SizedBox(width: 8),
+          const DecoderQuickButton(isMobile: true),
           const SizedBox(width: 8),
           ControlButton(
             icon: Icons.lock_rounded,
@@ -332,6 +335,8 @@ class TopControls extends StatelessWidget {
               videoHeight: controller.videoHeight.value, isMobile: false),
         ),
         const SizedBox(width: 8),
+        const DecoderQuickButton(isMobile: false),
+        const SizedBox(width: 8),
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           decoration: BoxDecoration(
@@ -389,13 +394,16 @@ class TopControls extends StatelessWidget {
     );
   }
 
-  Widget _buildMobilePortrait(ThemeData theme, PlayerController controller, bool isDark) {
+  Widget _buildMobilePortrait(
+      ThemeData theme, PlayerController controller, bool isDark) {
     final titleStyle = theme.textTheme.titleSmall?.copyWith(
       color: Get.isDarkMode ? theme.colorScheme.onSurface : Colors.white,
       fontWeight: FontWeight.w600,
       letterSpacing: 0.2,
     );
-    final titleText = controller.currentEpisode.value.title ?? controller.itemName ?? 'Unknown Title';
+    final titleText = controller.currentEpisode.value.title ??
+        controller.itemName ??
+        'Unknown Title';
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -412,7 +420,10 @@ class TopControls extends StatelessWidget {
                 isPrimary: true,
               ),
               const Spacer(),
-              Obx(() => _QualityChip(videoHeight: controller.videoHeight.value, isMobile: true)),
+              Obx(() => _QualityChip(
+                  videoHeight: controller.videoHeight.value, isMobile: true)),
+              const SizedBox(width: 8),
+              const DecoderQuickButton(isMobile: true),
               const SizedBox(width: 8),
               ControlButton(
                 icon: Icons.lock_rounded,
@@ -434,7 +445,8 @@ class TopControls extends StatelessWidget {
                         clipBehavior: Clip.antiAlias,
                         decoration: const BoxDecoration(
                           color: Colors.transparent,
-                          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+                          borderRadius:
+                              BorderRadius.vertical(top: Radius.circular(28)),
                         ),
                         child: const SettingsPlayer(isModal: true),
                       ),
@@ -454,7 +466,9 @@ class TopControls extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                 decoration: BoxDecoration(
-                  color: isDark ? theme.colorScheme.primary.opaque(0.15) : theme.colorScheme.primaryContainer,
+                  color: isDark
+                      ? theme.colorScheme.primary.opaque(0.15)
+                      : theme.colorScheme.primaryContainer,
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -462,7 +476,9 @@ class TopControls extends StatelessWidget {
                       ? "Offline"
                       : "Episode ${controller.currentEpisode.value.number}",
                   style: theme.textTheme.bodySmall?.copyWith(
-                    color: isDark ? theme.colorScheme.primary : theme.colorScheme.onPrimaryContainer,
+                    color: isDark
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.onPrimaryContainer,
                     fontWeight: FontWeight.w600,
                     fontSize: 12,
                   ),
@@ -475,13 +491,20 @@ class TopControls extends StatelessWidget {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
             decoration: BoxDecoration(
-              color: isDark ? theme.colorScheme.primary.opaque(0.15) : theme.colorScheme.primaryContainer,
+              color: isDark
+                  ? theme.colorScheme.primary.opaque(0.15)
+                  : theme.colorScheme.primaryContainer,
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
-              (controller.anilistData.title == "?" ? controller.folderName : controller.anilistData.title) ?? '',
+              (controller.anilistData.title == "?"
+                      ? controller.folderName
+                      : controller.anilistData.title) ??
+                  '',
               style: theme.textTheme.bodySmall?.copyWith(
-                color: isDark ? theme.colorScheme.primary : theme.colorScheme.onPrimaryContainer,
+                color: isDark
+                    ? theme.colorScheme.primary
+                    : theme.colorScheme.onPrimaryContainer,
                 fontWeight: FontWeight.w600,
                 fontSize: 12,
               ),

--- a/lib/screens/anime/watch/controls/top_controls.dart
+++ b/lib/screens/anime/watch/controls/top_controls.dart
@@ -200,22 +200,24 @@ class TopControls extends StatelessWidget {
           ControlButton(
             icon: Icons.settings_rounded,
             onPressed: () {
-              showModalBottomSheet(
-                  context: Get.context!,
-                  isScrollControlled: true,
-                  backgroundColor: Colors.transparent,
-                  builder: (context) => Container(
-                        height: MediaQuery.of(context).size.height,
-                        clipBehavior: Clip.antiAlias,
-                        decoration: const BoxDecoration(
-                          color: Colors.transparent,
-                          borderRadius:
-                              BorderRadius.vertical(top: Radius.circular(28)),
-                        ),
-                        child: const SettingsPlayer(
-                          isModal: true,
-                        ),
-                      ));
+              Get.find<PlayerController>().showSheetWithPause(
+                () => showModalBottomSheet(
+                    context: Get.context!,
+                    isScrollControlled: true,
+                    backgroundColor: Colors.transparent,
+                    builder: (context) => Container(
+                          height: MediaQuery.of(context).size.height,
+                          clipBehavior: Clip.antiAlias,
+                          decoration: const BoxDecoration(
+                            color: Colors.transparent,
+                            borderRadius:
+                                BorderRadius.vertical(top: Radius.circular(28)),
+                          ),
+                          child: const SettingsPlayer(
+                            isModal: true,
+                          ),
+                        )),
+              );
             },
             tooltip: 'Settings',
             compact: true,
@@ -357,22 +359,24 @@ class TopControls extends StatelessWidget {
               ControlButton(
                 icon: Icons.settings_rounded,
                 onPressed: () {
-                  showModalBottomSheet(
-                      context: Get.context!,
-                      isScrollControlled: true,
-                      backgroundColor: Colors.transparent,
-                      builder: (context) => Container(
-                            height: MediaQuery.of(context).size.height,
-                            clipBehavior: Clip.antiAlias,
-                            decoration: const BoxDecoration(
-                              color: Colors.transparent,
-                              borderRadius: BorderRadius.vertical(
-                                  top: Radius.circular(28)),
-                            ),
-                            child: const SettingsPlayer(
-                              isModal: true,
-                            ),
-                          ));
+                  Get.find<PlayerController>().showSheetWithPause(
+                    () => showModalBottomSheet(
+                        context: Get.context!,
+                        isScrollControlled: true,
+                        backgroundColor: Colors.transparent,
+                        builder: (context) => Container(
+                              height: MediaQuery.of(context).size.height,
+                              clipBehavior: Clip.antiAlias,
+                              decoration: const BoxDecoration(
+                                color: Colors.transparent,
+                                borderRadius: BorderRadius.vertical(
+                                    top: Radius.circular(28)),
+                              ),
+                              child: const SettingsPlayer(
+                                isModal: true,
+                              ),
+                            )),
+                  );
                 },
                 tooltip: 'Settings',
                 compact: true,
@@ -420,18 +424,20 @@ class TopControls extends StatelessWidget {
               ControlButton(
                 icon: Icons.settings_rounded,
                 onPressed: () {
-                  showModalBottomSheet(
-                    context: Get.context!,
-                    isScrollControlled: true,
-                    backgroundColor: Colors.transparent,
-                    builder: (context) => Container(
-                      height: MediaQuery.of(context).size.height,
-                      clipBehavior: Clip.antiAlias,
-                      decoration: const BoxDecoration(
-                        color: Colors.transparent,
-                        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+                  Get.find<PlayerController>().showSheetWithPause(
+                    () => showModalBottomSheet(
+                      context: Get.context!,
+                      isScrollControlled: true,
+                      backgroundColor: Colors.transparent,
+                      builder: (context) => Container(
+                        height: MediaQuery.of(context).size.height,
+                        clipBehavior: Clip.antiAlias,
+                        decoration: const BoxDecoration(
+                          color: Colors.transparent,
+                          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+                        ),
+                        child: const SettingsPlayer(isModal: true),
                       ),
-                      child: const SettingsPlayer(isModal: true),
                     ),
                   );
                 },

--- a/lib/screens/anime/watch/controls/widgets/bottom_sheet.dart
+++ b/lib/screens/anime/watch/controls/widgets/bottom_sheet.dart
@@ -461,13 +461,15 @@ class PlayerBottomSheets {
       onItemSelected: onItemSelected,
       customContent: customContent,
     );
-    return showModalBottomSheet<T>(
-      context: context,
-      isScrollControlled: true,
-      isDismissible: isDismissible,
-      backgroundColor: Colors.transparent,
-      builder: (context) =>
-          !isExpanded ? sheet : SizedBox(height: double.infinity, child: sheet),
+    return Get.find<PlayerController>().showSheetWithPause(
+      () => showModalBottomSheet<T>(
+        context: context,
+        isScrollControlled: true,
+        isDismissible: isDismissible,
+        backgroundColor: Colors.transparent,
+        builder: (context) =>
+            !isExpanded ? sheet : SizedBox(height: double.infinity, child: sheet),
+      ),
     );
   }
 
@@ -522,15 +524,17 @@ class PlayerBottomSheets {
       title: title,
       customContent: content,
     );
-    return showModalBottomSheet<T>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => isExpanded
-          ? SizedBox(
-              height: MediaQuery.of(context).size.height * expandedHeightFactor,
-              child: sheet)
-          : sheet,
+    return Get.find<PlayerController>().showSheetWithPause(
+      () => showModalBottomSheet<T>(
+        context: context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        builder: (context) => isExpanded
+            ? SizedBox(
+                height: MediaQuery.of(context).size.height * expandedHeightFactor,
+                child: sheet)
+            : sheet,
+      ),
     );
   }
 

--- a/lib/screens/anime/watch/controls/widgets/decoder_quick_button.dart
+++ b/lib/screens/anime/watch/controls/widgets/decoder_quick_button.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:anymex/controllers/settings/settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+class DecoderQuickButton extends StatelessWidget {
+  final bool isMobile;
+  final bool _glass;
+  final bool _netflix;
+
+  const DecoderQuickButton({super.key, this.isMobile = false})
+      : _glass = false,
+        _netflix = false;
+
+  const DecoderQuickButton.glass({super.key, this.isMobile = false})
+      : _glass = true,
+        _netflix = false;
+
+  const DecoderQuickButton.netflix({super.key, this.isMobile = false})
+      : _glass = false,
+        _netflix = true;
+
+  String _next(String current) {
+    if (Platform.isAndroid) {
+      return switch (current) {
+        'hw' => 'hw+',
+        'hw+' => 'sw',
+        _ => 'hw',
+      };
+    }
+    return current == 'hw' ? 'sw' : 'hw';
+  }
+
+  String _label(String v) => switch (v) {
+        'hw+' => 'HW+',
+        'hw' => 'HW',
+        'sw' => 'SW',
+        _ => v.toUpperCase(),
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final settings = Get.find<Settings>();
+
+    return Obx(() {
+      final current = settings.hardwareDecoder;
+
+      final Color bg;
+      final Border? border;
+      final double radius;
+      final EdgeInsets pad;
+      final TextStyle? style;
+
+      if (_glass) {
+        bg = const Color(0x24FFFFFF);
+        border = Border.all(color: const Color(0x40FFFFFF));
+        radius = 12;
+        pad = const EdgeInsets.symmetric(horizontal: 10, vertical: 4);
+        style = const TextStyle(
+            color: Colors.white, fontSize: 12, fontWeight: FontWeight.w600);
+      } else if (_netflix) {
+        bg = const Color(0x99000000);
+        border = Border.all(color: const Color(0x66FFFFFF));
+        radius = 8;
+        pad = const EdgeInsets.symmetric(horizontal: 10, vertical: 8);
+        style = const TextStyle(
+            color: Colors.white,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.2);
+      } else {
+        bg = isDark
+            ? theme.colorScheme.secondaryContainer.withValues(alpha: 0.15)
+            : theme.colorScheme.secondaryContainer;
+        border = null;
+        radius = isMobile ? 8.0 : 12.0;
+        pad = EdgeInsets.symmetric(
+            horizontal: isMobile ? 8 : 12, vertical: isMobile ? 2 : 4);
+        final color = isDark
+            ? theme.colorScheme.secondary
+            : theme.colorScheme.onSecondaryContainer;
+        style =
+            (isMobile ? theme.textTheme.bodySmall : theme.textTheme.bodyMedium)
+                ?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w600,
+                    fontSize: isMobile ? 12 : null);
+      }
+
+      return Tooltip(
+        message: '${_label(current)} → ${_label(_next(current))}',
+        child: GestureDetector(
+          onTap: () {
+            HapticFeedback.lightImpact();
+            settings.hardwareDecoder = _next(current);
+          },
+          child: Container(
+            padding: pad,
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(radius),
+              border: border,
+            ),
+            child: Text(_label(current), style: style),
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/screens/anime/watch/player/base_player.dart
+++ b/lib/screens/anime/watch/player/base_player.dart
@@ -41,6 +41,8 @@ abstract class BasePlayer {
 
   Future<void> pause();
 
+  Future<void> stop();
+
   Future<void> playOrPause();
 
   Future<void> setRate(double rate);

--- a/lib/screens/anime/watch/player/media_kit_player.dart
+++ b/lib/screens/anime/watch/player/media_kit_player.dart
@@ -216,6 +216,11 @@ class MediaKitPlayer extends base.BasePlayer {
   }
 
   @override
+  Future<void> stop() async {
+    await _player.stop();
+  }
+
+  @override
   Future<void> playOrPause() async {
     await _player.playOrPause();
   }

--- a/lib/screens/anime/watch/watch_view.dart
+++ b/lib/screens/anime/watch/watch_view.dart
@@ -65,8 +65,10 @@ class _WatchScreenState extends State<WatchScreen> {
         body: Stack(
       children: [
         Obx(() {
-          controller.playerReloadVersion.value;
-          return controller.videoWidget;
+          return KeyedSubtree(
+            key: ValueKey(controller.playerReloadVersion.value),
+            child: controller.videoWidget,
+          );
         }),
         PlayerOverlay(controller: controller),
         BufferingOverlay(controller: controller),

--- a/lib/screens/anime/widgets/character_staff_sheet.dart
+++ b/lib/screens/anime/widgets/character_staff_sheet.dart
@@ -818,8 +818,14 @@ class _CharacterStaffSheetContentState
                                       size: 16,
                                     ),
                                     GestureDetector(
-                                      onTap: () => showOnlyOnList.value =
-                                          !showOnlyOnList.value,
+                                      onTap: () {
+                                        if (!anilistAuth.isLoggedIn.value) {
+                                          snackBar("Please login to use this filter!");
+                                          return;
+                                        }
+                                        showOnlyOnList.value =
+                                            !showOnlyOnList.value;
+                                      },
                                       child: Row(
                                         children: [
                                           Obx(() => AnimatedContainer(

--- a/lib/screens/downloads/controller/download_controller.dart
+++ b/lib/screens/downloads/controller/download_controller.dart
@@ -71,7 +71,12 @@ class DownloadController extends GetxController {
     _initForegroundTask();
 
     Future.delayed(const Duration(seconds: 3), () async {
-      if (!await FlutterForegroundTask.isRunningService) {
+      bool isRunning = false;
+      if (Platform.isAndroid || Platform.isIOS) {
+        isRunning = await FlutterForegroundTask.isRunningService;
+      }
+      
+      if (!isRunning) {
         for (final task in activeTasks) {
           if (task.status == DownloadStatus.downloading ||
               task.status == DownloadStatus.queued) {
@@ -95,6 +100,8 @@ class DownloadController extends GetxController {
   }
 
   void _initForegroundTask() {
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+
     FlutterForegroundTask.init(
       androidNotificationOptions: AndroidNotificationOptions(
         channelId: 'anymex_downloads',
@@ -125,6 +132,7 @@ class DownloadController extends GetxController {
   }
 
   void _attachReceivePortListener() {
+    if (!Platform.isAndroid && !Platform.isIOS) return;
     if (_receivePortListening) return;
     final port = FlutterForegroundTask.receivePort;
     if (port == null) return;
@@ -133,7 +141,7 @@ class DownloadController extends GetxController {
   }
 
   Future<void> _startBackgroundServiceIfNotRunning() async {
-    if (Platform.isIOS) return;
+    if (!Platform.isAndroid) return;
     if (!await FlutterForegroundTask.isRunningService) {
       await FlutterForegroundTask.startService(
         notificationTitle: 'AnymeX Downloads',
@@ -898,7 +906,12 @@ class DownloadController extends GetxController {
       activeMangaTasks.refresh();
       _saveMangaActiveTasks();
 
-      if (await FlutterForegroundTask.isRunningService) {
+      bool isRunning = false;
+      if (Platform.isAndroid || Platform.isIOS) {
+        isRunning = await FlutterForegroundTask.isRunningService;
+      }
+
+      if (isRunning) {
         _sendToBackground({
           'type': 'CANCEL_TASK',
           'taskId': taskId,
@@ -967,7 +980,12 @@ class DownloadController extends GetxController {
   Future<void> cancelDownload(String taskId) async {
     dl.DownloadIsolatePool.instance.cancelTask(taskId);
 
-    if (await FlutterForegroundTask.isRunningService) {
+    bool isRunning = false;
+    if (Platform.isAndroid || Platform.isIOS) {
+      isRunning = await FlutterForegroundTask.isRunningService;
+    }
+
+    if (isRunning) {
       _sendToBackground({
         'type': 'CANCEL_TASK',
         'taskId': taskId,

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -27,8 +27,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:thanos_snap_effect/thanos_snap_effect.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:get/get.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({
@@ -43,6 +43,8 @@ class _HomePageState extends State<HomePage> {
   late ScrollController _scrollController;
   final ValueNotifier<bool> _isAppBarVisibleExternally =
       ValueNotifier<bool>(true);
+  bool _snapAll = false;
+  late final Stream<List<OfflineMedia>> _animeLibraryStream;
 
   Widget _buildRecentlyOpenedSection(CacheController cacheController) {
     final data = cacheController.getStoredAnime();
@@ -69,7 +71,7 @@ class _HomePageState extends State<HomePage> {
   Widget _buildContinueWatchingSection(
       OfflineStorageController offlineStorageController) {
     return StreamBuilder<List<OfflineMedia>>(
-      stream: offlineStorageController.watchAnimeLibrary(),
+      stream: _animeLibraryStream,
       builder: (context, snapshot) {
         final historyData = (snapshot.data ?? const <OfflineMedia>[])
             .where((e) => e.currentEpisode?.currentTrack != null)
@@ -86,14 +88,31 @@ class _HomePageState extends State<HomePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.only(left: 20.0),
-              child: Text(
-                "Local History",
-                style: TextStyle(
-                  fontFamily: "Poppins-SemiBold",
-                  fontSize: 17,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+              padding: const EdgeInsets.only(left: 20.0, right: 20.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    "Local History",
+                    style: TextStyle(
+                      fontFamily: "Poppins-SemiBold",
+                      fontSize: 17,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: () => _showClearAllHistoryDialog(
+                        context, offlineStorageController, visibleHistory),
+                    child: Text(
+                      "Clear All",
+                      style: TextStyle(
+                        fontFamily: "Poppins-SemiBold",
+                        fontSize: 13,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
             const SizedBox(height: 10),
@@ -110,9 +129,17 @@ class _HomePageState extends State<HomePage> {
                     mainAxisSpacing: 0,
                     mainAxisExtent: 300,
                   ),
-                  itemBuilder: (context, i) => ContinueWatchingCard(
+                  itemBuilder: (context, i) => _RemovableHistoryCard(
+                    key: ValueKey(visibleHistory[i].mediaId),
                     media: HistoryModel.fromOfflineMedia(
                         visibleHistory[i], ItemType.anime),
+                    snapAll: _snapAll,
+                    onRemoved: () {
+                      offlineStorageController.clearMediaHistory(
+                        visibleHistory[i].mediaId ?? '',
+                        mediaType: ItemType.anime,
+                      );
+                    },
                   ),
                 ),
               ),
@@ -120,6 +147,32 @@ class _HomePageState extends State<HomePage> {
           ],
         );
       },
+    );
+  }
+
+  void _showClearAllHistoryDialog(BuildContext context,
+      OfflineStorageController controller, List<OfflineMedia> items) {
+    showDialog(
+      context: context,
+      builder: (context) => AnymexDialog(
+        title: 'Clear All History',
+        contentWidget: const Text(
+          'Are you sure you want to clear all local watch history? This action cannot be undone.',
+          style: TextStyle(fontFamily: 'Poppins', fontSize: 14),
+        ),
+        confirmText: 'Clear All',
+        onConfirm: () {
+          HapticFeedback.mediumImpact();
+          setState(() => _snapAll = true);
+          Future.delayed(const Duration(milliseconds: 1500), () {
+            controller.clearMediaHistoryBulk(
+              items.map((e) => e.mediaId ?? ''),
+              mediaType: ItemType.anime,
+            );
+            if (mounted) setState(() => _snapAll = false);
+          });
+        },
+      ),
     );
   }
 
@@ -166,6 +219,7 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    _animeLibraryStream = Get.find<OfflineStorageController>().watchAnimeLibrary();
     _scrollController = ScrollController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _showDiscordDialog();
@@ -463,6 +517,67 @@ class ImageButton extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _RemovableHistoryCard extends StatefulWidget {
+  final HistoryModel media;
+  final VoidCallback onRemoved;
+  final bool snapAll;
+
+  const _RemovableHistoryCard({
+    super.key,
+    required this.media,
+    required this.onRemoved,
+    this.snapAll = false,
+  });
+
+  @override
+  State<_RemovableHistoryCard> createState() => _RemovableHistoryCardState();
+}
+
+class _RemovableHistoryCardState extends State<_RemovableHistoryCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1500),
+  );
+
+  @override
+  void didUpdateWidget(covariant _RemovableHistoryCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.snapAll && !oldWidget.snapAll) {
+      _controller.forward(from: 0);
+    }
+  }
+
+  void _triggerRemoval() {
+    HapticFeedback.lightImpact();
+    _controller.forward(from: 0).then((_) => widget.onRemoved());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Snappable(
+      animation: _controller,
+      outerPadding: const EdgeInsets.all(20),
+      style: const SnappableStyle(
+        particleLifetime: 0.6,
+        fadeOutDuration: 0.3,
+        particleSpeed: 1.0,
+        particleSize: SnappableParticleSize.squareFromRelativeWidth(0.008),
+      ),
+      child: ContinueWatchingCard(
+        media: widget.media,
+        onRemove: _triggerRemoval,
       ),
     );
   }

--- a/lib/utils/color_profiler.dart
+++ b/lib/utils/color_profiler.dart
@@ -234,9 +234,9 @@ class ColorProfileBottomSheet extends StatefulWidget {
     required this.player,
   });
 
-  static void showColorProfileSheet(
+  static Future<void> showColorProfileSheet(
       BuildContext context, PlayerController controller, dynamic player) {
-    showGeneralDialog(
+    return showGeneralDialog(
       context: context,
       barrierDismissible: true,
       barrierLabel: 'Color Profile',

--- a/lib/widgets/anime/continue_watching_cards.dart
+++ b/lib/widgets/anime/continue_watching_cards.dart
@@ -9,8 +9,9 @@ import 'package:flutter/material.dart';
 
 class ContinueWatchingCard extends StatelessWidget {
   final HistoryModel media;
+  final VoidCallback? onRemove;
 
-  const ContinueWatchingCard({super.key, required this.media});
+  const ContinueWatchingCard({super.key, required this.media, this.onRemove});
 
   @override
   Widget build(BuildContext context) {
@@ -95,6 +96,26 @@ class ContinueWatchingCard extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (onRemove != null)
+                  Positioned(
+                    top: 6,
+                    left: 6,
+                    child: GestureDetector(
+                      onTap: onRemove,
+                      child: Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: BoxDecoration(
+                          color:
+                              Colors.black.opaque(0.65, iReallyMeanIt: true),
+                          shape: BoxShape.circle,
+                          border:
+                              Border.all(color: Colors.white24, width: 0.5),
+                        ),
+                        child: const Icon(Icons.close_rounded,
+                            size: 14, color: Colors.white),
+                      ),
+                    ),
+                  ),
                 Positioned.fill(
                   child: Center(
                     child: Container(

--- a/lib/widgets/common/no_source.dart
+++ b/lib/widgets/common/no_source.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:anymex/screens/extensions/ExtensionScreen.dart';
 import 'package:flutter/material.dart';
 import 'package:anymex/utils/theme_extensions.dart';
 
@@ -39,12 +40,12 @@ class NoSourceSelectedWidget extends StatelessWidget {
             ElevatedButton.icon(
               onPressed: () {
                 if (isMobile) {
-                  // Navigator.pushReplacement(
-                  //   context,
-                  //   MaterialPageRoute(
-                  //     builder: (context) => const ExtensionScreen(),
-                  //   ),
-                  // );
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const ExtensionScreen(),
+                    ),
+                  );
                 } else {
                   Navigator.pop(
                     context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2057,6 +2057,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  thanos_snap_effect:
+    dependency: "direct main"
+    description:
+      name: thanos_snap_effect
+      sha256: "728595a48480c58244d9851f2182b6d43f78470074697c61e1ffc061f8a1234f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.9"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -122,6 +122,7 @@ dependencies:
     #     path: ../AnymeXExtensionRuntimeBridge
     jxl_coder: ^0.1.0
     libtorrent_flutter: ^1.0.3
+    thanos_snap_effect: ^0.0.9
 
 dev_dependencies:
     build_runner: ^2.4.11
@@ -159,6 +160,9 @@ flutter_native_splash:
 
 flutter:
     uses-material-design: true
+
+    shaders:
+        - packages/thanos_snap_effect/shader/thanos_snap_effect.glsl
 
     assets:
         - assets/images/


### PR DESCRIPTION
### Feet:
- feet : clear continue watching cards with cool(useless) snap effect
- feet : auto pause/play video when opened sheets
- feet: quick button  to switch between video decoders

### Fixes:
- fixed status Bar I remaining visible during EP changed
- fixed Linux App Crash during Browser Login
- fixed a race where download crashed on Linux i guess
- fixed Audio Bleeding for 2–3 seconds on Episode Switch
- fixed Brightness Slider Stuck on Screen for IOS
- fixed  closing and reopen extension selector resetting to unordered list
- fixed "go to ext" button not working
- fixed login required conditions where necessary 