### PR TITLE
feat: add slide to seek toggle in player settings

### DIFF
--- a/lib/controllers/settings/settings.dart
+++ b/lib/controllers/settings/settings.dart
@@ -635,6 +635,12 @@ class Settings extends GetxController {
     PlayerSettingsKeys.enableHoldToSeek.set(value);
   }
 
+  bool get enableSlideToSeek => _getPlayerSetting((s) => s.enableSlideToSeek);
+  set enableSlideToSeek(bool value) {
+    playerSettings.update((s) => s?.enableSlideToSeek = value);
+    PlayerSettingsKeys.enableSlideToSeek.set(value);
+  }
+
   bool get playerMenuAnimation =>
       _getPlayerSetting((s) => s.playerMenuAnimation);
   set playerMenuAnimation(bool value) {

--- a/lib/database/data_keys/keys.dart
+++ b/lib/database/data_keys/keys.dart
@@ -253,6 +253,7 @@ enum PlayerSettingsKeys {
   videoOutput,
   audioOutput,
   enableHoldToSeek,
+  enableSlideToSeek,
 }
 
 enum UISettingsKeys {

--- a/lib/models/player/player_adaptor.dart
+++ b/lib/models/player/player_adaptor.dart
@@ -36,6 +36,7 @@ class PlayerSettings {
   String videoOutput;
   String audioOutput;
   bool enableHoldToSeek;
+  bool enableSlideToSeek;
 
   PlayerSettings({
     this.speed = 1.0,
@@ -73,6 +74,7 @@ class PlayerSettings {
     this.videoOutput = 'gpu',
     this.audioOutput = 'auto',
     this.enableHoldToSeek = true,
+    this.enableSlideToSeek = true,
   });
 
   factory PlayerSettings.fromDB() {
@@ -151,6 +153,8 @@ class PlayerSettings {
           .get<String>(defaults.audioOutput),
       enableHoldToSeek: PlayerSettingsKeys.enableHoldToSeek
           .get<bool>(defaults.enableHoldToSeek),
+      enableSlideToSeek: PlayerSettingsKeys.enableSlideToSeek
+          .get<bool>(defaults.enableSlideToSeek),
     );
   }
 }

--- a/lib/screens/anime/watch/controls/widgets/double_tap_seek.dart
+++ b/lib/screens/anime/watch/controls/widgets/double_tap_seek.dart
@@ -286,6 +286,7 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
   void _onHorizontalDragStart(DragStartDetails details) {
     if (widget.controller.isLocked.value) return;
     if (_isHolding || _longPressStarted) return;
+    if (!Get.find<Settings>().enableSlideToSeek) return;
 
     _isHorizontalDragging = true;
     _dragStartPlayerPosition = widget.controller.currentPosition.value;
@@ -306,6 +307,7 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
   void _onHorizontalDragUpdate(DragUpdateDetails details) {
     if (!_isHorizontalDragging) return;
     if (widget.controller.isLocked.value) return;
+    if (!Get.find<Settings>().enableSlideToSeek) return;
 
     final screenWidth = MediaQuery.of(context).size.width;
     const sensitivity = 0.80;
@@ -330,6 +332,7 @@ class _DoubleTapSeekWidgetState extends State<DoubleTapSeekWidget>
 
   void _onHorizontalDragEnd(DragEndDetails details) {
     if (!_isHorizontalDragging) return;
+    if (!Get.find<Settings>().enableSlideToSeek) return;
 
     _isHorizontalDragging = false;
 

--- a/lib/screens/settings/sub_settings/settings_player.dart
+++ b/lib/screens/settings/sub_settings/settings_player.dart
@@ -2093,6 +2093,15 @@ class _SettingsPlayerState extends State<SettingsPlayer> with TickerProviderStat
                                       settings.enableHoldToSeek = val),
                               CustomSwitchTile(
                                   padding: const EdgeInsets.all(10),
+                                  icon: Icons.swap_horiz_rounded,
+                                  title: "Slide to Seek",
+                                  description:
+                                      "Enable horizontal swipe on player to seek through video",
+                                  switchValue: settings.enableSlideToSeek,
+                                  onChanged: (val) =>
+                                      settings.enableSlideToSeek = val),
+                              CustomSwitchTile(
+                                  padding: const EdgeInsets.all(10),
                                   icon: Icons.screenshot_rounded,
                                   title: "Save Last Frame",
                                   description:


### PR DESCRIPTION
Adds a "Slide to Seek" toggle in Settings > Player > Common that allows users to disable the horizontal swipe-to-seek gesture on the video player.