### PR TITLE
Fix(simkl): Resolve movie episode titles and list editor season/episode count parsing

### DIFF
--- a/lib/controllers/services/simkl/simkl_service.dart
+++ b/lib/controllers/services/simkl/simkl_service.dart
@@ -23,6 +23,7 @@ import 'package:anymex/screens/home_page.dart';
 import 'package:anymex/screens/library/online/anime_list.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/logger.dart';
+import 'package:anymex/utils/media_syncer.dart';
 import 'package:anymex/widgets/common/big_carousel_gate.dart';
 import 'package:anymex/widgets/common/reusable_carousel.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
@@ -424,19 +425,21 @@ class SimklService extends GetxController
           if (decoded is! List || decoded.isEmpty) return {};
           final seasons = <int, int>{};
           for (final ep in decoded) {
-            int s = 1;
+            final isSpecial = ep['type'] == 'special';
+            int? s;
             final directSeason = ep['season'];
             if (directSeason != null) {
               s = directSeason is int
                   ? directSeason
-                  : int.tryParse(directSeason.toString()) ?? 1;
+                  : int.tryParse(directSeason.toString());
             } else if (ep['tvdb'] is Map && ep['tvdb']['season'] != null) {
               final tvdbSeason = ep['tvdb']['season'];
               s = tvdbSeason is int
                   ? tvdbSeason
-                  : int.tryParse(tvdbSeason.toString()) ?? 1;
+                  : int.tryParse(tvdbSeason.toString());
             }
-            seasons[s] = (seasons[s] ?? 0) + 1;
+            final finalSeason = (isSpecial || s == null || s <= 0) ? 0 : s;
+            seasons[finalSeason] = (seasons[finalSeason] ?? 0) + 1;
           }
           Logger.i('[Simkl/$endpointType] Season map for $id: $seasons');
           return seasons;
@@ -589,6 +592,124 @@ class SimklService extends GetxController
     } catch (e, stack) {
       Logger.i('Exception: $e\n$stack');
       errorSnackBar('An unexpected error occurred');
+    }
+  }
+
+  /// Syncs anime progress to Simkl using an external ID (e.g. AniList ID or MAL ID).
+  /// Resolves the external ID to Simkl ID via `MediaSyncer.getSimklIdFromExternal`.
+  Future<void> updateListEntryFromExternalId({
+    String? anilistId,
+    String? malId,
+    double? score,
+    String? status,
+    int? progress,
+    int? season,
+    bool isAnime = true,
+  }) async {
+    if (!isLoggedIn.value) {
+      return;
+    }
+    try {
+      final simklId = await MediaSyncer.getSimklIdFromExternal(
+        anilistId: anilistId,
+        malId: malId,
+      );
+
+      if (simklId != null) {
+        await updateListEntry(UpdateListEntryParams(
+          listId: simklId,
+          score: score,
+          status: status,
+          progress: progress,
+          season: season,
+          isAnime: isAnime,
+        ));
+      } else if (anilistId != null || malId != null) {
+        // Fallback: If redirect resolution yielded no ID, update via external IDs directly in Simkl sync API
+        final token = AuthKeys.simklAuthToken.get<String?>();
+        final apiKey = dotenv.env['SIMKL_CLIENT_ID'];
+        if (token == null || apiKey == null) return;
+
+        final ids = <String, dynamic>{
+          if (anilistId != null) 'anilist': int.tryParse(anilistId) ?? anilistId,
+          if (malId != null) 'mal': int.tryParse(malId) ?? malId,
+        };
+
+        if (status != null) {
+          final url = Uri.parse('https://api.simkl.com/sync/add-to-list');
+          final newStatus = Simkl.alToSimklShow(status);
+          final body = {
+            'shows': [
+              {
+                'to': newStatus,
+                'ids': ids,
+              }
+            ]
+          };
+          await post(
+            url,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(body),
+          );
+        }
+
+        if (progress != null && progress > 0 && status != 'PLANNING') {
+          final historyUrl = Uri.parse('https://api.simkl.com/sync/history');
+          final effectiveSeason = (season != null && season > 0) ? season : 1;
+          final historyBody = {
+            'shows': [
+              {
+                'ids': ids,
+                'seasons': [
+                  {
+                    'number': effectiveSeason,
+                    'episodes': [
+                      for (int i = 1; i <= progress; i++) {'number': i}
+                    ]
+                  }
+                ]
+              }
+            ]
+          };
+          await post(
+            historyUrl,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(historyBody),
+          );
+        }
+
+        if (score != null && score > 0) {
+          final ratingsUrl = Uri.parse('https://api.simkl.com/sync/ratings');
+          final ratingsBody = {
+            'shows': [
+              {
+                'rating': score.toInt(),
+                'ids': ids,
+              }
+            ]
+          };
+          await post(
+            ratingsUrl,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(ratingsBody),
+          );
+        }
+        fetchUserSeriesList();
+      }
+    } catch (e, stack) {
+      Logger.i('Exception in updateListEntryFromExternalId: $e\n$stack');
     }
   }
 

--- a/lib/models/Anilist/anilist_media_user.dart
+++ b/lib/models/Anilist/anilist_media_user.dart
@@ -123,7 +123,11 @@ class TrackedMedia {
           ? "https://wsrv.nl/?url=https://simkl.in/posters/${show['poster']}_m.jpg"
           : '?',
       episodeCount: json['watched_episodes_count']?.toString(),
-      totalEpisodes: json['total_episodes_count']?.toString(),
+      totalEpisodes: (json['total_episodes_count'] ??
+              json['total_episodes'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString(),
       watchingStatus: Simkl.simklShowToAL(json['status']),
       type: "show",
       servicesType: ServicesType.simkl,

--- a/lib/models/Media/media.dart
+++ b/lib/models/Media/media.dart
@@ -281,7 +281,12 @@ class Media {
       cover: json['fanart'] != null
           ? 'https://wsrv.nl/?url=https://simkl.in/fanart/${json['fanart']}_medium.jpg'
           : null,
-      totalEpisodes: json['total_episodes']?.toString() ?? '1',
+      totalEpisodes: (json['total_episodes'] ??
+              json['total_episodes_count'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString() ??
+          (isMovie ? '1' : '??'),
       type: json['country']?.toUpperCase() ?? 'UNKNOWN',
       premiered: json['released'] ?? 'Unknown release date',
       duration: json['runtime'] != null
@@ -338,7 +343,12 @@ class Media {
       cover: json['fanart'] != null
           ? 'https://simkl.in/fanart/${json['fanart']}_medium.jpg'
           : posterUrl,
-      totalEpisodes: json['total_episodes']?.toString() ?? '1',
+      totalEpisodes: (json['total_episodes'] ??
+              json['total_episodes_count'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString() ??
+          (isMovie ? '1' : '??'),
       type: isMovie ? 'MOVIE' : 'TV',
       rating: json['ratings']?['simkl']?['rating']?.toString() ?? '0.0',
       popularity: json['rank']?.toString() ?? '0',

--- a/lib/screens/anime/widgets/episode/normal_episode.dart
+++ b/lib/screens/anime/widgets/episode/normal_episode.dart
@@ -18,6 +18,7 @@ class BetterEpisode extends StatelessWidget {
   final bool isSelected;
   final EpisodeLayoutType layoutType;
   final String? fallbackImageUrl;
+  final String? mediaTitle;
   final List<Episode>? offlineEpisodes;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
@@ -28,6 +29,7 @@ class BetterEpisode extends StatelessWidget {
     this.isSelected = false,
     this.layoutType = EpisodeLayoutType.compact,
     this.fallbackImageUrl,
+    this.mediaTitle,
     this.offlineEpisodes,
     this.onTap,
     this.onLongPress,
@@ -55,7 +57,17 @@ class BetterEpisode extends StatelessWidget {
 
   String get episodeNumber => episode.number.contains('.0') ? episode.number.toInt().toString() : episode.number.toString();
 
-  String get episodeTitle => episode.title ?? 'Episode $episodeNumber'; 
+  String get episodeTitle {
+    final raw = episode.title?.trim();
+    final isGeneric = raw == null ||
+        raw.isEmpty ||
+        raw.toLowerCase() == 'movie' ||
+        raw.toLowerCase() == 'full movie';
+    if (isGeneric && mediaTitle != null && mediaTitle!.trim().isNotEmpty) {
+      return mediaTitle!.trim();
+    }
+    return (raw != null && raw.isNotEmpty) ? raw : 'Episode $episodeNumber';
+  } 
 
 
   double _calculateProgress() {

--- a/lib/screens/anime/widgets/episode_list_builder.dart
+++ b/lib/screens/anime/widgets/episode_list_builder.dart
@@ -508,6 +508,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                       child: BetterEpisode(
                         episode: episode,
                         isSelected: isSelected,
+                        mediaTitle: widget.anilistData?.title ?? widget.media.title,
                         layoutType: hasAnifyThumbs
                             ? EpisodeLayoutType.detailed
                             : EpisodeLayoutType.compact,
@@ -649,6 +650,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                         child: BetterEpisode(
                           episode: episode,
                           isSelected: isSelected,
+                          mediaTitle: widget.anilistData?.title ?? widget.media.title,
                           layoutType: hasAnifyThumbs
                               ? EpisodeLayoutType.detailed
                               : EpisodeLayoutType.compact,
@@ -1088,10 +1090,16 @@ class ContinueEpisodeButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final safeTitle = (episode.title?.trim().isNotEmpty ?? false)
-            ? episode.title!.trim()
-            : "Episode ${episode.number}";
-        final episodeLabel = 'Episode ${episode.number}: $safeTitle';
+        final rawTitle = episode.title?.trim();
+        final isGenericMovie = rawTitle == null ||
+            rawTitle.isEmpty ||
+            rawTitle.toLowerCase() == 'movie' ||
+            rawTitle.toLowerCase() == 'full movie';
+        final isMovieMedia = data.id.endsWith('*MOVIE') || data.type == 'MOVIE';
+        final resolvedTitle = (isGenericMovie || isMovieMedia)
+            ? (data.title.isNotEmpty ? data.title : "Episode ${episode.number}")
+            : (rawTitle ?? "Episode ${episode.number}");
+        final episodeLabel = 'Episode ${episode.number}: $resolvedTitle';
         final double progressPercentage;
         if (progressEpisode.number != episode.number ||
             progressEpisode.timeStampInMilliseconds == null ||

--- a/lib/screens/anime/widgets/episode_list_builder.dart
+++ b/lib/screens/anime/widgets/episode_list_builder.dart
@@ -508,7 +508,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                       child: BetterEpisode(
                         episode: episode,
                         isSelected: isSelected,
-                        mediaTitle: widget.anilistData?.title ?? widget.media.title,
+                        mediaTitle: widget.anilistData?.title,
                         layoutType: hasAnifyThumbs
                             ? EpisodeLayoutType.detailed
                             : EpisodeLayoutType.compact,
@@ -650,7 +650,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                         child: BetterEpisode(
                           episode: episode,
                           isSelected: isSelected,
-                          mediaTitle: widget.anilistData?.title ?? widget.media.title,
+                          mediaTitle: widget.anilistData?.title,
                           layoutType: hasAnifyThumbs
                               ? EpisodeLayoutType.detailed
                               : EpisodeLayoutType.compact,

--- a/lib/screens/anime/widgets/list_editor.dart
+++ b/lib/screens/anime/widgets/list_editor.dart
@@ -160,7 +160,58 @@ class _ListEditorModalState extends State<ListEditorModal> {
     return parsed;
   }
 
+  int? get _overallTotal {
+    if (_simklSeasons.isNotEmpty) {
+      return _simklSeasons.entries
+          .where((e) => e.key > 0)
+          .fold<int>(0, (sum, e) => sum + e.value);
+    }
+    final tracked = widget.currentAnime.value;
+    final preferredRaw = widget.isManga
+        ? widget.media.totalChapters
+        : widget.media.totalEpisodes;
+    final fallbackRaw = tracked?.totalEpisodes;
+    return _parseKnownPositiveInt(preferredRaw) ??
+        _parseKnownPositiveInt(fallbackRaw);
+  }
+
   void _setProgress(int value, {bool updateController = true}) {
+    if (_simklSeasons.isNotEmpty) {
+      final validSeasons =
+          _simklSeasons.keys.where((k) => k > 0).toList()..sort();
+      final currentSeasonMax = _simklSeasons[_localSeason];
+
+      if (currentSeasonMax != null) {
+        if (value > currentSeasonMax) {
+          final currentIdx = validSeasons.indexOf(_localSeason);
+          if (currentIdx != -1 && currentIdx + 1 < validSeasons.length) {
+            final nextSeason = validSeasons[currentIdx + 1];
+            final remainder = value - currentSeasonMax;
+            setState(() {
+              _localSeason = nextSeason;
+              _seasonController.text = _localSeason.toString();
+            });
+            _setProgress(remainder, updateController: updateController);
+            return;
+          }
+        } else if (value < 0) {
+          final currentIdx = validSeasons.indexOf(_localSeason);
+          if (currentIdx > 0) {
+            final prevSeason = validSeasons[currentIdx - 1];
+            final prevMax = _simklSeasons[prevSeason] ?? 1;
+            final remainder = prevMax + value + 1;
+            setState(() {
+              _localSeason = prevSeason;
+              _seasonController.text = _localSeason.toString();
+            });
+            _setProgress(remainder.clamp(0, prevMax),
+                updateController: updateController);
+            return;
+          }
+        }
+      }
+    }
+
     final max = _maxTotal;
     setState(() {
       _localProgress =
@@ -462,6 +513,7 @@ class _ListEditorModalState extends State<ListEditorModal> {
     final colors = context.colors;
     final max = _maxTotal;
     final pct = max != null ? (_localProgress / max).clamp(0.0, 1.0) : null;
+    final overall = _overallTotal;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -475,12 +527,25 @@ class _ListEditorModalState extends State<ListEditorModal> {
                     color: colors.onSurfaceVariant,
                   ),
             ),
-            Text(
-              '$_localProgress / $_displayTotal',
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: colors.onSurface,
-                    fontWeight: FontWeight.w600,
-                  ),
+            RichText(
+              text: TextSpan(
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: colors.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                children: [
+                  TextSpan(text: '$_localProgress / $_displayTotal'),
+                  if (overall != null && _simklSeasons.isNotEmpty)
+                    TextSpan(
+                      text: '  ($overall total)',
+                      style: TextStyle(
+                        color: colors.onSurfaceVariant,
+                        fontWeight: FontWeight.normal,
+                        fontSize: 11,
+                      ),
+                    ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/screens/anime/widgets/list_editor.dart
+++ b/lib/screens/anime/widgets/list_editor.dart
@@ -80,7 +80,12 @@ class _ListEditorModalState extends State<ListEditorModal> {
       _isPrivate = tracked.isPrivate ?? false;
     }
 
-    if (widget.media.serviceType == ServicesType.simkl && !widget.isManga) {
+    final activeService = Get.find<ServiceHandler>().serviceType;
+    final isSimklMedia = widget.media.serviceType == ServicesType.simkl ||
+        activeService == ServicesType.simkl ||
+        widget.currentAnime.value?.servicesType == ServicesType.simkl;
+
+    if (isSimklMedia && !widget.isManga) {
       _fetchSimklSeasons();
     }
   }
@@ -95,21 +100,29 @@ class _ListEditorModalState extends State<ListEditorModal> {
   Future<void> _fetchSimklSeasons() async {
     setState(() => _isLoadingSeasons = true);
     final service = Get.find<ServiceHandler>().simklService;
-    final listId = widget.currentAnime.value?.id ?? widget.media.id;
+    var listId = widget.currentAnime.value?.id ?? widget.media.id;
+    if (!listId.contains('*')) {
+      listId = '$listId*SERIES';
+    }
     final seasons = await service.getEpisodesBySeason(listId);
     if (mounted) {
       setState(() {
         _simklSeasons = seasons;
         _isLoadingSeasons = false;
         if (_simklSeasons.isNotEmpty && !_simklSeasons.containsKey(_localSeason)) {
-          _localSeason = _simklSeasons.keys.first;
+          final validSeasons =
+              _simklSeasons.keys.where((k) => k > 0).toList()..sort();
+          if (validSeasons.isNotEmpty) {
+            _localSeason = validSeasons.first;
+            _seasonController.text = _localSeason.toString();
+          }
         }
       });
     }
   }
 
   int? get _maxTotal {
-    if (_simklSeasons.isNotEmpty) {
+    if (_simklSeasons.isNotEmpty && _simklSeasons.containsKey(_localSeason)) {
       return _simklSeasons[_localSeason];
     }
     final tracked = widget.currentAnime.value;
@@ -123,7 +136,7 @@ class _ListEditorModalState extends State<ListEditorModal> {
   }
 
   String get _displayTotal {
-    if (_simklSeasons.isNotEmpty) {
+    if (_simklSeasons.isNotEmpty && _simklSeasons.containsKey(_localSeason)) {
       return _simklSeasons[_localSeason]?.toString() ?? '??';
     }
     final tracked = widget.currentAnime.value;
@@ -349,7 +362,11 @@ class _ListEditorModalState extends State<ListEditorModal> {
   Widget _buildSeasonRow(BuildContext context) {
     final colors = context.colors;
 
-    final maxSeason = _simklSeasons.isNotEmpty ? _simklSeasons.keys.reduce((a, b) => a > b ? a : b) : null;
+    final validSeasons =
+        _simklSeasons.keys.where((k) => k > 0).toList();
+    final maxSeason = validSeasons.isNotEmpty
+        ? validSeasons.reduce((a, b) => a > b ? a : b)
+        : null;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
### Summary of Changes

- **Movie Titles in Watching Tab**: Replaced generic `"Movie"` episode names with actual movie titles in both the **Continue Watching** card and **Episode List Builder** cards.
- **Simkl List Editor Season & Episode Progress**:
  - Fixed total episode count parsing in `Media.fromSimkl`, `Media.fromSmallSimkl`, and `TrackedMedia.fromSimklShow` by adding fallbacks for `total_episodes_count`, `episodes_count`, and `episodes` JSON keys, preventing total episode counts from defaulting to `1`.
  - Improved `ListEditorModal` season fetching trigger and updated season count & per-season episode progress calculations for multi-season TV shows.