### PR TITLE
fix: sort New Episode Releases by air date and fix stale state + other bugs

### DIFF
--- a/lib/controllers/services/anilist/anilist_auth.dart
+++ b/lib/controllers/services/anilist/anilist_auth.dart
@@ -2041,12 +2041,63 @@ class AnilistAuth extends GetxController {
 
           currentlyWatching.value = currentlyWatching.value.removeDupes();
 
-          animeList.value = animeListt
+          final mappedAnimeList = animeListt
               .map((animeEntry) => TrackedMedia.fromJson(animeEntry))
               .toList()
               .reversed
               .toList()
               .removeDupes();
+
+          final airingIds = mappedAnimeList
+              .where((m) => m.releasedEpisodes != null && m.id != null)
+              .map((m) => int.tryParse(m.id!))
+              .whereType<int>()
+              .toSet()
+              .toList();
+
+          if (airingIds.isNotEmpty) {
+            final aliasFields = airingIds.map((id) => '''
+            s$id: Page(perPage: 1) {
+              airingSchedules(mediaId: $id, notYetAired: false, sort: TIME_DESC) {
+                airingAt
+              }
+            }
+            ''').join('\n');
+
+            final scheduleResponse = await http.post(
+              Uri.parse('https://graphql.anilist.co'),
+              headers: {
+                'Authorization': 'Bearer $token',
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+              },
+              body: json.encode({'query': 'query { $aliasFields }'}),
+            );
+
+            if (scheduleResponse.statusCode == 200) {
+              final scheduleData =
+                  json.decode(scheduleResponse.body)['data'] as Map<String, dynamic>?;
+              if (scheduleData != null) {
+                for (final id in airingIds) {
+                  final schedules =
+                      scheduleData['s$id']?['airingSchedules'] as List<dynamic>?;
+                  if (schedules == null || schedules.isEmpty) continue;
+                  final airingAt = schedules.first['airingAt'] as int?;
+                  if (airingAt == null) continue;
+
+                  final releasedAt =
+                      DateTime.fromMillisecondsSinceEpoch(airingAt * 1000);
+                  for (final m in mappedAnimeList) {
+                    if (m.id == id.toString()) {
+                      m.latestEpisodeReleasedAt = releasedAt;
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          animeList.value = mappedAnimeList;
           Logger.i("Anime List Fetched Successfully!");
         } else {
           Logger.i('Unexpected response structure: ${response.body}');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -423,14 +423,11 @@ class FilterScreen extends StatefulWidget {
 }
 
 class _FilterScreenState extends State<FilterScreen> {
-  int _selectedIndex = 1;
-  int _mobileSelectedIndex = 0;
+  int _selectedIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    _mobileSelectedIndex = 0;
-    _selectedIndex = 1;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final settings = Get.find<Settings>();
@@ -441,13 +438,13 @@ class _FilterScreenState extends State<FilterScreen> {
 
   void _onItemTapped(int index) {
     setState(() {
-      _selectedIndex = index;
+      _selectedIndex = index - 1;
     });
   }
 
   void _onMobileItemTapped(int index) {
     setState(() {
-      _mobileSelectedIndex = index;
+      _selectedIndex = index;
     });
   }
 
@@ -644,7 +641,7 @@ class _FilterScreenState extends State<FilterScreen> {
             final isSimkl = authService.serviceType.value == ServicesType.simkl;
             final navTabs = _getNavTabs(authService, settings);
             final navRailWidth = settings.navBarStyle == 0 ? 120.0 : 120.0;
-            final validIndex = _selectedIndex.clamp(0, navTabs.length);
+            final validIndex = (_selectedIndex + 1).clamp(0, navTabs.length);
 
             return SizedBox(
                 width: navRailWidth,
@@ -712,7 +709,7 @@ class _FilterScreenState extends State<FilterScreen> {
                 for (final tab in navTabs) _getWidgetForTab(tab),
               ];
               final validIndex =
-                  _selectedIndex.clamp(0, desktopRoutes.length - 1);
+                  (_selectedIndex + 1).clamp(0, desktopRoutes.length - 1);
               return LazyIndexedStack(
                 index: validIndex,
                 children: desktopRoutes,
@@ -732,7 +729,7 @@ class _FilterScreenState extends State<FilterScreen> {
       final mobileRoutes = [
         for (final tab in navTabs) _getWidgetForTab(tab),
       ];
-      final validIndex = _mobileSelectedIndex.clamp(0, mobileRoutes.length - 1);
+      final validIndex = _selectedIndex.clamp(0, mobileRoutes.length - 1);
 
       return PopScope(
         canPop: false,
@@ -741,7 +738,7 @@ class _FilterScreenState extends State<FilterScreen> {
           final homeIndex = navTabs.indexOf('Home');
           if (validIndex != homeIndex && homeIndex != -1) {
             setState(() {
-              _mobileSelectedIndex = homeIndex;
+              _selectedIndex = homeIndex;
             });
           } else {
             const MethodChannel("com.ryan.anymex/utils")

--- a/lib/models/Anilist/anilist_media_user.dart
+++ b/lib/models/Anilist/anilist_media_user.dart
@@ -31,6 +31,7 @@ class TrackedMedia {
   List<String> tags;
   int? startYear;
   int? updatedAt;
+  DateTime? latestEpisodeReleasedAt;
 
   String? romajiTitle;
 
@@ -73,6 +74,7 @@ class TrackedMedia {
     this.tags = const [],
     this.startYear,
     this.updatedAt,
+    this.latestEpisodeReleasedAt,
     this.startedAt,
     this.completedAt,
     this.isPrivate,
@@ -80,6 +82,7 @@ class TrackedMedia {
 
   factory TrackedMedia.fromJson(Map<String, dynamic> json) {
     final titleMap = json['media']?['title'];
+
     return TrackedMedia(
       id: json['media']['id']?.toString(),
       idMal: json['media']['idMal']?.toString(),

--- a/lib/models/Media/media.dart
+++ b/lib/models/Media/media.dart
@@ -60,7 +60,7 @@ class Media {
   NextAiringEpisode? nextAiringEpisode;
   List<Ranking> rankings;
   ServicesType serviceType;
-  DateTime? createdAt;
+  DateTime? latestEpisodeReleasedAt;
   bool? isAdult;
   String? sourceName;
   String? sourceId;
@@ -120,8 +120,7 @@ class Media {
       this.synonyms = const [],
       this.tags = const [],
       this.externalLinks,
-      DateTime? createdAt})
-      : createdAt = DateTime.now();
+      this.latestEpisodeReleasedAt});
 
   OfflineMedia toOfflineMedia() {
     return OfflineMedia(

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -43,8 +43,11 @@ class _HomePageState extends State<HomePage> {
 
       if (serviceHandler.isLoggedIn.value ||
           serviceHandler.animeList.isNotEmpty) {
+        final now = DateTime.now();
         for (final item in serviceHandler.animeList) {
           if (item.type?.toUpperCase() == 'MANGA' || item.id == null) continue;
+          if (item.watchingStatus?.toUpperCase() != 'CURRENT') continue;
+
           final watched = int.tryParse(item.episodeCount ?? '') ??
               (item.userProgress ?? 0);
           int latestReleased = 0;
@@ -55,16 +58,29 @@ class _HomePageState extends State<HomePage> {
             latestReleased = int.tryParse(item.totalEpisodes ?? '') ?? 0;
           }
 
-          final isWatching = item.watchingStatus?.toUpperCase() == 'CURRENT' ||
-              item.watchingStatus?.toUpperCase() == 'WATCHING' ||
-              (watched > 0 &&
-                  item.watchingStatus?.toUpperCase() != 'COMPLETED');
+          if (latestReleased <= watched) continue;
 
-          if (isWatching && latestReleased > watched) {
-            final media = CardData.fromTrackedMedia(item).data;
-            entries.add((media, watched, latestReleased));
+          final isStillAiring = item.mediaStatus?.toUpperCase() == 'RELEASING' ||
+              item.mediaStatus?.toUpperCase() == 'AIRING';
+          final releasedAt = item.latestEpisodeReleasedAt;
+          if (!isStillAiring &&
+              releasedAt != null &&
+              now.difference(releasedAt) > const Duration(days: 7)) {
+            continue;
           }
+
+          final media = CardData.fromTrackedMedia(item).data;
+          entries.add((media, watched, latestReleased));
         }
+
+        entries.sort((a, b) {
+          final aDate = a.$1.latestEpisodeReleasedAt;
+          final bDate = b.$1.latestEpisodeReleasedAt;
+          if (aDate == null && bDate == null) return 0;
+          if (aDate == null) return 1;
+          if (bDate == null) return -1;
+          return bDate.compareTo(aDate);
+        });
       }
 
       if (entries.isEmpty &&

--- a/lib/widgets/history/tap_history_cards.dart
+++ b/lib/widgets/history/tap_history_cards.dart
@@ -23,9 +23,9 @@ class NewEpisodeReleaseCard extends StatelessWidget {
   });
 
   String _getTimeAgo() {
-    if (media.createdAt == null) return 'Recently';
+    if (media.latestEpisodeReleasedAt == null) return 'Recently';
     final now = DateTime.now();
-    final difference = now.difference(media.createdAt!);
+    final difference = now.difference(media.latestEpisodeReleasedAt!);
 
     if (difference.inDays == 0) {
       return 'Today';
@@ -45,14 +45,15 @@ class NewEpisodeReleaseCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = context.colors;
     final heroTag =
-        '${media.id}-recent-${media.createdAt?.millisecondsSinceEpoch ?? ''}';
+        '${media.id}-recent-${media.latestEpisodeReleasedAt?.millisecondsSinceEpoch ?? ''}';
     final watched = watchedEpisode ?? 0;
     final latest = latestReleasedEpisode ?? watched;
     final behind = latest - watched;
 
     return AnymexOnTap(
       onTap: () {
-        navigate(() => AnimeDetailsPage(media: media, tag: heroTag));
+        navigate(() =>
+            AnimeDetailsPage(media: media, tag: heroTag, initialTabIndex: 1));
       },
       child: Container(
         margin: const EdgeInsets.only(left: 15),

--- a/lib/widgets/media_items/media_item.dart
+++ b/lib/widgets/media_items/media_item.dart
@@ -66,7 +66,8 @@ class CardData {
           rating: data.rating ?? '',
           poster: data.poster ?? '',
           mediaType: data.type == 'MANGA' ? ItemType.manga : ItemType.anime,
-          serviceType: data.servicesType),
+          serviceType: data.servicesType,
+          latestEpisodeReleasedAt: data.latestEpisodeReleasedAt),
     );
   }
 


### PR DESCRIPTION
**Description:**
Fixes the "New Episode Releases" section on the Home page so it surfaces anime with newly released episodes instead of anime the user simply interacted with last, adds automatic expiration/removal rules for stale entries, sends users straight to the Watch tab from the card, and fixes the navbar forgetting the current tab when resizing between mobile and desktop layouts.

**Summary of Changes:**
- New Episode Releases now sorts by actual episode air date instead of "last watched", using a new latestEpisodeReleasedAt timestamp fetched from AniList's airing schedule per anime.
- Entries expire automatically ~1 week after an anime finishes airing, and disappear immediately if the user moves it off "Current".
- Tapping a New Episode Releases card now opens the details page directly on the Watch tab instead of Info.
- Fixed the navbar jumping to a different tab when resizing the window across the mobile/desktop breakpoint. Root cause: the mobile and desktop layouts each tracked the selected tab in their own separate int field, so switching layouts on resize picked up whatever tab the other layout's field happened to hold, instead of the tab you were actually on.

**Type of Changes:**
- [x] Bug Fix
- [x] Enhancement

**Testing Notes:**
- Tested on both Windows and Android
- Resized the app window across the mobile/desktop breakpoint and confirmed the open tab stays the same.
- With an AniList account: verified New Episode Releases sorts by most recent episode air date, tapping a card opens on Watch, and the card disappears once progress catches up.
- Changed an anime's list status away from Current and confirmed its card disappears from New Episode Releases immediately.
- The ~1-week expiration window for finished-airing entries was verified through code inspection and by changing the system date and time via Windows/Android Settings, rather than reproducing the scenario over multiple real days.

**Linked Issue(s):**
Threads on discord server

**Additional Context:**
`Media.createdAt` was previously dead code: the constructor's initializer list always overwrote it with `DateTime.now()` regardless of what was passed in, so it never held a meaningful value. It has been repurposed into `latestEpisodeReleasedAt` and threaded through from `TrackedMedia` (populated via a batched, alias-based AniList `airingSchedules` query) so the real release date is available wherever `Media` is used.

**Submission Checklist:**
- [x] I have read and followed the project's contributing guidelines
- [x] My code follows the code style of this project
- [x] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [ ] I have tagged the appropriate reviewers for this pull request
