### PR TITLE
Feat(simkl): Sync anime watched on AniList and MyAnimeList to Simkl via external ID resolution

### DIFF
--- a/lib/controllers/services/anilist/anilist_auth.dart
+++ b/lib/controllers/services/anilist/anilist_auth.dart
@@ -2177,6 +2177,17 @@ class AnilistAuth extends GetxController {
             completedAt: completedAt));
       }
 
+      if (isAnime && serviceHandler.simklService.isLoggedIn.value) {
+        serviceHandler.simklService.updateListEntryFromExternalId(
+          anilistId: listId,
+          malId: malId,
+          score: score,
+          status: status,
+          progress: progress,
+          isAnime: isAnime,
+        );
+      }
+
       if (response.statusCode == 200) {
         final newMedia = currentMedia.value
           ..episodeCount = progress.toString()

--- a/lib/controllers/services/mal/mal_service.dart
+++ b/lib/controllers/services/mal/mal_service.dart
@@ -741,6 +741,20 @@ class MalService extends GetxController implements BaseService, OnlineService {
           completedAt: completedAt));
     }
 
+    if (isAnime && serviceHandler.simklService.isLoggedIn.value) {
+      final anilistId =
+          (params.syncIds?.isNotEmpty ?? false) ? params.syncIds![0] : null;
+      serviceHandler.simklService.updateListEntryFromExternalId(
+        malId: listId,
+        anilistId: anilistId,
+        score: score,
+        status: status,
+        progress: progress,
+        season: params.season,
+        isAnime: isAnime,
+      );
+    }
+
     if (req.statusCode == 200) {
       // snackBar(
       //     "${isAnime ? 'Anime' : 'Manga'} Tracked to ${isAnime ? 'Episode' : 'Chapter'} $progress Successfully!");

--- a/lib/controllers/services/simkl/simkl_service.dart
+++ b/lib/controllers/services/simkl/simkl_service.dart
@@ -23,6 +23,7 @@ import 'package:anymex/screens/home_page.dart';
 import 'package:anymex/screens/library/online/anime_list.dart';
 import 'package:anymex/utils/function.dart';
 import 'package:anymex/utils/logger.dart';
+import 'package:anymex/utils/media_syncer.dart';
 import 'package:anymex/widgets/common/big_carousel_gate.dart';
 import 'package:anymex/widgets/common/reusable_carousel.dart';
 import 'package:anymex/widgets/custom_widgets/anymex_progress.dart';
@@ -589,6 +590,124 @@ class SimklService extends GetxController
     } catch (e, stack) {
       Logger.i('Exception: $e\n$stack');
       errorSnackBar('An unexpected error occurred');
+    }
+  }
+
+  /// Syncs anime progress to Simkl using an external ID (e.g. AniList ID or MAL ID).
+  /// Resolves the external ID to Simkl ID via `MediaSyncer.getSimklIdFromExternal`.
+  Future<void> updateListEntryFromExternalId({
+    String? anilistId,
+    String? malId,
+    double? score,
+    String? status,
+    int? progress,
+    int? season,
+    bool isAnime = true,
+  }) async {
+    if (!isLoggedIn.value) {
+      return;
+    }
+    try {
+      final simklId = await MediaSyncer.getSimklIdFromExternal(
+        anilistId: anilistId,
+        malId: malId,
+      );
+
+      if (simklId != null) {
+        await updateListEntry(UpdateListEntryParams(
+          listId: simklId,
+          score: score,
+          status: status,
+          progress: progress,
+          season: season,
+          isAnime: isAnime,
+        ));
+      } else if (anilistId != null || malId != null) {
+        // Fallback: If redirect resolution yielded no ID, update via external IDs directly in Simkl sync API
+        final token = AuthKeys.simklAuthToken.get<String?>();
+        final apiKey = dotenv.env['SIMKL_CLIENT_ID'];
+        if (token == null || apiKey == null) return;
+
+        final ids = <String, dynamic>{
+          if (anilistId != null) 'anilist': int.tryParse(anilistId) ?? anilistId,
+          if (malId != null) 'mal': int.tryParse(malId) ?? malId,
+        };
+
+        if (status != null) {
+          final url = Uri.parse('https://api.simkl.com/sync/add-to-list');
+          final newStatus = Simkl.alToSimklShow(status);
+          final body = {
+            'shows': [
+              {
+                'to': newStatus,
+                'ids': ids,
+              }
+            ]
+          };
+          await post(
+            url,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(body),
+          );
+        }
+
+        if (progress != null && progress > 0 && status != 'PLANNING') {
+          final historyUrl = Uri.parse('https://api.simkl.com/sync/history');
+          final effectiveSeason = (season != null && season > 0) ? season : 1;
+          final historyBody = {
+            'shows': [
+              {
+                'ids': ids,
+                'seasons': [
+                  {
+                    'number': effectiveSeason,
+                    'episodes': [
+                      for (int i = 1; i <= progress; i++) {'number': i}
+                    ]
+                  }
+                ]
+              }
+            ]
+          };
+          await post(
+            historyUrl,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(historyBody),
+          );
+        }
+
+        if (score != null && score > 0) {
+          final ratingsUrl = Uri.parse('https://api.simkl.com/sync/ratings');
+          final ratingsBody = {
+            'shows': [
+              {
+                'rating': score.toInt(),
+                'ids': ids,
+              }
+            ]
+          };
+          await post(
+            ratingsUrl,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+              'simkl-api-key': apiKey,
+            },
+            body: jsonEncode(ratingsBody),
+          );
+        }
+        fetchUserSeriesList();
+      }
+    } catch (e, stack) {
+      Logger.i('Exception in updateListEntryFromExternalId: $e\n$stack');
     }
   }
 

--- a/lib/models/Anilist/anilist_media_user.dart
+++ b/lib/models/Anilist/anilist_media_user.dart
@@ -123,7 +123,11 @@ class TrackedMedia {
           ? "https://wsrv.nl/?url=https://simkl.in/posters/${show['poster']}_m.jpg"
           : '?',
       episodeCount: json['watched_episodes_count']?.toString(),
-      totalEpisodes: json['total_episodes_count']?.toString(),
+      totalEpisodes: (json['total_episodes_count'] ??
+              json['total_episodes'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString(),
       watchingStatus: Simkl.simklShowToAL(json['status']),
       type: "show",
       servicesType: ServicesType.simkl,

--- a/lib/models/Media/media.dart
+++ b/lib/models/Media/media.dart
@@ -281,7 +281,12 @@ class Media {
       cover: json['fanart'] != null
           ? 'https://wsrv.nl/?url=https://simkl.in/fanart/${json['fanart']}_medium.jpg'
           : null,
-      totalEpisodes: json['total_episodes']?.toString() ?? '1',
+      totalEpisodes: (json['total_episodes'] ??
+              json['total_episodes_count'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString() ??
+          (isMovie ? '1' : '??'),
       type: json['country']?.toUpperCase() ?? 'UNKNOWN',
       premiered: json['released'] ?? 'Unknown release date',
       duration: json['runtime'] != null
@@ -338,7 +343,12 @@ class Media {
       cover: json['fanart'] != null
           ? 'https://simkl.in/fanart/${json['fanart']}_medium.jpg'
           : posterUrl,
-      totalEpisodes: json['total_episodes']?.toString() ?? '1',
+      totalEpisodes: (json['total_episodes'] ??
+              json['total_episodes_count'] ??
+              json['episodes_count'] ??
+              json['episodes'])
+          ?.toString() ??
+          (isMovie ? '1' : '??'),
       type: isMovie ? 'MOVIE' : 'TV',
       rating: json['ratings']?['simkl']?['rating']?.toString() ?? '0.0',
       popularity: json['rank']?.toString() ?? '0',

--- a/lib/screens/anime/widgets/episode/normal_episode.dart
+++ b/lib/screens/anime/widgets/episode/normal_episode.dart
@@ -18,6 +18,7 @@ class BetterEpisode extends StatelessWidget {
   final bool isSelected;
   final EpisodeLayoutType layoutType;
   final String? fallbackImageUrl;
+  final String? mediaTitle;
   final List<Episode>? offlineEpisodes;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
@@ -28,6 +29,7 @@ class BetterEpisode extends StatelessWidget {
     this.isSelected = false,
     this.layoutType = EpisodeLayoutType.compact,
     this.fallbackImageUrl,
+    this.mediaTitle,
     this.offlineEpisodes,
     this.onTap,
     this.onLongPress,
@@ -55,7 +57,17 @@ class BetterEpisode extends StatelessWidget {
 
   String get episodeNumber => episode.number.contains('.0') ? episode.number.toInt().toString() : episode.number.toString();
 
-  String get episodeTitle => episode.title ?? 'Episode $episodeNumber'; 
+  String get episodeTitle {
+    final raw = episode.title?.trim();
+    final isGeneric = raw == null ||
+        raw.isEmpty ||
+        raw.toLowerCase() == 'movie' ||
+        raw.toLowerCase() == 'full movie';
+    if (isGeneric && mediaTitle != null && mediaTitle!.trim().isNotEmpty) {
+      return mediaTitle!.trim();
+    }
+    return (raw != null && raw.isNotEmpty) ? raw : 'Episode $episodeNumber';
+  } 
 
 
   double _calculateProgress() {

--- a/lib/screens/anime/widgets/episode_list_builder.dart
+++ b/lib/screens/anime/widgets/episode_list_builder.dart
@@ -508,6 +508,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                       child: BetterEpisode(
                         episode: episode,
                         isSelected: isSelected,
+                        mediaTitle: widget.anilistData?.title ?? widget.media.title,
                         layoutType: hasAnifyThumbs
                             ? EpisodeLayoutType.detailed
                             : EpisodeLayoutType.compact,
@@ -649,6 +650,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                         child: BetterEpisode(
                           episode: episode,
                           isSelected: isSelected,
+                          mediaTitle: widget.anilistData?.title ?? widget.media.title,
                           layoutType: hasAnifyThumbs
                               ? EpisodeLayoutType.detailed
                               : EpisodeLayoutType.compact,
@@ -1088,10 +1090,16 @@ class ContinueEpisodeButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final safeTitle = (episode.title?.trim().isNotEmpty ?? false)
-            ? episode.title!.trim()
-            : "Episode ${episode.number}";
-        final episodeLabel = 'Episode ${episode.number}: $safeTitle';
+        final rawTitle = episode.title?.trim();
+        final isGenericMovie = rawTitle == null ||
+            rawTitle.isEmpty ||
+            rawTitle.toLowerCase() == 'movie' ||
+            rawTitle.toLowerCase() == 'full movie';
+        final isMovieMedia = data.id.endsWith('*MOVIE') || data.type == 'MOVIE';
+        final resolvedTitle = (isGenericMovie || isMovieMedia)
+            ? (data.title.isNotEmpty ? data.title : "Episode ${episode.number}")
+            : (rawTitle ?? "Episode ${episode.number}");
+        final episodeLabel = 'Episode ${episode.number}: $resolvedTitle';
         final double progressPercentage;
         if (progressEpisode.number != episode.number ||
             progressEpisode.timeStampInMilliseconds == null ||

--- a/lib/screens/anime/widgets/episode_list_builder.dart
+++ b/lib/screens/anime/widgets/episode_list_builder.dart
@@ -508,7 +508,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                       child: BetterEpisode(
                         episode: episode,
                         isSelected: isSelected,
-                        mediaTitle: widget.anilistData?.title ?? widget.media.title,
+                        mediaTitle: widget.anilistData?.title,
                         layoutType: hasAnifyThumbs
                             ? EpisodeLayoutType.detailed
                             : EpisodeLayoutType.compact,
@@ -650,7 +650,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
                         child: BetterEpisode(
                           episode: episode,
                           isSelected: isSelected,
-                          mediaTitle: widget.anilistData?.title ?? widget.media.title,
+                          mediaTitle: widget.anilistData?.title,
                           layoutType: hasAnifyThumbs
                               ? EpisodeLayoutType.detailed
                               : EpisodeLayoutType.compact,

--- a/lib/screens/anime/widgets/list_editor.dart
+++ b/lib/screens/anime/widgets/list_editor.dart
@@ -80,7 +80,12 @@ class _ListEditorModalState extends State<ListEditorModal> {
       _isPrivate = tracked.isPrivate ?? false;
     }
 
-    if (widget.media.serviceType == ServicesType.simkl && !widget.isManga) {
+    final activeService = Get.find<ServiceHandler>().serviceType;
+    final isSimklMedia = widget.media.serviceType == ServicesType.simkl ||
+        activeService == ServicesType.simkl ||
+        widget.currentAnime.value?.servicesType == ServicesType.simkl;
+
+    if (isSimklMedia && !widget.isManga) {
       _fetchSimklSeasons();
     }
   }
@@ -95,21 +100,29 @@ class _ListEditorModalState extends State<ListEditorModal> {
   Future<void> _fetchSimklSeasons() async {
     setState(() => _isLoadingSeasons = true);
     final service = Get.find<ServiceHandler>().simklService;
-    final listId = widget.currentAnime.value?.id ?? widget.media.id;
+    var listId = widget.currentAnime.value?.id ?? widget.media.id;
+    if (!listId.contains('*')) {
+      listId = '$listId*SERIES';
+    }
     final seasons = await service.getEpisodesBySeason(listId);
     if (mounted) {
       setState(() {
         _simklSeasons = seasons;
         _isLoadingSeasons = false;
         if (_simklSeasons.isNotEmpty && !_simklSeasons.containsKey(_localSeason)) {
-          _localSeason = _simklSeasons.keys.first;
+          final validSeasons =
+              _simklSeasons.keys.where((k) => k > 0).toList()..sort();
+          if (validSeasons.isNotEmpty) {
+            _localSeason = validSeasons.first;
+            _seasonController.text = _localSeason.toString();
+          }
         }
       });
     }
   }
 
   int? get _maxTotal {
-    if (_simklSeasons.isNotEmpty) {
+    if (_simklSeasons.isNotEmpty && _simklSeasons.containsKey(_localSeason)) {
       return _simklSeasons[_localSeason];
     }
     final tracked = widget.currentAnime.value;
@@ -123,7 +136,7 @@ class _ListEditorModalState extends State<ListEditorModal> {
   }
 
   String get _displayTotal {
-    if (_simklSeasons.isNotEmpty) {
+    if (_simklSeasons.isNotEmpty && _simklSeasons.containsKey(_localSeason)) {
       return _simklSeasons[_localSeason]?.toString() ?? '??';
     }
     final tracked = widget.currentAnime.value;
@@ -349,7 +362,11 @@ class _ListEditorModalState extends State<ListEditorModal> {
   Widget _buildSeasonRow(BuildContext context) {
     final colors = context.colors;
 
-    final maxSeason = _simklSeasons.isNotEmpty ? _simklSeasons.keys.reduce((a, b) => a > b ? a : b) : null;
+    final validSeasons =
+        _simklSeasons.keys.where((k) => k > 0).toList();
+    final maxSeason = validSeasons.isNotEmpty
+        ? validSeasons.reduce((a, b) => a > b ? a : b)
+        : null;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/utils/media_syncer.dart
+++ b/lib/utils/media_syncer.dart
@@ -54,4 +54,84 @@ class MediaSyncer {
     }
     return null;
   }
+
+  /// Resolves an external ID (e.g. anilist, mal, kitsu, tvdb, imdb, etc.)
+  /// to a Simkl ID using Simkl's redirect endpoint:
+  /// `GET https://api.simkl.com/redirect?to=simkl&{service}={id}`
+  static Future<String?> getSimklIdFromExternal({
+    String? anilistId,
+    String? malId,
+    String? service,
+    String? externalId,
+  }) async {
+    final client = Client();
+    try {
+      String? paramName;
+      String? idToUse;
+
+      if (service != null && externalId != null) {
+        paramName = service;
+        idToUse = externalId;
+      } else if (anilistId != null) {
+        paramName = 'anilist';
+        idToUse = anilistId;
+      } else if (malId != null) {
+        paramName = 'mal';
+        idToUse = malId;
+      }
+
+      if (paramName == null || idToUse == null) return null;
+
+      final url = Uri.parse(
+          'https://api.simkl.com/redirect?to=simkl&$paramName=$idToUse');
+      final request = Request('GET', url)..followRedirects = false;
+      final response = await client.send(request);
+
+      final location = response.headers['location'];
+      if (location != null) {
+        final match =
+            RegExp(r'/(?:anime|shows|movies)/(\d+)').firstMatch(location);
+        if (match != null) {
+          return match.group(1);
+        }
+      }
+
+      // If resolving via anilist failed, fallback to malId if available
+      if (paramName == 'anilist' && malId != null) {
+        final fallbackUrl =
+            Uri.parse('https://api.simkl.com/redirect?to=simkl&mal=$malId');
+        final fallbackReq = Request('GET', fallbackUrl)..followRedirects = false;
+        final fallbackResp = await client.send(fallbackReq);
+        final fallbackLoc = fallbackResp.headers['location'];
+        if (fallbackLoc != null) {
+          final match =
+              RegExp(r'/(?:anime|shows|movies)/(\d+)').firstMatch(fallbackLoc);
+          if (match != null) {
+            return match.group(1);
+          }
+        }
+      }
+    } catch (e) {
+      Logger.i('Error resolving Simkl ID: $e');
+    } finally {
+      client.close();
+    }
+    return null;
+  }
+
+  /// Fetches anime details from Simkl API by Simkl ID:
+  /// `GET https://api.simkl.com/anime/{simklId}`
+  static Future<Map<String, dynamic>?> fetchSimklAnimeDetails(
+      String simklId) async {
+    try {
+      final url = Uri.parse('https://api.simkl.com/anime/$simklId');
+      final resp = await get(url);
+      if (resp.statusCode == 200) {
+        return jsonDecode(resp.body) as Map<String, dynamic>;
+      }
+    } catch (e) {
+      Logger.i('Error fetching Simkl anime details: $e');
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
Merge: https://github.com/RyanYuuki/AnymeX/pull/501 first, closes #499 

### Summary
Anime watched through AniList or MyAnimeList services were previously not synced to Simkl. This PR enables automatic progress, status, and rating sync to Simkl using Simkl's native external ID resolution endpoint (`https://api.simkl.com/redirect?to=simkl&...`).

### Changes Included
- **External ID Resolution**: Added `getSimklIdFromExternal` and `fetchSimklAnimeDetails` in `MediaSyncer` to dynamically map external IDs (AniList, MAL, Kitsu, TVDB, IMDB, etc.) directly to Simkl IDs.
- **Simkl External Entry Updating**: Added `updateListEntryFromExternalId` in `SimklService` to resolve IDs and update list entries (`/sync/add-to-list`, `/sync/history`, `/sync/ratings`).
- **Cross-Service Sync**: Integrated Simkl sync calls into `AnilistAuth` and `MalService` whenever an anime entry update occurs while logged into Simkl.