### PR TITLE
fix: resolve multi-season autoplay navigation and completion tracking issues

### DIFF
--- a/lib/controllers/offline/offline_storage_controller.dart
+++ b/lib/controllers/offline/offline_storage_controller.dart
@@ -658,7 +658,7 @@ class OfflineStorageController extends GetxController {
       episode.lastWatchedTime = DateTime.now().millisecondsSinceEpoch;
 
       final index = existingAnime.watchedEpisodes!
-          .indexWhere((e) => e.number == episode.number);
+          .indexWhere((e) => e.isSameEpisode(episode));
       existingAnime.watchedEpisodes =
           List<Episode>.from(existingAnime.watchedEpisodes!);
 
@@ -684,9 +684,14 @@ class OfflineStorageController extends GetxController {
     }
   }
 
-  Episode? getWatchedEpisode(String anilistId, String episodeNumber) {
+  Episode? getWatchedEpisode(String anilistId, String episodeNumber, {Episode? episode}) {
     final anime = getAnimeById(anilistId);
     if (anime?.watchedEpisodes == null) return null;
+
+    if (episode != null) {
+      return anime!.watchedEpisodes!
+          .firstWhereOrNull((e) => e.isSameEpisode(episode));
+    }
 
     return anime!.watchedEpisodes!
         .firstWhereOrNull((e) => e.number == episodeNumber);

--- a/lib/database/isar_models/episode.dart
+++ b/lib/database/isar_models/episode.dart
@@ -111,11 +111,10 @@ extension EpisodeMap on Episode {
     if (identical(this, other)) return true;
 
     // 1. If both have valid links, link is the most definitive episode identifier
-    if (link != null &&
-        other.link != null &&
-        link!.trim().isNotEmpty &&
-        other.link!.trim().isNotEmpty) {
-      return link!.trim() == other.link!.trim();
+    final thisLink = link?.trim() ?? '';
+    final otherLink = other.link?.trim() ?? '';
+    if (thisLink.isNotEmpty && otherLink.isNotEmpty) {
+      return thisLink == otherLink;
     }
 
     // 2. If episode numbers don't match, they are not the same
@@ -123,25 +122,28 @@ extension EpisodeMap on Episode {
       return false;
     }
 
-    // 3. If both have sortMap metadata (e.g. season, cour, etc.)
+    // 3. Compare sortMap metadata (e.g. season, cour, etc.)
     final thisSort = sortMap;
     final otherSort = other.sortMap;
-    if (thisSort.isNotEmpty && otherSort.isNotEmpty) {
+    if (thisSort.isNotEmpty || otherSort.isNotEmpty) {
       if (thisSort.length != otherSort.length) return false;
       for (final entry in thisSort.entries) {
         if (otherSort[entry.key]?.toLowerCase() != entry.value.toLowerCase()) {
           return false;
         }
       }
-      return true;
     }
 
-    // 4. If both have titles and they differ
-    if (title != null &&
-        other.title != null &&
-        title!.trim().isNotEmpty &&
-        other.title!.trim().isNotEmpty) {
-      return title!.trim() == other.title!.trim();
+    // 4. If both have titles, compare them
+    final thisTitle = title?.trim() ?? '';
+    final otherTitle = other.title?.trim() ?? '';
+    if (thisTitle.isNotEmpty && otherTitle.isNotEmpty) {
+      return thisTitle == otherTitle;
+    }
+
+    // 5. If one has link and the other doesn't, treat as distinct (e.g. placeholder vs resolved)
+    if (thisLink.isNotEmpty != otherLink.isNotEmpty) {
+      return false;
     }
 
     return true;

--- a/lib/database/isar_models/episode.dart
+++ b/lib/database/isar_models/episode.dart
@@ -105,4 +105,45 @@ extension EpisodeMap on Episode {
     }
     return result;
   }
+
+  bool isSameEpisode(Episode? other) {
+    if (other == null) return false;
+    if (identical(this, other)) return true;
+
+    // 1. If both have valid links, link is the most definitive episode identifier
+    if (link != null &&
+        other.link != null &&
+        link!.trim().isNotEmpty &&
+        other.link!.trim().isNotEmpty) {
+      return link!.trim() == other.link!.trim();
+    }
+
+    // 2. If episode numbers don't match, they are not the same
+    if (number.trim() != other.number.trim()) {
+      return false;
+    }
+
+    // 3. If both have sortMap metadata (e.g. season, cour, etc.)
+    final thisSort = sortMap;
+    final otherSort = other.sortMap;
+    if (thisSort.isNotEmpty && otherSort.isNotEmpty) {
+      if (thisSort.length != otherSort.length) return false;
+      for (final entry in thisSort.entries) {
+        if (otherSort[entry.key]?.toLowerCase() != entry.value.toLowerCase()) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // 4. If both have titles and they differ
+    if (title != null &&
+        other.title != null &&
+        title!.trim().isNotEmpty &&
+        other.title!.trim().isNotEmpty) {
+      return title!.trim() == other.title!.trim();
+    }
+
+    return true;
+  }
 }

--- a/lib/screens/anime/watch/controller/player_controller.dart
+++ b/lib/screens/anime/watch/controller/player_controller.dart
@@ -58,34 +58,34 @@ import 'package:volume_controller/volume_controller.dart';
 import '../../../../database/isar_models/track.dart' as model;
 
 extension PlayerControllerExtensions on PlayerController {
+  int get currentEpisodeIndex {
+    final cur = currentEpisode.value;
+    final index = episodeList.indexWhere((e) => e.isSameEpisode(cur));
+    if (index != -1) return index;
+    return episodeList.indexWhere((e) => e.number == cur.number);
+  }
+
   bool get hasNextEpisode {
-    final index =
-        episodeList.indexWhere((e) => e.number == currentEpisode.value.number);
+    final index = currentEpisodeIndex;
     return index != -1 && index < episodeList.length - 1;
   }
 
   bool get hasPreviousEpisode {
-    final index =
-        episodeList.indexWhere((e) => e.number == currentEpisode.value.number);
+    final index = currentEpisodeIndex;
     return index > 0;
   }
 
   Episode? get nextEpisode {
-    final index =
-        episodeList.indexWhere((e) => e.number == currentEpisode.value.number);
+    final index = currentEpisodeIndex;
     if (index == -1 || index >= episodeList.length - 1) return null;
     return episodeList[index + 1];
   }
 
   Episode? get previousEpisode {
-    final index =
-        episodeList.indexWhere((e) => e.number == currentEpisode.value.number);
+    final index = currentEpisodeIndex;
     if (index <= 0) return null;
     return episodeList[index - 1];
   }
-
-  int get currentEpisodeIndex =>
-      episodeList.indexWhere((e) => e.number == currentEpisode.value.number);
 }
 
 class PlayerController extends GetxController with WidgetsBindingObserver {
@@ -169,7 +169,8 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
   }
 
   Episode? get savedEpisode => offlineStorage.getWatchedEpisode(
-      anilistData.id, currentEpisode.value.number.toString());
+      anilistData.id, currentEpisode.value.number.toString(),
+      episode: currentEpisode.value);
 
   final offlineStorage = Get.find<OfflineStorageController>();
 
@@ -2635,6 +2636,9 @@ class PlayerController extends GetxController with WidgetsBindingObserver {
         lastWatchedTime: DateTime.now().millisecondsSinceEpoch,
         source: episode.source,
         desc: episode.desc,
+        sortKeys: episode.sortKeys,
+        sortVals: episode.sortVals,
+        filler: episode.filler,
       );
 
       await offlineStorage.addOrUpdateAnime(

--- a/lib/screens/anime/watch/controls/widgets/episodes_pane.dart
+++ b/lib/screens/anime/watch/controls/widgets/episodes_pane.dart
@@ -1,3 +1,4 @@
+import 'package:anymex/database/isar_models/episode.dart';
 import 'package:anymex/screens/anime/watch/controller/player_controller.dart';
 import 'package:anymex/screens/anime/widgets/episode/normal_episode.dart';
 import 'package:anymex/utils/string_extensions.dart';
@@ -226,10 +227,10 @@ class EpisodesPane extends StatelessWidget {
                               (e) => e.link == controller.selectedVideo.value?.url);
                           return idx >= 0 ? idx : 0;
                         }
-                        final numIdx =
-                            controller.currentEpisode.value.number.toInt() - 1;
-                        return numIdx.clamp(
-                            0, controller.episodeList.length - 1);
+                        final numIdx = controller.currentEpisodeIndex;
+                        return numIdx >= 0
+                            ? numIdx.clamp(0, controller.episodeList.length - 1)
+                            : 0;
                       })(),
                       separatorBuilder: (context, i) =>
                           const SizedBox(height: 8),
@@ -239,7 +240,7 @@ class EpisodesPane extends StatelessWidget {
                         final isSelected = controller.isOffline.value
                             ? episode.link ==
                                 controller.selectedVideo.value?.url
-                            : episode == controller.currentEpisode.value;
+                            : episode.isSameEpisode(controller.currentEpisode.value);
                         final offlineEpisode = controller.offlineStorage
                             .getAnimeById(controller.anilistData.id)
                             ?.episodes;

--- a/lib/screens/anime/widgets/episode/normal_episode.dart
+++ b/lib/screens/anime/widgets/episode/normal_episode.dart
@@ -74,7 +74,7 @@ class BetterEpisode extends StatelessWidget {
     if (offlineEpisodes == null) return 0.0;
 
     final savedEP = offlineEpisodes!.cast<Episode?>().firstWhere(
-          (e) => e?.number == episode.number,
+          (e) => e != null && e.isSameEpisode(episode),
           orElse: () => null,
         );
 

--- a/lib/screens/anime/widgets/episode_list_builder.dart
+++ b/lib/screens/anime/widgets/episode_list_builder.dart
@@ -213,21 +213,47 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
     }
 
     final savedData = offlineStorage.getAnimeById(widget.anilistData!.id);
-    final nextEpisode = widget.episodeList
-        .firstWhereOrNull((e) => e.number.toInt() == (userProgress.value + 1));
-    final fallbackEP = widget.episodeList
-        .firstWhereOrNull((e) => e.number.toInt() == (userProgress.value));
     final saved = savedData?.currentEpisode;
-    final nextSaved = saved ?? widget.episodeList[0];
-    if (savedEpisode.value.number != nextSaved.number) {
+    final nextSaved =
+        saved != null ? _resolveEpisode(saved) : widget.episodeList[0];
+    if (savedEpisode.value.number != nextSaved.number ||
+        !savedEpisode.value.isSameEpisode(nextSaved)) {
       savedEpisode.value = nextSaved;
     }
     offlineEpisodes = savedData?.watchedEpisodes ?? widget.episodeList;
-    final nextSelected = nextEpisode ?? fallbackEP ?? savedEpisode.value;
-    if (selectedEpisode.value.number != nextSelected.number) {
+
+    Episode? nextEpisode;
+    if (saved != null) {
+      final savedIndex =
+          widget.episodeList.indexWhere((e) => e.isSameEpisode(saved));
+      if (savedIndex != -1) {
+        final ts = saved.timeStampInMilliseconds ?? 0;
+        final dur = saved.durationInMilliseconds ?? 0;
+        final bool isSavedCompleted =
+            dur > 0 && (ts / dur) * 100 >= settingsController.markAsCompleted;
+        if (isSavedCompleted && savedIndex + 1 < widget.episodeList.length) {
+          nextEpisode = widget.episodeList[savedIndex + 1];
+        } else {
+          nextEpisode = widget.episodeList[savedIndex];
+        }
+      }
+    }
+
+    if (nextEpisode == null) {
+      nextEpisode = widget.episodeList.firstWhereOrNull(
+              (e) => e.number.toInt() == (userProgress.value + 1)) ??
+          widget.episodeList.firstWhereOrNull(
+              (e) => e.number.toInt() == (userProgress.value)) ??
+          savedEpisode.value;
+    }
+
+    final nextSelected = nextEpisode;
+    if (selectedEpisode.value.number != nextSelected.number ||
+        !selectedEpisode.value.isSameEpisode(nextSelected)) {
       selectedEpisode.value = nextSelected;
     }
-    if (continueEpisode.value.number != nextSelected.number) {
+    if (continueEpisode.value.number != nextSelected.number ||
+        !continueEpisode.value.isSameEpisode(nextSelected)) {
       continueEpisode.value = nextSelected;
     }
   }
@@ -235,6 +261,9 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
   void _initSortGrouping() {
     final sections = buildEpisodeSortSections(widget.episodeList);
     final nextSelection = <String, String>{};
+    final savedData =
+        offlineStorage.getAnimeById(widget.anilistData?.id ?? '');
+    final savedSortMap = savedData?.currentEpisode?.sortMap;
 
     for (final section in sections) {
       final availableValues = _availableValuesForKey(
@@ -247,9 +276,14 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
       }
 
       final currentValue = selectedSortValues[section.key];
-      nextSelection[section.key] = availableValues.contains(currentValue)
-          ? currentValue!
-          : availableValues.first;
+      final savedValue = savedSortMap?[section.key];
+      if (currentValue != null && availableValues.contains(currentValue)) {
+        nextSelection[section.key] = currentValue;
+      } else if (savedValue != null && availableValues.contains(savedValue)) {
+        nextSelection[section.key] = savedValue;
+      } else {
+        nextSelection[section.key] = availableValues.first;
+      }
     }
 
     if (selectedSortValues.length != nextSelection.length ||
@@ -284,6 +318,9 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
       return Episode(number: "1", title: "Episode 1");
     }
     return widget.episodeList.firstWhereOrNull((e) {
+          return e.isSameEpisode(episode);
+        }) ??
+        widget.episodeList.firstWhereOrNull((e) {
           return _areEpisodesEquivalent(e, episode);
         }) ??
         widget.episodeList
@@ -325,17 +362,7 @@ class _EpisodeListBuilderState extends State<EpisodeListBuilder> {
   }
 
   bool _areEpisodesEquivalent(Episode first, Episode second) {
-    if (first.number != second.number) {
-      return false;
-    }
-
-    final firstSortMap = first.sortMap;
-    final secondSortMap = second.sortMap;
-    if (firstSortMap.isEmpty || secondSortMap.isEmpty) {
-      return true;
-    }
-
-    return mapEquals(firstSortMap, secondSortMap);
+    return first.isSameEpisode(second);
   }
 
   int _compareEpisodesByNumber(Episode first, Episode second) {


### PR DESCRIPTION
### Summary of Changes
- **Fix Multi-Season Autoplay & Navigation**: Fixed episode indexing in `PlayerControllerExtensions` and `EpisodesPane` to use comprehensive episode comparison (`isSameEpisode` comparing `link`, `sortMap`/season, and `number`) so autoplay and Next Episode actions stay in the active season (Season 2/3) and properly transition across seasons.
- **Fix Season Completion Bleed**: Updated `BetterEpisode._calculateProgress` and `OfflineStorageController` to track and retrieve watch progress per unique episode, preventing Season 1 completion from marking Season 2/3 episodes as completed.
- **Preserve Season Metadata**: Ensured `sortKeys`, `sortVals`, and `filler` are retained during local tracking and continue-watching resolution in `EpisodeListBuilder`.