### PR TITLE
Feat(simkl): Add Manage Simkl Lists feature for home page customization

### DIFF
--- a/lib/controllers/services/simkl/simkl_service.dart
+++ b/lib/controllers/services/simkl/simkl_service.dart
@@ -22,6 +22,7 @@ import 'package:anymex/screens/anime/misc/calendar.dart';
 import 'package:anymex/screens/home_page.dart';
 import 'package:anymex/screens/library/online/anime_list.dart';
 import 'package:anymex/utils/function.dart';
+import 'package:anymex/controllers/settings/settings.dart';
 import 'package:anymex/utils/logger.dart';
 import 'package:anymex/utils/media_syncer.dart';
 import 'package:anymex/widgets/common/big_carousel_gate.dart';
@@ -211,6 +212,12 @@ class SimklService extends GetxController
 
   @override
   RxList<Widget> homeWidgets(BuildContext context) {
+    final settings = Get.find<Settings>();
+    final acceptedLists = settings.homePageCardsSimkl.entries
+        .where((entry) => entry.value)
+        .map<String>((entry) => entry.key)
+        .toList();
+
     return [
       if (isLoggedIn.value)
         LayoutBuilder(
@@ -292,12 +299,20 @@ class SimklService extends GetxController
         },
       ),
       const SizedBox(height: 25),
-      if (isLoggedIn.value) ...[
-        buildSection("Planned Movies", continueWatchingMovies.value,
-            variant: DataVariant.anilist),
-        buildSection("Continue Watching (SHOWS)", continueWatchingSeries.value,
-            variant: DataVariant.anilist),
-      ],
+      if (isLoggedIn.value)
+        Obx(() => Column(
+              children: acceptedLists.map((e) {
+                final isShowsList = e.contains("Shows") || e.contains("Series");
+                final sourceList = isShowsList ? mangaList : animeList;
+                final filtered = filterListByLabel(sourceList, e);
+                return ReusableCarousel(
+                  data: filtered,
+                  title: e,
+                  variant: DataVariant.anilist,
+                  type: isShowsList ? ItemType.manga : ItemType.anime,
+                );
+              }).toList(),
+            )),
       if (trendingMovies.value.isNotEmpty)
         ReusableCarousel(
             data: trendingMovies.value.sublist(0, 10),

--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -364,6 +364,8 @@ class Settings extends GetxController {
   Map<String, bool> get homePageCards => _getUISetting((s) => s.homePageCards);
   Map<String, bool> get homePageCardsMal =>
       _getUISetting((s) => s.homePageCardsMal);
+  Map<String, bool> get homePageCardsSimkl =>
+      _getUISetting((s) => s.homePageCardsSimkl);
 
   String get _currentTabOrderKey {
     final service = Get.isRegistered<ServiceHandler>()
@@ -710,5 +712,13 @@ class Settings extends GetxController {
     currentCards[key] = value;
     uiSettings.update((s) => s?.homePageCardsMal = currentCards);
     UISettingsKeys.homePageCardsMal.set(jsonEncode(currentCards));
+  }
+
+  void updateHomePageCardSimkl(String key, bool value) {
+    final currentCards =
+        Map<String, bool>.from(uiSettings.value.homePageCardsSimkl);
+    currentCards[key] = value;
+    uiSettings.update((s) => s?.homePageCardsSimkl = currentCards);
+    UISettingsKeys.homePageCardsSimkl.set(jsonEncode(currentCards));
   }
 }

--- a/lib/database/data_keys/keys.dart
+++ b/lib/database/data_keys/keys.dart
@@ -173,6 +173,7 @@ enum AuthKeys {
   malRefreshToken,
   simklAuthToken,
   malSessionId,
+  mangaBakaAuthToken,
 }
 
 enum SearchKeys { novelSearchedQueries }
@@ -270,6 +271,7 @@ enum UISettingsKeys {
   enableAnimation,
   disableGradient,
   homePageCardsMal,
+  homePageCardsSimkl,
   cardStyle,
   historyCardStyle,
   liquidMode,

--- a/lib/models/ui/ui_adaptor.dart
+++ b/lib/models/ui/ui_adaptor.dart
@@ -19,6 +19,7 @@ class UISettings {
   bool enableAnimation;
   bool disableGradient;
   Map<String, bool> homePageCardsMal;
+  Map<String, bool> homePageCardsSimkl;
   int cardStyle;
   int historyCardStyle;
   bool liquidMode;
@@ -48,6 +49,7 @@ class UISettings {
     this.translucentTabBar = true,
     Map<String, bool>? homePageCards,
     Map<String, bool>? homePageCardsMal,
+    Map<String, bool>? homePageCardsSimkl,
     this.enableAnimation = true,
     this.disableGradient = false,
     this.cardStyle = 2,
@@ -91,6 +93,19 @@ class UISettings {
               "Dropped Manga": false,
               "Planning Animes": false,
               "Planning Manga": false,
+            },
+        homePageCardsSimkl = homePageCardsSimkl ??
+            {
+              "Continue Watching (Movies)": true,
+              "Continue Watching (Shows)": true,
+              "Completed Movies": false,
+              "Completed Shows": false,
+              "Paused Movies": false,
+              "Paused Shows": false,
+              "Dropped Movies": false,
+              "Dropped Shows": false,
+              "Planning Movies": false,
+              "Planning Shows": false,
             };
 
   void normalizeMaps() {
@@ -100,12 +115,15 @@ class UISettings {
     homePageCardsMal = Map<String, bool>.from(homePageCardsMal);
     homePageCardsMal.putIfAbsent('Recommended Animes', () => true);
     homePageCardsMal.putIfAbsent('Recommended Mangas', () => true);
+    homePageCardsSimkl = Map<String, bool>.from(homePageCardsSimkl);
   }
 
   factory UISettings.fromDB() {
     final uiDefaults = UISettings();
     final homeCardsRaw = UISettingsKeys.homePageCards.get<String?>(null);
     final homeCardsMalRaw = UISettingsKeys.homePageCardsMal.get<String?>(null);
+    final homeCardsSimklRaw =
+        UISettingsKeys.homePageCardsSimkl.get<String?>(null);
     return UISettings(
       glowMultiplier:
           UISettingsKeys.glowMultiplier.get<double>(uiDefaults.glowMultiplier),
@@ -140,6 +158,9 @@ class UISettings {
           UISettingsKeys.disableGradient.get<bool>(uiDefaults.disableGradient),
       homePageCardsMal: homeCardsMalRaw != null
           ? Map<String, bool>.from(jsonDecode(homeCardsMalRaw))
+          : null,
+      homePageCardsSimkl: homeCardsSimklRaw != null
+          ? Map<String, bool>.from(jsonDecode(homeCardsSimklRaw))
           : null,
       cardStyle: UISettingsKeys.cardStyle.get<int>(uiDefaults.cardStyle),
       historyCardStyle:

--- a/lib/screens/settings/sub_settings/settings_common.dart
+++ b/lib/screens/settings/sub_settings/settings_common.dart
@@ -258,7 +258,7 @@ class _SettingsCommonState extends State<SettingsCommon> {
                             title: 'Manage Anilist Lists',
                             description:
                                 "Choose which list to show on home page",
-                            onTap: () => _showHomePageCardsDialog(),
+                            onTap: () => _showHomePageCardsDialog(ServicesType.anilist),
                           )),
                       AnymexExpansionTile(
                           initialExpanded: true,
@@ -268,7 +268,17 @@ class _SettingsCommonState extends State<SettingsCommon> {
                             title: 'Manage MyAnimeList Lists',
                             description:
                                 "Choose which list to show on home page",
-                            onTap: () => _showHomePageCardsDialog(),
+                            onTap: () => _showHomePageCardsDialog(ServicesType.mal),
+                          )),
+                      AnymexExpansionTile(
+                          initialExpanded: true,
+                          title: 'Simkl',
+                          content: CustomTile(
+                            icon: Icons.format_list_bulleted_sharp,
+                            title: 'Manage Simkl Lists',
+                            description:
+                                "Choose which list to show on home page",
+                            onTap: () => _showHomePageCardsDialog(ServicesType.simkl),
                           )),
                     ],
                   ),
@@ -281,17 +291,25 @@ class _SettingsCommonState extends State<SettingsCommon> {
     );
   }
 
-  void _showHomePageCardsDialog() {
+  void _showHomePageCardsDialog([ServicesType? serviceType]) {
+    final targetService = serviceType ?? serviceHandler.serviceType.value;
+    final serviceName = targetService == ServicesType.simkl
+        ? 'Simkl'
+        : (targetService == ServicesType.mal ? 'MyAnimeList' : 'Anilist');
+
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text("Manage Home Page Cards"),
+          title: Text("Manage $serviceName Home Page Cards"),
           content: SizedBox(
             width: double.maxFinite,
             child: Obx(() {
-              final homePageCards =
-                  isMal ? settings.homePageCardsMal : settings.homePageCards;
+              final homePageCards = targetService == ServicesType.simkl
+                  ? settings.homePageCardsSimkl
+                  : (targetService == ServicesType.mal
+                      ? settings.homePageCardsMal
+                      : settings.homePageCards);
               return SuperListView.builder(
                 shrinkWrap: true,
                 itemCount: homePageCards.length,
@@ -304,9 +322,13 @@ class _SettingsCommonState extends State<SettingsCommon> {
                     value: value,
                     onChanged: (bool? newValue) {
                       if (newValue != null) {
-                        isMal
-                            ? settings.updateHomePageCardMal(key, newValue)
-                            : settings.updateHomePageCard(key, newValue);
+                        if (targetService == ServicesType.simkl) {
+                          settings.updateHomePageCardSimkl(key, newValue);
+                        } else if (targetService == ServicesType.mal) {
+                          settings.updateHomePageCardMal(key, newValue);
+                        } else {
+                          settings.updateHomePageCard(key, newValue);
+                        }
                       }
                     },
                   );

--- a/lib/utils/function.dart
+++ b/lib/utils/function.dart
@@ -569,37 +569,48 @@ List<TrackedMedia> filterListByStatus(
 List<TrackedMedia> filterListByLabel(
     List<TrackedMedia> animeList, String label) {
   return animeList.where((anime) {
-    if (label == "Continue Watching" && anime.watchingStatus == 'CURRENT') {
+    if ((label == "Continue Watching" ||
+            label == "Continue Watching (Movies)" ||
+            label == "Continue Watching (Shows)") &&
+        anime.watchingStatus == 'CURRENT') {
       return true;
     }
     if (label == "Continue Reading" && anime.watchingStatus == 'CURRENT') {
       return true;
     }
-    if (label == "Completed TV" && anime.watchingStatus == 'COMPLETED') {
+    if ((label == "Completed TV" || label == "Completed Movies") &&
+        anime.watchingStatus == 'COMPLETED') {
       return true;
     }
-    if (label == "Completed Manga" && anime.watchingStatus == 'COMPLETED') {
+    if ((label == "Completed Manga" || label == "Completed Shows") &&
+        anime.watchingStatus == 'COMPLETED') {
       return true;
     }
     if (label == "Completed Movie" && anime.watchingStatus == 'COMPLETED') {
       return true;
     }
-    if (label == "Paused Animes" && anime.watchingStatus == 'PAUSED') {
+    if ((label == "Paused Animes" || label == "Paused Movies") &&
+        anime.watchingStatus == 'PAUSED') {
       return true;
     }
-    if (label == "Paused Manga" && anime.watchingStatus == 'PAUSED') {
+    if ((label == "Paused Manga" || label == "Paused Shows") &&
+        anime.watchingStatus == 'PAUSED') {
       return true;
     }
-    if (label == "Dropped Animes" && anime.watchingStatus == 'DROPPED') {
+    if ((label == "Dropped Animes" || label == "Dropped Movies") &&
+        anime.watchingStatus == 'DROPPED') {
       return true;
     }
-    if (label == "Dropped Manga" && anime.watchingStatus == 'DROPPED') {
+    if ((label == "Dropped Manga" || label == "Dropped Shows") &&
+        anime.watchingStatus == 'DROPPED') {
       return true;
     }
-    if (label == "Planning Animes" && anime.watchingStatus == 'PLANNING') {
+    if ((label == "Planning Animes" || label == "Planning Movies") &&
+        anime.watchingStatus == 'PLANNING') {
       return true;
     }
-    if (label == "Planning Manga" && anime.watchingStatus == 'PLANNING') {
+    if ((label == "Planning Manga" || label == "Planning Shows") &&
+        anime.watchingStatus == 'PLANNING') {
       return true;
     }
     if (label == "Rewatching Animes" && anime.watchingStatus == 'REPEATING') {


### PR DESCRIPTION
Adds support for managing Simkl list cards on the Home page, matching the list management functionality of AniList and MyAnimeList. 

Users can now choose which Simkl lists (Movies & Shows/Series: Continue Watching, Completed, Paused, Dropped, Planning) appear on their home screen via **Settings > Common > Manage Simkl Lists**.

#### Changes Summary:
- **Settings State & Storage**: Added `homePageCardsSimkl` UI setting, defaults, and persistence keys.
- **Settings UI**: Added "Manage Simkl Lists" tile and updated list selection dialog to support Simkl list toggles.
- **List Filtering & Home Page**: Extended `filterListByLabel` for Simkl status categories and updated `SimklService.homeWidgets` to dynamically render active Simkl lists when logged in.