### PR TITLE
fix: replace em-dash with ASCII hyphen in libtorrent setup script

### DIFF
--- a/scripts/setup_libtorrent_windows.ps1
+++ b/scripts/setup_libtorrent_windows.ps1
@@ -107,7 +107,7 @@ $prebuiltBase = Join-Path $ltDirFullName "prebuilt\windows"
 $prebuiltDll  = Join-Path $prebuiltBase "$Arch\libtorrent_flutter.dll"
 
 if (Test-Path $prebuiltDll) {
-    Write-Host "libtorrent_flutter prebuilt already exists at $prebuiltDll — nothing to do." -ForegroundColor Green
+    Write-Host "libtorrent_flutter prebuilt already exists at $prebuiltDll - nothing to do." -ForegroundColor Green
     exit 0
 }
 


### PR DESCRIPTION

Windows PowerShell 5.1 doesn't read .ps1 files as UTF-8 by default, so the em-dash character broke the script's string parsing, causing:
```
ParserError: TerminatorExpectedAtEndOfString
Missing closing '}' in statement block or type definition in : AnymeX/scripts\setup_libtorrent_windows.ps1:132 car:66
+ ...  libtorrent_flutter DLL ready at $prebuiltDll" -ForegroundColor Green
```